### PR TITLE
Add resilient KV fallback and CI diff guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: |
+          git fetch origin main || echo "No main branch found on origin"
+          if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            git branch --track main origin/main 2>/dev/null || true
+          fi
+
+      - name: Diff against main
+        run: |
+          if git rev-parse --verify main >/dev/null 2>&1; then
+            git diff main HEAD
+          else
+            echo "Local main branch not available; skipping diff."
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build project
+        run: npm run build

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { useKV } from '@github/spark/hooks'
+import { useKV } from '@/hooks/useSparkKV'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'

--- a/src/hooks/use-agentic-engine.ts
+++ b/src/hooks/use-agentic-engine.ts
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react'
-import { useKV } from '@github/spark/hooks'
+import { useKV } from '@/hooks/useSparkKV'
 import { AgenticEngine } from '@/lib/agentic/AgenticEngine'
 import { SystemContext, Improvement, ImprovementStatus, AgenticConfig } from '@/lib/agentic/types'
 

--- a/src/hooks/useSparkKV.ts
+++ b/src/hooks/useSparkKV.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+export type UseKVReturn<T> = readonly [
+  T | undefined,
+  (newValue: T | ((oldValue?: T) => T)) => void,
+  () => void
+]
+
+const memoryStore = new Map<string, unknown>()
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const storage = window.localStorage
+    const testKey = '__spark_kv_test__'
+    storage.setItem(testKey, '1')
+    storage.removeItem(testKey)
+    return storage
+  } catch (error) {
+    console.warn('[useSparkKV] Local storage unavailable, falling back to in-memory store.', error)
+    return null
+  }
+}
+
+function readValue<T>(key: string, storage: Storage | null): T | undefined {
+  if (storage) {
+    try {
+      const raw = storage.getItem(key)
+      if (raw !== null) {
+        return JSON.parse(raw) as T
+      }
+    } catch (error) {
+      console.warn(`[useSparkKV] Failed to parse stored value for key "${key}"`, error)
+    }
+  }
+
+  if (memoryStore.has(key)) {
+    return memoryStore.get(key) as T
+  }
+
+  return undefined
+}
+
+function persistValue<T>(key: string, value: T, storage: Storage | null) {
+  memoryStore.set(key, value as unknown)
+
+  if (!storage) {
+    return
+  }
+
+  try {
+    storage.setItem(key, JSON.stringify(value))
+  } catch (error) {
+    console.warn(`[useSparkKV] Failed to persist value for key "${key}"`, error)
+  }
+}
+
+function removeValue(key: string, storage: Storage | null) {
+  memoryStore.delete(key)
+
+  if (!storage) {
+    return
+  }
+
+  try {
+    storage.removeItem(key)
+  } catch (error) {
+    console.warn(`[useSparkKV] Failed to remove value for key "${key}"`, error)
+  }
+}
+
+function parseStorageEventValue<T>(event: StorageEvent): T | undefined {
+  if (event.newValue === null) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(event.newValue) as T
+  } catch (error) {
+    console.warn('[useSparkKV] Failed to parse storage event value', error)
+    return undefined
+  }
+}
+
+export function useSafeKV<T = string>(key: string, initialValue?: T): UseKVReturn<T> {
+  const storageRef = useRef<Storage | null>(null)
+  const initializedRef = useRef(false)
+
+  if (storageRef.current === null) {
+    storageRef.current = getStorage()
+  }
+
+  const [value, setValue] = useState<T | undefined>(() => {
+    const stored = readValue<T>(key, storageRef.current)
+    if (stored !== undefined) {
+      initializedRef.current = true
+      return stored
+    }
+
+    return initialValue
+  })
+
+  useEffect(() => {
+    storageRef.current = getStorage()
+  }, [])
+
+  useEffect(() => {
+    const storage = storageRef.current
+    const stored = readValue<T>(key, storage)
+
+    if (stored !== undefined) {
+      initializedRef.current = true
+      setValue(stored)
+      return
+    }
+
+    if (!initializedRef.current && initialValue !== undefined) {
+      initializedRef.current = true
+      setValue(initialValue)
+      persistValue(key, initialValue, storage)
+    }
+  }, [key, initialValue])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (!event.key || event.key !== key) {
+        return
+      }
+
+      const storage = storageRef.current
+      if (storage && event.storageArea !== storage) {
+        return
+      }
+
+      const nextValue = parseStorageEventValue<T>(event)
+      if (nextValue === undefined) {
+        removeValue(key, storageRef.current)
+      } else {
+        persistValue(key, nextValue, storageRef.current)
+      }
+      setValue(nextValue)
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [key])
+
+  const setPersistedValue = useCallback(
+    (nextValue: T | ((current?: T) => T)) => {
+      setValue(currentValue => {
+        const resolvedValue =
+          typeof nextValue === 'function'
+            ? (nextValue as (current?: T) => T)(currentValue)
+            : nextValue
+
+        persistValue(key, resolvedValue, storageRef.current)
+        return resolvedValue
+      })
+    },
+    [key]
+  )
+
+  const deleteValue = useCallback(() => {
+    removeValue(key, storageRef.current)
+    setValue(undefined)
+    initializedRef.current = false
+  }, [key])
+
+  return useMemo(() => [value, setPersistedValue, deleteValue] as const, [value, setPersistedValue, deleteValue])
+}
+
+export { useSafeKV as useKV }


