### PR TITLE
chore: add seed.yaml automation contract (AUTONOMY Sprint)

### DIFF
--- a/seed.yaml
+++ b/seed.yaml
@@ -1,0 +1,37 @@
+# seed.yaml — Automation Contract for organvm-iii-ergon/public-record-data-scrapper
+# Schema: seed/v1.0
+# Generated: 2026-02-12 (AUTONOMY Sprint)
+# Category: standard
+
+schema_version: "1.0"
+organ: III
+organ_name: Commerce
+repo: public-record-data-scrapper
+org: organvm-iii-ergon
+
+metadata:
+  implementation_status: PRODUCTION
+  tier: flagship
+  promotion_status: PUBLIC_PROCESS
+  last_validated: "2026-02-11"
+  generated: "2026-02-12"
+  sprint: "AUTONOMY"
+
+agents:
+  - name: ci
+    trigger: on_push
+    workflow: .github/workflows/ci-typescript.yml
+    description: "Continuous integration pipeline"
+
+produces:
+  - type: dependency
+    description: Consumed by organvm-v-logos/public-process
+    consumers: [organvm-v-logos/public-process]
+
+subscriptions:
+  - event: governance.updated
+    source: ORGAN-IV
+    action: Check compliance with updated governance rules
+  - event: health-audit.completed
+    source: ORGAN-IV
+    action: Review audit findings for this repo


### PR DESCRIPTION
Adds seed.yaml — the machine-readable automation contract declaring what this repo produces and consumes in the inter-organ system. Part of the AUTONOMY Sprint deploying contracts to all 88 repos.

## Summary by Sourcery

Add a machine-readable automation contract (seed.yaml) describing this repo’s role in the inter-organ system.

Chores:
- Declare organ, repo, and organization metadata in a new seed.yaml automation contract.
- Document CI workflow, produced dependency, and governance/audit event subscriptions in the automation contract.