### PR TITLE
Replace Contrast scan workflow with GitHub CodeQL

### DIFF
--- a/.github/workflows/contrast-scan.yml
+++ b/.github/workflows/contrast-scan.yml
@@ -1,53 +1,46 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow will initiate a Contrast Scan on your built artifact, and subsequently upload the results SARIF to Github.
-# Because Contrast Scan is designed to run against your deployable artifact, you need to build an artifact that will be passed to the Contrast Scan Action.
-# Contrast Scan currently supports Java, JavaScript and .NET artifacts.
-# For more information about the Contrast Scan GitHub Action see here: https://github.com/Contrast-Security-OSS/contrastscan-action
-
-# Pre-requisites:
-# All Contrast related account secrets should be configured as GitHub secrets to be passed as inputs to the Contrast Scan Action.
-# The required secrets are CONTRAST_API_KEY, CONTRAST_ORGANIZATION_ID and CONTRAST_AUTH_HEADER.
+name: CodeQL
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
-    - cron: '16 23 * * 0'
+    - cron: '30 1 * * 0'
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
-name: Scan analyze workflow
 jobs:
-  build-and-scan:
-    permissions:
-        contents: read # for actions/checkout
-        security-events: write # for github/codeql-action/upload-sarif
-        actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
-    # check out project
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
     steps:
-    - uses: actions/checkout@v4
-    # Since Contrast Scan is designed to run against your deployable artifact, the steps to build your artifact should go here.
-    # -name: Build Project
-    # ...
-    # Scan Artifact
-    - name: Contrast Scan Action
-      uses: Contrast-Security-OSS/contrastscan-action@7352a45d9678ec8a434cf061b07ffb51c1e351a1
-      with:
-        artifact: mypath/target/myartifact.jar # replace this path with the path to your built artifact
-        apiKey: ${{ secrets.CONTRAST_API_KEY }}
-        orgId: ${{ secrets.CONTRAST_ORGANIZATION_ID }}
-        authHeader: ${{ secrets.CONTRAST_AUTH_HEADER }}
-    #Upload the results to GitHub
-    - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: results.sarif # The file name must be 'results.sarif', as this is what the Github Action will output
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- replace the third-party Contrast scanning workflow with the standard GitHub CodeQL analysis workflow to keep actions within the allowed organizations

## Testing
- not run (workflow configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f6b39f488323a71dee30603b7a4e)

## Summary by Sourcery

Replace the Contrast Scan workflow with the standard GitHub CodeQL analysis workflow, update its schedule and permissions, and configure CodeQL steps for JavaScript projects

Enhancements:
- Remove third-party Contrast Scan steps and integrate GitHub CodeQL init, autobuild, and analyze actions
- Adjust workflow schedule and grant appropriate permissions for CodeQL security-events and actions access
- Restrict analysis matrix to JavaScript language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code analysis and security scanning infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->