### PR TITLE
Document code scanning policy requirements

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,17 @@ This information will help us triage your report more quickly.
 ## Policy
 
 See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)
+
+## Code Scanning Availability
+
+This repository currently cannot run GitHub Actions that power the default CodeQL
+code-scanning workflow because the organization-wide policy blocks the
+`actions/*` and `github/codeql-action/*` action publishers. If you want automated
+code-scanning results to appear in the repository Security tab, update the
+policy to allow those publishers or configure an approved reusable workflow that
+invokes them on your behalf.
+
+If relaxing the policy is not possible, you can still produce code-scanning
+results by running CodeQL locally or in an approved environment and uploading
+the SARIF output through the
+[code scanning API](https://docs.github.com/en/rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data).


### PR DESCRIPTION
## Summary
- document the current restriction preventing CodeQL code scanning from running
- explain options for allowing the required GitHub Actions or uploading SARIF results manually

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f6b39f488323a71dee30603b7a4e)

## Summary by Sourcery

Document the current policy restrictions on GitHub CodeQL scanning and outline options to enable automated scans or manually upload SARIF results

Documentation:
- Add a “Code Scanning Availability” section to SECURITY.md explaining that organization policy blocks default CodeQL workflows
- Describe how to permit required action publishers or invoke scans via a reusable workflow
- Explain the alternative of running CodeQL locally and uploading SARIF output through the code scanning API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy information regarding code scanning availability and alternative approaches for security analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->