### PR TITLE
Fix agent state persistence and ensure main branch availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "tsc -b --noCheck && vite build",
         "lint": "eslint .",
         "optimize": "vite optimize",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "postinstall": "node ./scripts/ensure-main-branch.mjs"
     },
     "dependencies": {
         "@github/spark": "^0.39.0",

--- a/scripts/ensure-main-branch.mjs
+++ b/scripts/ensure-main-branch.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const gitDirectory = join(repoRoot, '.git')
+
+if (!existsSync(gitDirectory)) {
+  process.exit(0)
+}
+
+function commandSucceeds(command) {
+  try {
+    execSync(command, { stdio: 'ignore' })
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+function runCommand(command) {
+  try {
+    execSync(command, { stdio: 'inherit' })
+    return true
+  } catch (error) {
+    console.warn(`[ensure-main-branch] Command failed: ${command}`)
+    return false
+  }
+}
+
+const hasLocalMain = commandSucceeds('git rev-parse --verify main')
+
+if (hasLocalMain) {
+  process.exit(0)
+}
+
+const hasOrigin = commandSucceeds('git remote show origin')
+if (!hasOrigin) {
+  console.warn('[ensure-main-branch] Remote "origin" not found. Skipping fetch for main branch.')
+  process.exit(0)
+}
+
+const remoteHasMain = commandSucceeds('git ls-remote --exit-code --heads origin main')
+if (!remoteHasMain) {
+  console.warn('[ensure-main-branch] Remote does not have a "main" branch. Skipping fetch.')
+  process.exit(0)
+}
+
+console.log('[ensure-main-branch] Fetching missing main branch from origin...')
+
+if (runCommand('git fetch origin main:main')) {
+  process.exit(0)
+}
+
+console.log('[ensure-main-branch] Direct fetch failed. Attempting to fetch all branches and create local tracking branch...')
+
+if (runCommand('git fetch origin')) {
+  if (!commandSucceeds('git rev-parse --verify main')) {
+    runCommand('git branch --track main origin/main')
+  }
+}
+
+process.exit(0)

--- a/src/hooks/use-agentic-engine.ts
+++ b/src/hooks/use-agentic-engine.ts
@@ -5,9 +5,9 @@
  */
 
 import { useState, useEffect, useCallback } from 'react'
-import { useKV } from '@github/spark/hooks'
 import { AgenticEngine } from '@/lib/agentic/AgenticEngine'
 import { SystemContext, Improvement, ImprovementStatus, AgenticConfig } from '@/lib/agentic/types'
+import { usePersistentState } from './usePersistentState'
 
 export interface UseAgenticEngineResult {
   engine: AgenticEngine | null
@@ -22,8 +22,8 @@ export interface UseAgenticEngineResult {
 export function useAgenticEngine(context: SystemContext, config?: Partial<AgenticConfig>): UseAgenticEngineResult {
   const [engine] = useState(() => new AgenticEngine(config))
   const [isRunning, setIsRunning] = useState(false)
-  const [improvements, setImprovements] = useKV<Improvement[]>('agentic-improvements', [])
-  const [lastRunTime, setLastRunTime] = useKV<string>('agentic-last-run', '')
+  const [improvements, setImprovements] = usePersistentState<Improvement[]>('agentic-improvements', [])
+  const [lastRunTime, setLastRunTime] = usePersistentState<string>('agentic-last-run', '')
   const [systemHealth, setSystemHealth] = useState(engine.getSystemHealth())
 
   // Run autonomous cycle

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+
+/**
+ * Stores state in localStorage when available to avoid external KV dependencies.
+ * Provides a drop-in replacement for useState that persists values between sessions.
+ */
+export function usePersistentState<T>(
+  key: string,
+  initialValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const isBrowser = typeof window !== 'undefined'
+
+  const [state, setState] = useState<T>(() => {
+    if (!isBrowser) {
+      return initialValue
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(key)
+      if (storedValue !== null) {
+        return JSON.parse(storedValue) as T
+      }
+    } catch (error) {
+      console.warn(`[usePersistentState] Failed to read key "${key}" from localStorage`, error)
+    }
+
+    return initialValue
+  })
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return
+    }
+
+    try {
+      window.localStorage.setItem(key, JSON.stringify(state))
+    } catch (error) {
+      console.warn(`[usePersistentState] Failed to persist key "${key}" to localStorage`, error)
+    }
+  }, [key, state])
+
+  return [state, setState]
+}


### PR DESCRIPTION
## Summary
- replace the spark KV dependency in the agentic engine hook with a local persistent state helper to avoid invalid connect calls
- add a reusable persistent state hook backed by localStorage for agent state caching
- add a postinstall script that fetches the main branch when missing so git diff comparisons succeed in CI

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f3ff07a48323a914eaf3ca059242)

## Summary by Sourcery

Introduce a localStorage‐backed state hook for agent state persistence and migrate the agentic engine to use it, and add a postinstall script to fetch the missing main branch for CI consistency

New Features:
- Add usePersistentState hook for reusable localStorage-backed state persistence
- Add postinstall script to fetch the main branch when missing to support CI git diff operations

Enhancements:
- Replace @github/spark KV usage in useAgenticEngine with the new usePersistentState hook

CI:
- Invoke ensure-main-branch script in postinstall to guarantee local main branch presence