### PR TITLE
feat: add Stripe billing scaffold

### DIFF
--- a/apps/web/src/features/pricing/PricingPage.tsx
+++ b/apps/web/src/features/pricing/PricingPage.tsx
@@ -1,0 +1,160 @@
+/**
+ * Pricing page — displays subscription tiers and handles checkout.
+ *
+ * Checks /api/billing/status first to determine if Stripe is configured.
+ * If not configured, shows a "coming soon" state.
+ */
+
+import { useState, useEffect } from 'react'
+
+interface BillingStatus {
+  configured: boolean
+  provider: string
+}
+
+const TIERS = [
+  {
+    name: 'Starter',
+    price: '$29',
+    period: '/month',
+    description: 'For individual researchers and small teams',
+    features: [
+      'Up to 1,000 record lookups/month',
+      'Basic property data',
+      'CSV export',
+      'Email support'
+    ],
+    cta: 'Start Free Trial',
+    highlighted: false
+  },
+  {
+    name: 'Professional',
+    price: '$99',
+    period: '/month',
+    description: 'For agencies and growing teams',
+    features: [
+      'Up to 10,000 record lookups/month',
+      'Full property + owner data',
+      'API access',
+      'Batch processing',
+      'Priority support'
+    ],
+    cta: 'Start Free Trial',
+    highlighted: true
+  },
+  {
+    name: 'Enterprise',
+    price: 'Custom',
+    period: '',
+    description: 'For large organizations with custom needs',
+    features: [
+      'Unlimited record lookups',
+      'Dedicated infrastructure',
+      'Custom integrations',
+      'SLA guarantee',
+      'Dedicated account manager'
+    ],
+    cta: 'Contact Sales',
+    highlighted: false
+  }
+]
+
+export function PricingPage() {
+  const [status, setStatus] = useState<BillingStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/billing/status')
+      .then((r) => r.json())
+      .then(setStatus)
+      .catch(() => setStatus({ configured: false, provider: 'none' }))
+  }, [])
+
+  async function handleCheckout() {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/billing/checkout', { method: 'POST' })
+      const data = await res.json()
+      if (data.url) {
+        window.location.href = data.url
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '2rem' }}>
+      <h1 style={{ textAlign: 'center', marginBottom: '0.5rem' }}>Pricing</h1>
+      <p style={{ textAlign: 'center', opacity: 0.7, marginBottom: '2rem' }}>
+        Public record intelligence at scale
+      </p>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          gap: '1.5rem'
+        }}
+      >
+        {TIERS.map((tier) => (
+          <div
+            key={tier.name}
+            style={{
+              border: tier.highlighted ? '2px solid #3b82f6' : '1px solid #333',
+              borderRadius: 12,
+              padding: '1.5rem',
+              background: tier.highlighted ? '#1e293b' : 'transparent'
+            }}
+          >
+            <h3>{tier.name}</h3>
+            <div style={{ fontSize: '2rem', fontWeight: 700 }}>
+              {tier.price}
+              <span style={{ fontSize: '1rem', opacity: 0.6 }}>{tier.period}</span>
+            </div>
+            <p style={{ opacity: 0.7, fontSize: '0.9rem' }}>{tier.description}</p>
+            <ul style={{ listStyle: 'none', padding: 0 }}>
+              {tier.features.map((f) => (
+                <li key={f} style={{ padding: '0.25rem 0' }}>
+                  ✓ {f}
+                </li>
+              ))}
+            </ul>
+            <button
+              onClick={tier.name === 'Enterprise' ? undefined : handleCheckout}
+              disabled={loading || !status?.configured}
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                marginTop: '1rem',
+                borderRadius: 8,
+                border: 'none',
+                background: tier.highlighted ? '#3b82f6' : '#444',
+                color: '#fff',
+                cursor: status?.configured ? 'pointer' : 'not-allowed',
+                opacity: status?.configured ? 1 : 0.5
+              }}
+            >
+              {status?.configured ? tier.cta : 'Coming Soon'}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {!status?.configured && (
+        <p
+          style={{
+            textAlign: 'center',
+            marginTop: '2rem',
+            opacity: 0.5,
+            fontSize: '0.85rem'
+          }}
+        >
+          Payment processing is being configured. Check back soon.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default PricingPage

--- a/apps/web/src/features/pricing/index.ts
+++ b/apps/web/src/features/pricing/index.ts
@@ -1,0 +1,1 @@
+export { PricingPage } from './PricingPage'

--- a/server/integrations/stripe/index.ts
+++ b/server/integrations/stripe/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Stripe integration — handles checkout sessions and webhook events.
+ *
+ * Activation steps:
+ * 1. npm install stripe
+ * 2. Set STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET in .env
+ * 3. Create a product + price in Stripe Dashboard
+ * 4. Set STRIPE_PRICE_ID to the price ID
+ */
+
+import Stripe from 'stripe'
+import { config } from '../../config'
+
+let stripeClient: Stripe | null = null
+
+export function getStripe(): Stripe {
+  if (!stripeClient) {
+    const key = config.stripe?.secretKey || process.env.STRIPE_SECRET_KEY
+    if (!key) {
+      throw new Error('STRIPE_SECRET_KEY is not configured')
+    }
+    stripeClient = new Stripe(key, { apiVersion: '2025-04-30.basil' })
+  }
+  return stripeClient
+}
+
+export function isStripeConfigured(): boolean {
+  return !!(config.stripe?.secretKey || process.env.STRIPE_SECRET_KEY)
+}
+
+export interface CheckoutOptions {
+  priceId: string
+  customerId?: string
+  successUrl: string
+  cancelUrl: string
+  metadata?: Record<string, string>
+}
+
+export async function createCheckoutSession(
+  options: CheckoutOptions
+): Promise<Stripe.Checkout.Session> {
+  const stripe = getStripe()
+  return stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: options.priceId, quantity: 1 }],
+    customer: options.customerId,
+    success_url: options.successUrl,
+    cancel_url: options.cancelUrl,
+    metadata: options.metadata
+  })
+}
+
+export async function constructWebhookEvent(
+  payload: Buffer,
+  signature: string
+): Promise<Stripe.Event> {
+  const stripe = getStripe()
+  const secret = config.stripe?.webhookSecret || process.env.STRIPE_WEBHOOK_SECRET
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET is not configured')
+  }
+  return stripe.webhooks.constructEvent(payload, signature, secret)
+}

