### PR TITLE
Add resilient agent callback client and CI diff guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure main branch ref is available
+        run: |
+          if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+            echo "origin/main not found locally. Attempting to fetch..."
+            git fetch origin main || echo "⚠️ Unable to fetch origin/main. Continuing without diff."
+          fi
+
+      - name: Diff with main if present
+        run: |
+          if git show-ref --verify --quiet refs/remotes/origin/main; then
+            git diff origin/main HEAD
+          else
+            echo "origin/main branch is unavailable; skipping diff step."
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/src/lib/agentic/AgentCallbackClient.ts
+++ b/src/lib/agentic/AgentCallbackClient.ts
@@ -1,0 +1,141 @@
+import { AgentCallbackOptions, AgentCallbackPayload } from './types'
+
+export class AgentCallbackError extends Error {
+  public readonly cause?: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'AgentCallbackError'
+    this.cause = cause
+  }
+}
+
+export class AgentCallbackClient {
+  private connected = false
+  private readonly options: AgentCallbackOptions
+  private readonly retries: number
+  private readonly retryDelay: number
+
+  constructor(options: AgentCallbackOptions) {
+    if (!options.transport && !options.endpoint) {
+      throw new AgentCallbackError(
+        'AgentCallbackClient requires either a transport or an endpoint to deliver payloads.'
+      )
+    }
+
+    this.options = {
+      retries: 3,
+      retryDelayMs: 500,
+      headers: { 'Content-Type': 'application/json' },
+      ...options
+    }
+
+    this.retries = this.options.retries ?? 3
+    this.retryDelay = this.options.retryDelayMs ?? 500
+  }
+
+  async sendCycleResult(payload: AgentCallbackPayload): Promise<void> {
+    await this.ensureConnected()
+
+    let attempt = 0
+    // We treat the initial try as attempt 1 for clearer logging
+    while (attempt <= this.retries) {
+      try {
+        await this.performSend(payload)
+        return
+      } catch (error) {
+        attempt += 1
+        console.warn(`⚠️ Agent callback attempt ${attempt} failed`, error)
+
+        if (attempt > this.retries) {
+          throw new AgentCallbackError('Unable to deliver agent callback after retrying.', error)
+        }
+
+        const delay = this.retryDelay * Math.pow(2, attempt - 1)
+        await this.delay(delay)
+      }
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.connected) {
+      return
+    }
+
+    const { transport } = this.options
+
+    if (transport && hasCallable(transport, 'disconnect')) {
+      try {
+        await transport.disconnect!()
+      } catch (error) {
+        console.warn('⚠️ Failed to disconnect agent callback transport cleanly.', error)
+      }
+    }
+
+    this.connected = false
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.connected) {
+      return
+    }
+
+    const { transport } = this.options
+
+    if (transport) {
+      if ('connect' in transport) {
+        if (!hasCallable(transport, 'connect')) {
+          throw new AgentCallbackError('Configured callback transport exposes a non-callable connect handler.')
+        }
+
+        await transport.connect!()
+      }
+
+      this.connected = true
+      return
+    }
+
+    // Fetch transport does not require a connection step
+    this.connected = true
+  }
+
+  private async performSend(payload: AgentCallbackPayload): Promise<void> {
+    const { transport, endpoint, headers } = this.options
+
+    if (transport) {
+      if (!hasCallable(transport, 'send')) {
+        throw new AgentCallbackError('Configured callback transport is missing a callable send() method.')
+      }
+
+      await transport.send(payload)
+      return
+    }
+
+    if (!endpoint) {
+      throw new AgentCallbackError('No callback endpoint configured for AgentCallbackClient.')
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    })
+
+    if (!response.ok) {
+      throw new AgentCallbackError(
+        `Callback request failed with status ${response.status}${response.statusText ? ` - ${response.statusText}` : ''}.`
+      )
+    }
+  }
+
+  private async delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+}
+
+function hasCallable<T extends object, K extends keyof T>(
+  value: T,
+  key: K
+): value is T & Record<K, (...args: unknown[]) => unknown> {
+  return typeof value[key] === 'function'
+}

--- a/src/lib/agentic/AgenticCouncil.ts
+++ b/src/lib/agentic/AgenticCouncil.ts
@@ -6,23 +6,20 @@
  * to the next agent in sequence.
  */
 
