### PR TITLE
Handle async improvement approval in dashboard

### DIFF
--- a/src/components/AgenticDashboard.tsx
+++ b/src/components/AgenticDashboard.tsx
@@ -208,7 +208,7 @@ export function AgenticDashboard({ agentic }: AgenticDashboardProps) {
 
 interface ImprovementCardProps {
   improvement: Improvement
-  onApprove: (id: string) => void
+  onApprove: (id: string) => Promise<void>
   priorityColors: Record<ImprovementPriority, string>
   categoryIcons: Record<ImprovementCategory, React.ReactNode>
   showActions?: boolean
@@ -327,7 +327,9 @@ function ImprovementCard({
           {showActions && status === 'detected' && (
             <Button
               size="sm"
-              onClick={() => onApprove(improvement.id)}
+              onClick={async () => {
+                await onApprove(improvement.id)
+              }}
               className="gap-2"
             >
               <CheckCircle className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- update the improvement card approve handler type to expect an async callback
- await the approve action in the button click handler so asynchronous errors can surface

## Testing
- npx tsc --noEmit *(fails: existing type errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a4a1b71c83238582851c8db911a0)

## Summary by Sourcery

Allow the improvement approval handler to be asynchronous in the dashboard and ensure errors are surfaced by awaiting the callback.

Enhancements:
- Change ImprovementCardProps.onApprove signature to return a Promise<void> instead of void
- Wrap the approve button click handler in an async function and await onApprove to surface asynchronous errors