### PR DESCRIPTION
### **User description**
## Summary
- add a local-storage and in-memory backed KV hook so the app no longer calls Spark's runtime connection when it is unavailable
- update the app and agentic engine hook to use the resilient KV helper
- add a CI workflow that fetches `main` before diffing and runs lint/build so `git diff main HEAD` no longer fails

## Testing
- npm run build
- npm run lint *(fails: existing lint violations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f3ff07a48323a914eaf3ca059242)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace Spark's KV hook with resilient local-storage and in-memory fallback implementation

- Add CI workflow to fetch main branch before diffing and running lint/build

- Update app and agentic engine to use new resilient KV hook


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Spark KV Hook"] -->|replaced by| B["useSparkKV Hook"]
  B -->|with fallback| C["localStorage + Memory Store"]
  D["CI Workflow"] -->|fetches| E["main branch"]
  E -->|enables| F["git diff main HEAD"]
  F -->|runs| G["lint & build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSparkKV.ts</strong><dd><code>Resilient KV hook with dual storage fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useSparkKV.ts

<ul><li>New resilient KV hook implementation with localStorage and in-memory <br>fallback<br> <li> Handles storage unavailability gracefully with console warnings<br> <li> Supports value persistence, deletion, and cross-tab synchronization <br>via storage events<br> <li> Provides same interface as original Spark KV hook for drop-in <br>replacement</ul>


</details>


  </td>
  <td><a href="https://github.com/ivi374forivi/public-record-data-scrapper/pull/94/files#diff-a2788b34bcaa0311152de67a82a13627cf52fbfd5f68d8555c4607b8aa209d54">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Update to use resilient KV hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.tsx

<ul><li>Update import to use new resilient <code>useSparkKV</code> hook instead of Spark's <br>hook</ul>


</details>


  </td>
  <td><a href="https://github.com/ivi374forivi/public-record-data-scrapper/pull/94/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-agentic-engine.ts</strong><dd><code>Update to use resilient KV hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/use-agentic-engine.ts

<ul><li>Update import to use new resilient <code>useSparkKV</code> hook instead of Spark's <br>hook</ul>


</details>


  </td>
  <td><a href="https://github.com/ivi374forivi/public-record-data-scrapper/pull/94/files#diff-a4ddeb5c8971c7e705789e5c2982bb13ecf49641f443defafdaf7554a019b2de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>CI workflow with main branch fetch and diff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>New CI workflow that runs on push and pull requests<br> <li> Fetches main branch before running git diff to prevent failures<br> <li> Runs npm lint and build after dependency installation<br> <li> Handles cases where main branch is unavailable with graceful fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/ivi374forivi/public-record-data-scrapper/pull/94/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Add a resilient key-value storage hook with localStorage and memory fallback, update the app to use it, and enhance CI to fetch the main branch before diffing and enforce lint and build checks

New Features:
- Introduce a resilient useKV hook with localStorage and in-memory fallback for key-value storage
- Add a GitHub Actions CI workflow that fetches the main branch before diffing and runs lint and build

Enhancements:
- Update App and agentic engine hooks to use the new resilient useKV implementation

CI:
- Configure CI to fetch origin/main, perform git diff, and run npm lint and build on push and pull requests