-import { Agent, AgentAnalysis, SystemContext, Improvement, ImprovementStatus, AgentRole } from './types'
+import {
+  Agent,
+  AgentAnalysis,
+  SystemContext,
+  ImprovementStatus,
+  AgentRole,
+  CouncilReview
+} from './types'
 import { DataAnalyzerAgent } from './agents/DataAnalyzerAgent'
 import { OptimizerAgent } from './agents/OptimizerAgent'
 import { SecurityAgent } from './agents/SecurityAgent'
 import { UXEnhancerAgent } from './agents/UXEnhancerAgent'
 import { CompetitorAgent } from './agents/CompetitorAgent'
 import { v4 as uuidv4 } from 'uuid'
-
-export interface CouncilReview {
-  id: string
-  startedAt: string
-  completedAt?: string
-  agents: Agent[]
-  analyses: AgentAnalysis[]
-  improvements: Improvement[]
-  status: 'in-progress' | 'completed' | 'failed'
-}
 
 export class AgenticCouncil {
   private agents: Agent[]

--- a/src/lib/agentic/index.ts
+++ b/src/lib/agentic/index.ts
@@ -8,6 +8,7 @@ export * from './types'
 export * from './BaseAgent'
 export * from './AgenticEngine'
 export * from './AgenticCouncil'
+export * from './AgentCallbackClient'
 
 // Export agent implementations
 export { DataAnalyzerAgent } from './agents/DataAnalyzerAgent'

--- a/src/lib/agentic/types.ts
+++ b/src/lib/agentic/types.ts
@@ -69,6 +69,16 @@ export interface AgentAnalysis {
   timestamp: string
 }
 
+export interface CouncilReview {
+  id: string
+  startedAt: string
+  completedAt?: string
+  agents: Agent[]
+  analyses: AgentAnalysis[]
+  improvements: Improvement[]
+  status: 'in-progress' | 'completed' | 'failed'
+}
+
 export interface Finding {
   id: string
   category: ImprovementCategory
@@ -134,4 +144,42 @@ export interface AgenticConfig {
   maxDailyImprovements: number
   reviewRequired: ImprovementCategory[]
   enabledAgents: AgentRole[]
+}
+
+export interface AgentCallbackPayload {
+  review: CouncilReview
+  executedImprovements: Improvement[]
+  pendingImprovements: Improvement[]
+}
+
+export interface AgentCallbackTransport {
+  connect?: () => Promise<void> | void
+  disconnect?: () => Promise<void> | void
+  send: (payload: AgentCallbackPayload) => Promise<unknown> | unknown
+}
+
+export interface AgentCallbackOptions {
+  /**
+   * Endpoint to POST callback payloads to. When provided, the client will use `fetch`
+   * with the supplied headers instead of a custom transport.
+   */
+  endpoint?: string
+  /**
+   * Optional transport implementation. When present, the transport's `send` method will
+   * be used to deliver payloads. The transport may also expose `connect`/`disconnect`
+   * hooks which will be invoked when available.
+   */
+  transport?: AgentCallbackTransport
+  /**
+   * Number of retry attempts before giving up on a callback request.
+   */
+  retries?: number
+  /**
+   * Initial delay in milliseconds before retrying a failed request.
+   */
+  retryDelayMs?: number
+  /**
+   * Optional headers to include when using the default `fetch` transport.
+   */
+  headers?: Record<string, string>
 }


### PR DESCRIPTION
## Summary
- add an AgentCallbackClient with connection guards and retry handling to stop `connect` runtime errors
- wire the new client into the agentic engine and hook while exporting supporting types
- add a CI workflow that fetches `origin/main` before diffing so the diff step no longer fails on missing refs

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f3ff07a48323a914eaf3ca059242)

## Summary by Sourcery

Enable robust agent callback handling by introducing AgentCallbackClient with retry logic and integrating it into the engine and hook, refactor review types into shared definitions, and improve the CI diff step to guard against missing origin/main refs.

New Features:
- Add AgentCallbackClient with retry and connection guards for resilient callback delivery
- Integrate AgentCallbackClient into AgenticEngine and useAgenticEngine hook to dispatch cycle results

Enhancements:
- Move CouncilReview type into shared types and export AgentCallbackClient in the public API
- Derive simulateExecution metrics dynamically from SystemContext performance metrics

CI:
- Add GitHub Actions workflow that fetches origin/main before running git diff to prevent missing-ref errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced callback support for agent execution cycles, enabling integration with external systems via HTTP or custom transport implementations.
  * Established automated CI/CD pipeline for continuous integration and build verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->