### PR TITLE
Fix ReactNode import usage in AgenticDashboard

### DIFF
--- a/src/components/AgenticDashboard.tsx
+++ b/src/components/AgenticDashboard.tsx
@@ -4,7 +4,7 @@
  * Displays autonomous system improvements, agent analyses, and execution status
  */
 
-import { useState } from 'react'
+import { type ReactNode, useState } from 'react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -40,7 +40,7 @@ export function AgenticDashboard({ agentic }: AgenticDashboardProps) {
     low: 'bg-blue-500'
   }
 
-  const categoryIcons: Record<ImprovementCategory, React.ReactNode> = {
+  const categoryIcons: Record<ImprovementCategory, ReactNode> = {
     'performance': <TrendUp className="w-4 h-4" />,
     'security': <Shield className="w-4 h-4" />,
     'usability': <Sparkle className="w-4 h-4" />,
@@ -210,7 +210,7 @@ interface ImprovementCardProps {
   improvement: Improvement
   onApprove: (id: string) => void
   priorityColors: Record<ImprovementPriority, string>
-  categoryIcons: Record<ImprovementCategory, React.ReactNode>
+  categoryIcons: Record<ImprovementCategory, ReactNode>
   showActions?: boolean
 }
 


### PR DESCRIPTION
## Summary
- import the ReactNode type directly and update type annotations in the agentic dashboard component

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a4c8576083239d29a0bb258e8473)

## Summary by Sourcery

Bug Fixes:
- Import ReactNode type directly and replace React.ReactNode references