### PR TITLE
docs: update evolution prompt with Tony text + portability header

### DIFF
--- a/docs/EVOLUTION-PROMPT-2026-03-23.md
+++ b/docs/EVOLUTION-PROMPT-2026-03-23.md
@@ -1,3 +1,25 @@
+# Tony Carbone — Text + Scrapper Evolution Prompt
+
+## Text Message (send to 305-546-5774)
+
+---
+
+Hey Tony — been thinking about our conversation. Went back into the UCC platform with fresh eyes after hearing about your underwriting flow. Two things jumped out:
+
+1. The 50-state agents are solid but I mapped out a reliability layer on top — health monitoring per state, auto-failover, and a simple dashboard you could check anytime to see coverage status (green/yellow/red per state with last-pull timestamps).
+
+2. The bigger thing — UCC filings are table stakes. What nobody else is doing is combining UCC data with bank statement patterns, filing termination alerts (merchant just paid off an advance = fresh capacity), and funder identification (who else is already chasing the same merchant). That's the next-level stuff we talked about.
+
+I put together a roadmap. Want to hop on a quick call this week so I can walk you through it?
+
+---
+
+## Scrapper Evolution Prompt (standalone — bring into the repo)
+
+_NOTE: This is a copy of the evolution prompt, relocated from the scrapper repo's docs/ directory to this standalone location for portability._
+
+---
+
 # Evolution Prompt: Beyond UCC Scraping — Next-Generation MCA Intelligence
 
 **Date:** 2026-03-23
@@ -12,7 +34,7 @@
 
 ## Phase 1: Reliability Hardening (Answer: "Will it continue to work?")
 
-The current 50-state agent architecture uses fallback strategies (API → bulk download → vendor feed → scrape). Harden this:
+The current 50-state agent architecture uses fallback strategies (API -> bulk download -> vendor feed -> scrape). Harden this:
 
 ### 1.1 Anti-Fragile Scraping Infrastructure
 
