### PR TITLE
fix(server): main-module guard — no auto-start on import (#237)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -373,31 +373,40 @@ export class Server {
   }
 }
 
-// Start server if this file is run directly
-const server = new Server()
-server.start().catch((error) => {
-  console.error('Fatal error during server startup:', error)
-  process.exit(1)
-})
+// Start the server only when this module is executed directly — never on
+// import (e.g. by tests or tooling). The esbuild bundle (scripts/build-server.mjs)
+// shims `import.meta.url` to `pathToFileURL(__filename)`, so this guard holds in
+// both the bundled CJS entrypoint (`node dist/server.cjs`) and the raw ESM source
+// (`tsx server/index.ts`); importing the module yields the `Server` class with no
+// side effects.
+const invokedDirectly = process.argv[1] === fileURLToPath(import.meta.url)
 
-// Graceful shutdown on termination signals (guarded against duplicates inside
-// shutdown()).
-process.on('SIGTERM', () => {
-  void server.shutdown('SIGTERM')
-})
-process.on('SIGINT', () => {
-  void server.shutdown('SIGINT')
-})
+if (invokedDirectly) {
+  const server = new Server()
+  server.start().catch((error) => {
+    console.error('Fatal error during server startup:', error)
+    process.exit(1)
+  })
 
-// Process-level safety nets: log loudly and shut down cleanly rather than
-// leaving the process in an undefined state.
-process.on('unhandledRejection', (reason) => {
-  console.error('[FATAL] Unhandled promise rejection:', reason)
-  void server.shutdown('unhandledRejection')
-})
-process.on('uncaughtException', (error) => {
-  console.error('[FATAL] Uncaught exception:', error)
-  void server.shutdown('uncaughtException')
-})
+  // Graceful shutdown on termination signals (guarded against duplicates inside
+  // shutdown()).
+  process.on('SIGTERM', () => {
+    void server.shutdown('SIGTERM')
+  })
+  process.on('SIGINT', () => {
+    void server.shutdown('SIGINT')
+  })
+
+  // Process-level safety nets: log loudly and shut down cleanly rather than
+  // leaving the process in an undefined state.
+  process.on('unhandledRejection', (reason) => {
+    console.error('[FATAL] Unhandled promise rejection:', reason)
+    void server.shutdown('unhandledRejection')
+  })
+  process.on('uncaughtException', (error) => {
+    console.error('[FATAL] Uncaught exception:', error)
+    void server.shutdown('uncaughtException')
+  })
+}
 
 export default Server


### PR DESCRIPTION
## What
Guards the server bootstrap in `server/index.ts` so it only starts when the module is **executed directly**, not when **imported** (e.g. by tests/tooling).

## Why
The bottom of `server/index.ts` carried the comment "Start server if this file is run directly" but had **no actual guard** — it unconditionally `new Server()` + `.start()` and registered global `process` handlers at module load. Any import booted the full server. That is the bug #237 reports.

## How / Verification
Guard: `process.argv[1] === fileURLToPath(import.meta.url)`.

Checked against `scripts/build-server.mjs`: the esbuild bundle defines `import.meta.url` → `import_meta_url` with banner `pathToFileURL(__filename).href`. Reproduced the exact transform locally (bounded `esbuild`, same define+banner, all deps external) — compiles clean, and the bundled output is:
```js
const import_meta_url = require("url").pathToFileURL(__filename).href;
var invokedDirectly = process.argv[1] === fileURLToPath(import_meta_url);
```
So the guard is **TRUE** for prod (`node dist/server.cjs`) and `tsx server/index.ts`, and **FALSE** on import. Production boot is preserved; import side-effects are eliminated.

Closes #237