### PR TITLE
Add local persistence hook and guard CI diff step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - work
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure base branch available for diff
+        shell: bash
+        run: |
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            DEFAULT_BRANCH="main"
+          fi
+
+          if git show-ref --quiet --verify "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            if ! git rev-parse --verify main >/dev/null 2>&1; then
+              git branch main "origin/$DEFAULT_BRANCH"
+            fi
+            git diff main HEAD >/dev/null
+          else
+            echo "Base branch origin/$DEFAULT_BRANCH not found. Skipping diff step."
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { useKV } from '@github/spark/hooks'
+import { useKV } from '@/hooks/use-persistent-kv'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'

--- a/src/hooks/use-agentic-engine.ts
+++ b/src/hooks/use-agentic-engine.ts
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react'
-import { useKV } from '@github/spark/hooks'
+import { useKV } from '@/hooks/use-persistent-kv'
 import { AgenticEngine } from '@/lib/agentic/AgenticEngine'
 import { SystemContext, Improvement, ImprovementStatus, AgenticConfig } from '@/lib/agentic/types'
 

--- a/src/hooks/use-persistent-kv.ts
+++ b/src/hooks/use-persistent-kv.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type SetStateAction<T> = T | ((previous?: T) => T)
+
+type StoredValue<T> = T | undefined
+
+const STORAGE_PREFIX = 'prds:'
+const memoryStore = new Map<string, unknown>()
+
+function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function readFromStorage<T>(key: string, isBrowser: boolean): StoredValue<T> {
+  if (isBrowser) {
+    try {
+      const raw = window.localStorage.getItem(key)
+      if (raw === null) return undefined
+      return JSON.parse(raw) as T
+    } catch (error) {
+      console.warn(`Failed to read persisted value for key "${key}":`, error)
+      return undefined
+    }
+  }
+
+  if (memoryStore.has(key)) {
+    return memoryStore.get(key) as T
+  }
+
+  return undefined
+}
+
+function writeToStorage<T>(key: string, value: StoredValue<T>, isBrowser: boolean): void {
+  if (isBrowser) {
+    try {
+      if (value === undefined) {
+        window.localStorage.removeItem(key)
+      } else {
+        window.localStorage.setItem(key, JSON.stringify(value))
+      }
+      return
+    } catch (error) {
+      console.warn(`Failed to persist value for key "${key}". Falling back to in-memory storage.`, error)
+    }
+  }
+
+  if (value === undefined) {
+    memoryStore.delete(key)
+  } else {
+    memoryStore.set(key, value)
+  }
+}
+
+export function usePersistentKV<T = string>(
+  key: string,
+  initialValue?: T
+): readonly [StoredValue<T>, (newValue: SetStateAction<T>) => void, () => void] {
+  const storageKey = useMemo(() => `${STORAGE_PREFIX}${key}`, [key])
+  const isBrowser = isBrowserEnvironment()
+
+  const [value, setValue] = useState<StoredValue<T>>(() => {
+    const stored = readFromStorage<T>(storageKey, isBrowser)
+    if (stored !== undefined) {
+      return stored
+    }
+
+    if (initialValue !== undefined) {
+      writeToStorage<T>(storageKey, initialValue, isBrowser)
+      return initialValue
+    }
+
+    return initialValue
+  })
+
+  const setPersistedValue = useCallback(
+    (update: SetStateAction<T>) => {
+      setValue(previous => {
+        const nextValue = typeof update === 'function'
+          ? (update as (previous?: T) => T)(previous)
+          : update
+
+        writeToStorage<T>(storageKey, nextValue, isBrowser)
+        return nextValue
+      })
+    },
+    [isBrowser, storageKey]
+  )
+
+  const deleteValue = useCallback(() => {
+    writeToStorage<T>(storageKey, undefined, isBrowser)
+    setValue(undefined)
+  }, [isBrowser, storageKey])
+
+  useEffect(() => {
+    if (!isBrowser) return
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey) return
+
+      if (event.newValue === null) {
+        setValue(undefined)
+        return
+      }
+
+      try {
+        setValue(event.newValue ? (JSON.parse(event.newValue) as T) : undefined)
+      } catch (error) {
+        console.warn(`Failed to parse storage event for key "${storageKey}":`, error)
+        setValue(undefined)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [isBrowser, storageKey])
+
+  return [value, setPersistedValue, deleteValue]
+}
+
+export { usePersistentKV as useKV }


### PR DESCRIPTION
## Summary
- replace usage of the Spark KV hook with a local persistent storage hook that works in non-workbench environments
- add a reusable hook that stores values in localStorage with an in-memory fallback for tests
- add a CI workflow that fetches the default branch, ensures a local `main` reference, and guards the git diff step before building

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f3ff07a48323a914eaf3ca059242)

## Summary by Sourcery

Provide a local persistent storage hook for non-workbench environments and harden the CI pipeline by verifying diffs against the default branch before build

New Features:
- Add a reusable React hook usePersistentKV (alias useKV) for local persistence with localStorage and an in-memory fallback
- Introduce a CI step that fetches the default branch, creates a local main reference if needed, and guards the git diff before building

Enhancements:
- Replace existing Spark KV hook usage with the new local persistence hook

CI:
- Add a CI workflow that checks out full history, enforces a guarded git diff step, sets up Node.js environment, installs dependencies, and runs the build