@@ -32,9 +54,9 @@ The current 50-state agent architecture uses fallback strategies (API → bulk d
 - [ ] Add vendor feed fallback for high-value states (CA, TX, FL, NY) — commercial UCC data providers as insurance
 - [ ] Create quarterly "state portal audit" automation: re-validate all 50 agents against live portals, report degradation
 
-### 1.3 Tony-Specific Deliverable
+### 1.3 Client-Facing Deliverable
 
-- [ ] Build a simple status page Tony can check: "All 50 states green/yellow/red" with last-pull timestamps
+- [ ] Build a simple status page: "All 50 states green/yellow/red" with last-pull timestamps
 - [ ] Weekly email digest: records collected, new filings by state, system health score
 
 ---
@@ -47,7 +69,7 @@ UCC filings tell you "this business has existing financing." That's table stakes
 - **Ability**: Can they actually handle another advance?
 - **Competition**: Who else is already chasing this merchant?
 
-### 2.1 Bank Statement Intelligence (Tony's Primary Interest)
+### 2.1 Bank Statement Intelligence
 
 The Plaid integration already exists in `server/integrations/plaid/`. Extend it:
 
@@ -59,7 +81,7 @@ The Plaid integration already exists in `server/integrations/plaid/`. Extend it:
   - NSF/overdraft frequency (risk signal)
 - [ ] Create "stacking detection": identify merchants with multiple concurrent advances by spotting multiple fixed daily debits to different entities
 - [ ] Build "capacity calculator": given current revenue and existing obligations, estimate max new advance amount
-- [ ] **Public records angle** (what Tony specifically asked about):
+- [ ] **Public records expansion:**
   - Court records scraping for judgments, defaults, confessions of judgment (COJ)
   - State UCC-3 amendment tracking (terminations = freed-up capacity, amendments = restructuring)
   - Business entity status changes via SOS (new formations = growth, dissolutions = risk)
@@ -69,14 +91,14 @@ The Plaid integration already exists in `server/integrations/plaid/`. Extend it:
 
 Current enrichment pulls from SEC EDGAR, OSHA, USPTO, Census, SAM.gov. Add:
 
-- [ ] **Google Business Profile signals**: review velocity, rating trends, response rate, photo freshness (active business proxy)
-- [ ] **Hiring signals**: Indeed/LinkedIn job postings (hiring = growth = may need capital for expansion)
+- [ ] **Google Business Profile signals**: review velocity, rating trends, response rate, photo freshness
+- [ ] **Hiring signals**: Indeed/LinkedIn job postings (hiring = growth = may need capital)
 - [ ] **Technology stack changes**: BuiltWith/Wappalyzer (upgrading tech = investing in business)
-- [ ] **Web traffic trends**: SimilarWeb API or Semrush (traffic growth/decline as health proxy)
-- [ ] **Social media activity**: posting frequency, engagement trends (active marketing = active business)
+- [ ] **Web traffic trends**: SimilarWeb API or Semrush (traffic growth/decline)
+- [ ] **Social media activity**: posting frequency, engagement trends
 - [ ] **Domain age + SSL cert monitoring**: new domains = new business, expired SSL = neglect
 - [ ] **Yelp/TripAdvisor for hospitality vertical**: review velocity as revenue proxy
-- [ ] **Equipment lease filings**: UCC-1 filings specifically for equipment (signals capital expenditure patterns)
+- [ ] **Equipment lease filings**: UCC-1 filings specifically for equipment
 - [ ] **SBA loan data**: businesses that received SBA loans may need bridge financing
 
 ### 2.3 Competitive Intelligence Layer
@@ -84,70 +106,66 @@ Current enrichment pulls from SEC EDGAR, OSHA, USPTO, Census, SAM.gov. Add:
 This is what no current MCA lead provider offers:
 
 - [ ] **Funder identification from UCC filings**: map secured party names to known MCA funders/brokers
-  - Build a funder database: company name → known DBA names → filing patterns
+  - Build a funder database: company name -> known DBA names -> filing patterns
   - Detect when a merchant has filings from aggressive stackers vs. conservative funders
-- [ ] **Filing velocity tracking**: a merchant getting a new UCC filing every 60 days is a serial stacker (high risk but also high demand signal)
+- [ ] **Filing velocity tracking**: a merchant getting a new UCC filing every 60 days is a serial stacker
 - [ ] **Competitive heat map**: which funders are most active in which states/industries?
-- [ ] **"Fresh filing" alerts**: real-time notification when a UCC filing is terminated (= merchant just paid off an advance, has fresh capacity)
+- [ ] **"Fresh filing" alerts**: real-time notification when a UCC filing is terminated (= merchant paid off, has fresh capacity)
 
 ### 2.4 Predictive Scoring Engine (ML v2)
 
-Current scoring engine assigns 0-100 priority score. Upgrade:
-
-- [ ] Train on outcome data: which leads actually converted? Which defaulted? (Requires Tony's historical data)
-- [ ] Multi-signal fusion: combine UCC age + bank patterns + health signals + competitive position into a composite "readiness score"
-- [ ] Time-decay weighting: recent signals matter more than stale data
-- [ ] Segment-specific models: restaurant MCA prospects behave differently from trucking companies
+- [ ] Train on outcome data: which leads converted? Which defaulted? (Requires client historical data)
+- [ ] Multi-signal fusion: UCC age + bank patterns + health signals + competitive position -> composite "readiness score"
+- [ ] Time-decay weighting: recent signals > stale data
+- [ ] Segment-specific models: restaurants behave differently from trucking companies
 - [ ] "Optimal timing" predictor: when in the advance lifecycle is a merchant most likely to re-up?
 
 ---
 
-## Phase 3: Delivery & Automation (Tony's Sales Team)
+## Phase 3: Sales Team Automation
 
-### 3.1 Sales Team Automation
+### 3.1 Outreach Automation
 
-Tony's team currently does manual outreach. Automate:
-
-- [ ] Smart dialer queue: prioritize calls by readiness score, time zone, and best-contact-time model
-- [ ] Pre-call briefing auto-generation: one-page summary of the merchant (filings, estimated revenue, existing obligations, talking points)
+- [ ] Smart dialer queue: prioritize calls by readiness score, time zone, best-contact-time model
+- [ ] Pre-call briefing auto-generation: one-page merchant summary (filings, revenue estimate, obligations, talking points)
 - [ ] Automated email/SMS sequences triggered by events:
   - New UCC filing = "We noticed you recently secured financing..."
-  - UCC termination = "Congratulations on paying off your advance. Ready for growth capital?"
-  - Business growth signal = "We see [business name] is expanding..."
-- [ ] CRM integration: push scored leads directly into their pipeline tool
-- [ ] Compliance auto-check before outreach: TCPA consent, DNC list, state-specific disclosure requirements
+  - UCC termination = "Ready for growth capital?"
+  - Business growth signal = "We see [business] is expanding..."
+- [ ] CRM integration: push scored leads directly into pipeline tool
+- [ ] Compliance auto-check: TCPA consent, DNC list, state-specific disclosures
 
-### 3.2 Rehab/Healthcare Vertical (Flyland.com)
+### 3.2 Healthcare Vertical (Flyland.com)
 
-Tony also runs healthcare SaaS. The same intelligence platform pattern applies:
+Same intelligence platform pattern for healthcare:
 
-- [ ] Map healthcare-specific public records: state licensing boards, CMS provider enrollment, NPPES (NPI registry)
-- [ ] Rehab facility signals: licensing changes, capacity changes, ownership transfers
-- [ ] Ad campaign intelligence: monitor competitor ad spend via Meta Ad Library, Google Ads Transparency
-- [ ] Patient volume proxies: Google Trends for facility-specific search terms, review volume changes
+- [ ] State licensing boards, CMS provider enrollment, NPPES (NPI registry)
+- [ ] Rehab facility signals: licensing changes, capacity, ownership transfers
+- [ ] Ad campaign intelligence: Meta Ad Library, Google Ads Transparency
+- [ ] Patient volume proxies: Google Trends, review volume changes
 
 ---
 
-## Implementation Priority (for Tony)
+## Implementation Priority
 
 | Priority | Item                                      | Why                                             | Effort    |
 | -------- | ----------------------------------------- | ----------------------------------------------- | --------- |
 | P0       | Coverage dashboard + status page          | Answers "will it continue to work?" immediately | 1-2 days  |
 | P0       | State agent health monitoring             | Proactive reliability                           | 2-3 days  |
-| P1       | Bank statement pattern analyzer           | Tony's primary interest from the call           | 1-2 weeks |
+| P1       | Bank statement pattern analyzer           | Primary interest from the call                  | 1-2 weeks |
 | P1       | Funder identification from UCC filings    | Unique competitive advantage                    | 1 week    |
 | P1       | UCC termination alerts ("fresh capacity") | Highest-conversion trigger in MCA               | 3-5 days  |
 | P2       | Pre-call briefing auto-gen                | Sales team immediate productivity gain          | 1 week    |
-| P2       | Business health signal enrichment         | Scoring accuracy improvement                    | 2-3 weeks |
-| P3       | Predictive scoring v2                     | Requires outcome data from Tony                 | 3-4 weeks |
+| P2       | Business health signal enrichment         | Scoring accuracy                                | 2-3 weeks |
+| P3       | Predictive scoring v2                     | Requires client outcome data                    | 3-4 weeks |
 | P3       | Healthcare vertical adaptation            | Flyland.com expansion                           | 2-3 weeks |
 
 ---
 
 ## Technical Notes
 
-- Current stack: TypeScript, Express, PostgreSQL (RDS), Redis (ElastiCache), BullMQ workers, React 19, Vercel, Terraform + AWS
+- Stack: TypeScript, Express, PostgreSQL (RDS), Redis (ElastiCache), BullMQ workers, React 19, Vercel, Terraform + AWS
 - Existing integrations: Plaid, Twilio, SendGrid, Stripe, ACH
 - 2,055 tests, 100% coverage — maintain this discipline
-- Agent orchestrator pattern in `server/queue/workers/` — new data source agents follow the same pattern
-- Public records scraping must respect robots.txt and rate limits — we're building a sustainable data business, not a one-time scrape
+- Agent orchestrator pattern in `server/queue/workers/` — new agents follow the same pattern
+- Respect robots.txt and rate limits — sustainable data business, not one-time scrape


### PR DESCRIPTION
## Summary
- Added Tony Carbone text message draft to evolution prompt header
- Added portability note for standalone use outside the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the evolution prompt document with client-agnostic language, add a standalone portability header, and include an example text message for outreach context.

Documentation:
- Add a new header section with a Tony Carbone example text message and a note explaining the document’s standalone, portable usage.
- Generalize client-specific wording throughout the evolution prompt to be reusable beyond a single client while keeping the same roadmap structure.