--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -1,0 +1,83 @@
+/**
+ * Billing routes — Stripe checkout and webhook handling.
+ *
+ * POST /api/billing/checkout — create a checkout session
+ * POST /api/billing/webhook  — handle Stripe webhook events
+ * GET  /api/billing/status   — check if billing is configured
+ */
+
+import { Router, Request, Response } from 'express'
+import {
+  createCheckoutSession,
+  constructWebhookEvent,
+  isStripeConfigured
+} from '../integrations/stripe'
+
+const router = Router()
+
+router.get('/status', (_req: Request, res: Response) => {
+  res.json({
+    configured: isStripeConfigured(),
+    provider: 'stripe'
+  })
+})
+
+router.post('/checkout', async (req: Request, res: Response) => {
+  if (!isStripeConfigured()) {
+    res.status(503).json({ error: 'Billing not configured' })
+    return
+  }
+
+  const priceId = process.env.STRIPE_PRICE_ID
+  if (!priceId) {
+    res.status(503).json({ error: 'No price configured' })
+    return
+  }
+
+  const origin = req.headers.origin || 'http://localhost:5173'
+
+  const session = await createCheckoutSession({
+    priceId,
+    successUrl: `${origin}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancelUrl: `${origin}/billing/cancel`,
+    metadata: {
+      source: 'public-record-data-scrapper'
+    }
+  })
+
+  res.json({ url: session.url })
+})
+
+router.post('/webhook', async (req: Request, res: Response) => {
+  const signature = req.headers['stripe-signature'] as string
+  if (!signature) {
+    res.status(400).json({ error: 'Missing stripe-signature header' })
+    return
+  }
+
+  const event = await constructWebhookEvent(req.body, signature)
+
+  switch (event.type) {
+    case 'checkout.session.completed':
+      console.log('[billing] Checkout completed:', event.data.object)
+      break
+    case 'customer.subscription.created':
+      console.log('[billing] Subscription created:', event.data.object)
+      break
+    case 'customer.subscription.deleted':
+      console.log('[billing] Subscription cancelled:', event.data.object)
+      break
+    case 'invoice.payment_succeeded':
+      console.log('[billing] Payment succeeded:', event.data.object)
+      break
+    case 'invoice.payment_failed':
+      console.log('[billing] Payment failed:', event.data.object)
+      break
+    default:
+      console.log(`[billing] Unhandled event: ${event.type}`)
+  }
+
+  res.json({ received: true })
+})
+
+export default router


### PR DESCRIPTION
## Summary

- Wire Stripe payment infrastructure: client singleton, checkout session creation, webhook event handler
- Add Express billing routes: `GET /api/billing/status`, `POST /api/billing/checkout`, `POST /api/billing/webhook`
- Add 3-tier pricing page (Starter $29/mo, Professional $99/mo, Enterprise custom) that gracefully degrades to "Coming Soon" when Stripe is not configured

## Activation

1. `npm install stripe`
2. Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` in `.env`
3. Create a product + price in Stripe Dashboard
4. Set `STRIPE_PRICE_ID` to the price ID

## Files

| File | Purpose |
|------|---------|
| `server/integrations/stripe/index.ts` | Stripe client, checkout, webhook construction |
| `server/routes/billing.ts` | Express router for billing endpoints |
| `apps/web/src/features/pricing/PricingPage.tsx` | React pricing UI with billing status check |
| `apps/web/src/features/pricing/index.ts` | Re-export |

## Test plan

- [ ] Verify `GET /api/billing/status` returns `{ configured: false }` without env vars
- [ ] Verify pricing page renders with "Coming Soon" buttons when unconfigured
- [ ] With Stripe test keys: verify checkout redirect works
- [ ] Verify webhook signature validation rejects invalid signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)