### PR TITLE
chore: organvm auto-sync drift (2026-06-06 refresh) + gitignore .lh/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ src-tauri/bindings/
 # The server/ directory is tracked in this repo. This negation shields it from
 # any broader ignore rules in contributors' global git excludes (e.g. /server/).
 !/server/
+# VSCode Local History extension
+.lh/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,29 +46,23 @@ Global policy: /Users/4jp/AGENTS.md applies and cannot be overridden.
 - Prefer environment variables and secrets managers for production credentials.
 
 <!-- ORGANVM:AUTO:START -->
-
 ## Agent Context (auto-generated — do not edit)
 
 This repo participates in the **ORGAN-III (Commerce)** swarm.
 
 ### Active Subscriptions
-
 - Event: `governance.updated` → Action: Check compliance with updated governance rules
 - Event: `health-audit.completed` → Action: Review audit findings for this repo
 
 ### Production Responsibilities
-
 - **Produce** `dependency` for organvm-v-logos/public-process
 
 ### External Dependencies
-
-- _No external dependencies_
+- *No external dependencies*
 
 ### Governance Constraints
-
 - Adhere to unidirectional flow: I→II→III
 - Never commit secrets or credentials
 
-_Last synced: 2026-04-14T21:31:55Z_
-
+*Last synced: 2026-06-06T01:01:09Z*
 <!-- ORGANVM:AUTO:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,25 +158,21 @@ This repository is a managed component of the ORGANVM meta-workspace.
 - **Intelligence:** Conductor MCP tools are available for routing and mission synthesis.
 
 <!-- ORGANVM:AUTO:START -->
-
 ## System Context (auto-generated — do not edit)
 
 **Organ:** ORGAN-III (Commerce) | **Tier:** flagship | **Status:** GRADUATED
 **Org:** `organvm-iii-ergon` | **Repo:** `public-record-data-scrapper`
 
 ### Edges
-
 - **Produces** → `organvm-v-logos/public-process`: dependency
 
 ### Siblings in Commerce
-
 `classroom-rpg-aetheria`, `gamified-coach-interface`, `trade-perpetual-future`, `fetch-familiar-friends`, `sovereign-ecosystem--real-estate-luxury`, `search-local--happy-hour`, `multi-camera--livestream--framework`, `universal-mail--automation`, `mirror-mirror`, `the-invisible-ledger`, `enterprise-plugin`, `virgil-training-overlay`, `tab-bookmark-manager`, `a-i-chat--exporter`, `.github` ... and 16 more
 
 ### Governance
-
 - Strictly unidirectional flow: I→II→III. No dependencies on Theory (I).
 
-_Last synced: 2026-04-14T21:31:54Z_
+*Last synced: 2026-06-06T01:01:09Z*
 
 ## Active Handoff Protocol
 
@@ -190,144 +186,61 @@ NOT be trusted. A different agent will verify your output against these constrai
 ## Session Review Protocol
 
 At the end of each session that produces or modifies files:
-
 1. Run `organvm session review --latest` to get a session summary
 2. Check for unimplemented plans: `organvm session plans --project .`
 3. Export significant sessions: `organvm session export <id> --slug <slug>`
 4. Run `organvm prompts distill --dry-run` to detect uncovered operational patterns
 
 Transcripts are on-demand (never committed):
-
 - `organvm session transcript <id>` — conversation summary
 - `organvm session transcript <id> --unabridged` — full audit trail
 - `organvm session prompts <id>` — human prompts only
 
+
 ## System Library
 
-Plans: 269 indexed | Chains: 5 available | SOPs: 121 active
+Plans: 269 indexed | Chains: 5 available | SOPs: 18 active
 Discover: `organvm plans search <query>` | `organvm chains list` | `organvm sop lifecycle`
-Library: `meta-organvm/praxis-perpetua/library/`
+Library: `/Users/4jp/Code/organvm/praxis-perpetua/library`
+
 
 ## Active Directives
 
-| Scope   | Phase | Name                                                     | Description                                                                  |
-| ------- | ----- | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| system  | any   | atomic-clock                                             | The Atomic Clock                                                             |
-| system  | any   | execution-sequence                                       | Execution Sequence                                                           |
-| system  | any   | multi-agent-dispatch                                     | Multi-Agent Dispatch                                                         |
-| system  | any   | session-handoff-avalanche                                | Session Handoff Avalanche                                                    |
-| system  | any   | system-loops                                             | System Loops                                                                 |
-| system  | any   | prompting-standards                                      | Prompting Standards                                                          |
-| system  | any   | research-standards-bibliography                          | APPENDIX: Research Standards Bibliography                                    |
-| system  | any   | phase-closing-and-forward-plan                           | METADOC: Phase-Closing Commemoration & Forward Attack Plan                   |
-| system  | any   | research-standards                                       | METADOC: Architectural Typology & Research Standards                         |
-| system  | any   | sop-ecosystem                                            | METADOC: SOP Ecosystem — Taxonomy, Inventory & Coverage                      |
-| system  | any   | autonomous-content-syndication                           | SOP: Autonomous Content Syndication (The Broadcast Protocol)                 |
-| system  | any   | autopoietic-systems-diagnostics                          | SOP: Autopoietic Systems Diagnostics (The Mirror of Eternity)                |
-| system  | any   | background-task-resilience                               | background-task-resilience                                                   |
-| system  | any   | cicd-resilience-and-recovery                             | SOP: CI/CD Pipeline Resilience & Recovery                                    |
-| system  | any   | community-event-facilitation                             | SOP: Community Event Facilitation (The Dialectic Crucible)                   |
-| system  | any   | context-window-conservation                              | context-window-conservation                                                  |
-| system  | any   | conversation-to-content-pipeline                         | SOP — Conversation-to-Content Pipeline                                       |
-| system  | any   | cross-agent-handoff                                      | SOP: Cross-Agent Session Handoff                                             |
-| system  | any   | cross-channel-publishing-metrics                         | SOP: Cross-Channel Publishing Metrics (The Echo Protocol)                    |
-| system  | any   | data-migration-and-backup                                | SOP: Data Migration and Backup Protocol (The Memory Vault)                   |
-| system  | any   | document-audit-feature-extraction                        | SOP: Document Audit & Feature Extraction                                     |
-| system  | any   | dynamic-lens-assembly                                    | SOP: Dynamic Lens Assembly                                                   |
-| system  | any   | essay-publishing-and-distribution                        | SOP: Essay Publishing & Distribution                                         |
-| system  | any   | formal-methods-applied-protocols                         | SOP: Formal Methods Applied Protocols                                        |
-| system  | any   | formal-methods-master-taxonomy                           | SOP: Formal Methods Master Taxonomy (The Blueprint of Proof)                 |
-| system  | any   | formal-methods-tla-pluscal                               | SOP: Formal Methods — TLA+ and PlusCal Verification (The Blueprint Verifier) |
-| system  | any   | generative-art-deployment                                | SOP: Generative Art Deployment (The Gallery Protocol)                        |
-| system  | any   | market-gap-analysis                                      | SOP: Full-Breath Market-Gap Analysis & Defensive Parrying                    |
-| system  | any   | mcp-server-fleet-management                              | SOP: MCP Server Fleet Management (The Server Protocol)                       |
-| system  | any   | multi-agent-swarm-orchestration                          | SOP: Multi-Agent Swarm Orchestration (The Polymorphic Swarm)                 |
-| system  | any   | network-testament-protocol                               | SOP: Network Testament Protocol (The Mirror Protocol)                        |
-| system  | any   | open-source-licensing-and-ip                             | SOP: Open Source Licensing and IP (The Commons Protocol)                     |
-| system  | any   | performance-interface-design                             | SOP: Performance Interface Design (The Stage Protocol)                       |
-| system  | any   | pitch-deck-rollout                                       | SOP: Pitch Deck Generation & Rollout                                         |
-| system  | any   | polymorphic-agent-testing                                | SOP: Polymorphic Agent Testing (The Adversarial Protocol)                    |
-| system  | any   | promotion-and-state-transitions                          | SOP: Promotion & State Transitions                                           |
-| system  | any   | recursive-study-feedback                                 | SOP: Recursive Study & Feedback Loop (The Ouroboros)                         |
-| system  | any   | repo-onboarding-and-habitat-creation                     | SOP: Repo Onboarding & Habitat Creation                                      |
-| system  | any   | research-to-implementation-pipeline                      | SOP: Research-to-Implementation Pipeline (The Gold Path)                     |
-| system  | any   | security-and-accessibility-audit                         | SOP: Security & Accessibility Audit                                          |
-| system  | any   | session-self-critique                                    | session-self-critique                                                        |
-| system  | any   | smart-contract-audit-and-legal-wrap                      | SOP: Smart Contract Audit and Legal Wrap (The Ledger Protocol)               |
-| system  | any   | source-evaluation-and-bibliography                       | SOP: Source Evaluation & Annotated Bibliography (The Refinery)               |
-| system  | any   | stranger-test-protocol                                   | SOP: Stranger Test Protocol                                                  |
-| system  | any   | strategic-foresight-and-futures                          | SOP: Strategic Foresight & Futures (The Telescope)                           |
-| system  | any   | styx-pipeline-traversal                                  | SOP: Styx Pipeline Traversal (The 7-Organ Transmutation)                     |
-| system  | any   | system-dashboard-telemetry                               | SOP: System Dashboard Telemetry (The Panopticon Protocol)                    |
-| system  | any   | the-descent-protocol                                     | the-descent-protocol                                                         |
-| system  | any   | the-membrane-protocol                                    | the-membrane-protocol                                                        |
-| system  | any   | theoretical-concept-versioning                           | SOP: Theoretical Concept Versioning (The Epistemic Protocol)                 |
-| system  | any   | theory-to-concrete-gate                                  | theory-to-concrete-gate                                                      |
-| system  | any   | typological-hermeneutic-analysis                         | SOP: Typological & Hermeneutic Analysis (The Archaeology)                    |
-| unknown | any   | SOP-SS-ATM-001_001-atomic-decomposition                  | SOP-SS-ATM-001_001: Atomic Decomposition & Coverage Proof                    |
-| unknown | any   | SOP-SS-CLT-001_001-ontology_client_decisions             | SOP-SS-CLT-001_001-ontology_client_decisions                                 |
-| unknown | any   | SOP-SS-CNT-001_001-content-extraction-and-node-injection | SOP-SS-CNT-001_001: Content Extraction & Node Injection                      |
-| unknown | any   | SOP-SS-ISS-001-001-ontology-issue-specification          | SOP-SS-ISS-001-001-ontology-issue-specification                              |
-| unknown | any   | SOP-SS-PRC-001_001-ontology_meta_process                 | SOP-SS-PRC-001-001-ontology-meta-process                                     |
-| unknown | any   | SOP-SS-QAB-001_001-project-board-qa                      | SOP-SS-QAB-001_001-project-board-qa                                          |
-| unknown | any   | SOP-SS-TRK-001_001-ontology_issue_tracking               | SOP-SS-TRK-001_001-ontology_issue_tracking                                   |
-| unknown | any   | registry                                                 | SOP Registry — Sovereign Systems                                             |
+| Scope | Phase | Name | Description |
+|-------|-------|------|-------------|
+| system | any | atomic-clock | The Atomic Clock |
+| system | any | execution-sequence | Execution Sequence |
+| system | any | multi-agent-dispatch | Multi-Agent Dispatch |
+| system | any | session-handoff-avalanche | Session Handoff Avalanche |
+| system | any | system-loops | System Loops |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | background-task-resilience | background-task-resilience |
+| system | any | context-window-conservation | context-window-conservation |
+| system | any | session-self-critique | session-self-critique |
+| system | any | the-descent-protocol | the-descent-protocol |
+| system | any | the-membrane-protocol | the-membrane-protocol |
+| system | any | theory-to-concrete-gate | theory-to-concrete-gate |
+| system | any | triangulation-protocol | triangulation-protocol |
 
-Linked skills: cicd-resilience-and-recovery, continuous-learning-agent, evaluation-to-growth, genesis-dna, multi-agent-workforce-planner, promotion-and-state-transitions, quality-gate-baseline-calibration, repo-onboarding-and-habitat-creation, structural-integrity-audit
+Linked skills: SOP-TRIADIC-REVIEW-PROTOCOL, cicd-resilience-and-recovery, continuous-learning-agent, evaluation-to-growth, genesis-dna, multi-agent-workforce-planner, promotion-and-state-transitions, quality-gate-baseline-calibration, repo-onboarding-and-habitat-creation, session-self-critique, structural-integrity-audit, the-membrane-protocol, triple-reference
+
 
 **Prompting (Anthropic)**: context 200K tokens, format: XML tags, thinking: extended thinking (budget_tokens)
 
-## Ecosystem Status
 
-- **delivery**: 0/2 live, 0 planned
-- **revenue**: 0/1 live, 1 planned
-- **marketing**: 0/2 live, 1 planned
-- **community**: 0/1 live, 0 planned
-- **content**: 0/2 live, 1 planned
-- **listings**: 0/1 live, 1 planned
+## Atomization Pipeline
 
-Run: `organvm ecosystem show public-record-data-scrapper` | `organvm ecosystem validate --organ III`
+Run `organvm atoms pipeline --write && organvm atoms fanout --write` to generate task queue.
 
-## External Mirrors (Network Testament)
-
-- **technical** (7): facebook/react, eslint/eslint, prettier/prettier, tailwindlabs/tailwindcss, microsoft/TypeScript +2 more
-
-Convergences: 20 | Run: `organvm network map --repo public-record-data-scrapper` | `organvm network suggest`
-
-## Entity Identity (Ontologia)
-
-**UID:** `ent_repo_01KKKX3RVM84W1V9XGANHNW54G` | **Matched by:** primary_name
-
-Resolve: `organvm ontologia resolve public-record-data-scrapper` | History: `organvm ontologia history ent_repo_01KKKX3RVM84W1V9XGANHNW54G`
-
-## Live System Variables (Ontologia)
-
-| Variable                | Value | Scope  | Updated    |
-| ----------------------- | ----- | ------ | ---------- |
-| `active_repos`          | 89    | global | 2026-04-14 |
-| `archived_repos`        | 54    | global | 2026-04-14 |
-| `ci_workflows`          | 107   | global | 2026-04-14 |
-| `code_files`            | 0     | global | 2026-04-14 |
-| `dependency_edges`      | 60    | global | 2026-04-14 |
-| `operational_organs`    | 10    | global | 2026-04-14 |
-| `published_essays`      | 29    | global | 2026-04-14 |
-| `repos_with_tests`      | 0     | global | 2026-04-14 |
-| `sprints_completed`     | 33    | global | 2026-04-14 |
-| `test_files`            | 0     | global | 2026-04-14 |
-| `total_organs`          | 10    | global | 2026-04-14 |
-| `total_repos`           | 145   | global | 2026-04-14 |
-| `total_words_formatted` | 0     | global | 2026-04-14 |
-| `total_words_numeric`   | 0     | global | 2026-04-14 |
-| `total_words_short`     | 0K+   | global | 2026-04-14 |
-
-Metrics: 9 registered | Observations: 32128 recorded
-Resolve: `organvm ontologia status` | Refresh: `organvm refresh`
 
 ## System Density (auto-generated)
 
-AMMOI: 58% | Edges: 42 | Tensions: 33 | Clusters: 5 | Adv: 23 | Events(24h): 32336
-Structure: 8 organs / 145 repos / 1654 components (depth 17) | Inference: 98% | Organs: META-ORGANVM:65%, ORGAN-I:53%, ORGAN-II:48%, ORGAN-III:54% +5 more
-Last pulse: 2026-04-14T21:31:36 | Δ24h: -1.0% | Δ7d: n/a
+AMMOI: 25% | Edges: 0 | Tensions: 0 | Clusters: 0 | Adv: 27 | Events(24h): 38774
+Structure: 8 organs / 149 repos / 1654 components (depth 17) | Inference: 0% | Organs: META-ORGANVM:63%, ORGAN-I:53%, ORGAN-II:48%, ORGAN-III:55% +5 more
+Last pulse: 2026-06-06T01:01:02 | Δ24h: n/a | Δ7d: n/a
+
 
 ## Dialect Identity (Trivium)
 
@@ -337,6 +250,7 @@ Strongest translations: I (formal), II (structural), VII (structural)
 
 Scan: `organvm trivium scan III <OTHER>` | Matrix: `organvm trivium matrix` | Synthesize: `organvm trivium synthesize`
 
+
 ## Logos Documentation Layer
 
 **Status:** MISSING | **Symmetry:** 0.0 (VACUUM)
@@ -344,18 +258,16 @@ Scan: `organvm trivium scan III <OTHER>` | Matrix: `organvm trivium matrix` | Sy
 Nature demands a documentation counterpart. This formation maintains its narrative record in `docs/logos/`.
 
 ### The Tetradic Counterpart
-
 - **[Telos (Idealized Form)](../docs/logos/telos.md)** — The dream and theoretical grounding.
 - **[Pragma (Concrete State)](../docs/logos/pragma.md)** — The honest account of what exists.
 - **[Praxis (Remediation Plan)](../docs/logos/praxis.md)** — The attack vectors for evolution.
 - **[Receptio (Reception)](../docs/logos/receptio.md)** — The account of the constructed polis.
 
 ### Alchemical I/O
-
 - **[Source & Transmutation](../docs/logos/alchemical-io.md)** — Narrative of inputs, process, and returns.
 
 - **[Public Essay](https://organvm-v-logos.github.io/public-process/)** — System-wide narrative entry.
 
-_Compliance: Formation is currently void._
+*Compliance: Formation is currently void.*
 
 <!-- ORGANVM:AUTO:END -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,25 +10,21 @@ This repository is a managed component of the ORGANVM meta-workspace.
 - **Intelligence:** Conductor MCP tools are available for routing and mission synthesis.
 
 <!-- ORGANVM:AUTO:START -->
-
 ## System Context (auto-generated — do not edit)
 
 **Organ:** ORGAN-III (Commerce) | **Tier:** flagship | **Status:** GRADUATED
 **Org:** `organvm-iii-ergon` | **Repo:** `public-record-data-scrapper`
 
 ### Edges
-
 - **Produces** → `organvm-v-logos/public-process`: dependency
 
 ### Siblings in Commerce
-
 `classroom-rpg-aetheria`, `gamified-coach-interface`, `trade-perpetual-future`, `fetch-familiar-friends`, `sovereign-ecosystem--real-estate-luxury`, `search-local--happy-hour`, `multi-camera--livestream--framework`, `universal-mail--automation`, `mirror-mirror`, `the-invisible-ledger`, `enterprise-plugin`, `virgil-training-overlay`, `tab-bookmark-manager`, `a-i-chat--exporter`, `.github` ... and 16 more
 
 ### Governance
-
 - Strictly unidirectional flow: I→II→III. No dependencies on Theory (I).
 
-_Last synced: 2026-04-14T21:31:55Z_
+*Last synced: 2026-06-06T01:01:09Z*
 
 ## Active Handoff Protocol
 
@@ -42,144 +38,61 @@ NOT be trusted. A different agent will verify your output against these constrai
 ## Session Review Protocol
 
 At the end of each session that produces or modifies files:
-
 1. Run `organvm session review --latest` to get a session summary
 2. Check for unimplemented plans: `organvm session plans --project .`
 3. Export significant sessions: `organvm session export <id> --slug <slug>`
 4. Run `organvm prompts distill --dry-run` to detect uncovered operational patterns
 
 Transcripts are on-demand (never committed):
-
 - `organvm session transcript <id>` — conversation summary
 - `organvm session transcript <id> --unabridged` — full audit trail
 - `organvm session prompts <id>` — human prompts only
 
+
 ## System Library
 
-Plans: 269 indexed | Chains: 5 available | SOPs: 121 active
+Plans: 269 indexed | Chains: 5 available | SOPs: 18 active
 Discover: `organvm plans search <query>` | `organvm chains list` | `organvm sop lifecycle`
-Library: `meta-organvm/praxis-perpetua/library/`
+Library: `/Users/4jp/Code/organvm/praxis-perpetua/library`
+
 
 ## Active Directives
 
-| Scope   | Phase | Name                                                     | Description                                                                  |
-| ------- | ----- | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| system  | any   | atomic-clock                                             | The Atomic Clock                                                             |
-| system  | any   | execution-sequence                                       | Execution Sequence                                                           |
-| system  | any   | multi-agent-dispatch                                     | Multi-Agent Dispatch                                                         |
-| system  | any   | session-handoff-avalanche                                | Session Handoff Avalanche                                                    |
-| system  | any   | system-loops                                             | System Loops                                                                 |
-| system  | any   | prompting-standards                                      | Prompting Standards                                                          |
-| system  | any   | research-standards-bibliography                          | APPENDIX: Research Standards Bibliography                                    |
-| system  | any   | phase-closing-and-forward-plan                           | METADOC: Phase-Closing Commemoration & Forward Attack Plan                   |
-| system  | any   | research-standards                                       | METADOC: Architectural Typology & Research Standards                         |
-| system  | any   | sop-ecosystem                                            | METADOC: SOP Ecosystem — Taxonomy, Inventory & Coverage                      |
-| system  | any   | autonomous-content-syndication                           | SOP: Autonomous Content Syndication (The Broadcast Protocol)                 |
-| system  | any   | autopoietic-systems-diagnostics                          | SOP: Autopoietic Systems Diagnostics (The Mirror of Eternity)                |
-| system  | any   | background-task-resilience                               | background-task-resilience                                                   |
-| system  | any   | cicd-resilience-and-recovery                             | SOP: CI/CD Pipeline Resilience & Recovery                                    |
-| system  | any   | community-event-facilitation                             | SOP: Community Event Facilitation (The Dialectic Crucible)                   |
-| system  | any   | context-window-conservation                              | context-window-conservation                                                  |
-| system  | any   | conversation-to-content-pipeline                         | SOP — Conversation-to-Content Pipeline                                       |
-| system  | any   | cross-agent-handoff                                      | SOP: Cross-Agent Session Handoff                                             |
-| system  | any   | cross-channel-publishing-metrics                         | SOP: Cross-Channel Publishing Metrics (The Echo Protocol)                    |
-| system  | any   | data-migration-and-backup                                | SOP: Data Migration and Backup Protocol (The Memory Vault)                   |
-| system  | any   | document-audit-feature-extraction                        | SOP: Document Audit & Feature Extraction                                     |
-| system  | any   | dynamic-lens-assembly                                    | SOP: Dynamic Lens Assembly                                                   |
-| system  | any   | essay-publishing-and-distribution                        | SOP: Essay Publishing & Distribution                                         |
-| system  | any   | formal-methods-applied-protocols                         | SOP: Formal Methods Applied Protocols                                        |
-| system  | any   | formal-methods-master-taxonomy                           | SOP: Formal Methods Master Taxonomy (The Blueprint of Proof)                 |
-| system  | any   | formal-methods-tla-pluscal                               | SOP: Formal Methods — TLA+ and PlusCal Verification (The Blueprint Verifier) |
-| system  | any   | generative-art-deployment                                | SOP: Generative Art Deployment (The Gallery Protocol)                        |
-| system  | any   | market-gap-analysis                                      | SOP: Full-Breath Market-Gap Analysis & Defensive Parrying                    |
-| system  | any   | mcp-server-fleet-management                              | SOP: MCP Server Fleet Management (The Server Protocol)                       |
-| system  | any   | multi-agent-swarm-orchestration                          | SOP: Multi-Agent Swarm Orchestration (The Polymorphic Swarm)                 |
-| system  | any   | network-testament-protocol                               | SOP: Network Testament Protocol (The Mirror Protocol)                        |
-| system  | any   | open-source-licensing-and-ip                             | SOP: Open Source Licensing and IP (The Commons Protocol)                     |
-| system  | any   | performance-interface-design                             | SOP: Performance Interface Design (The Stage Protocol)                       |
-| system  | any   | pitch-deck-rollout                                       | SOP: Pitch Deck Generation & Rollout                                         |
-| system  | any   | polymorphic-agent-testing                                | SOP: Polymorphic Agent Testing (The Adversarial Protocol)                    |
-| system  | any   | promotion-and-state-transitions                          | SOP: Promotion & State Transitions                                           |
-| system  | any   | recursive-study-feedback                                 | SOP: Recursive Study & Feedback Loop (The Ouroboros)                         |
-| system  | any   | repo-onboarding-and-habitat-creation                     | SOP: Repo Onboarding & Habitat Creation                                      |
-| system  | any   | research-to-implementation-pipeline                      | SOP: Research-to-Implementation Pipeline (The Gold Path)                     |
-| system  | any   | security-and-accessibility-audit                         | SOP: Security & Accessibility Audit                                          |
-| system  | any   | session-self-critique                                    | session-self-critique                                                        |
-| system  | any   | smart-contract-audit-and-legal-wrap                      | SOP: Smart Contract Audit and Legal Wrap (The Ledger Protocol)               |
-| system  | any   | source-evaluation-and-bibliography                       | SOP: Source Evaluation & Annotated Bibliography (The Refinery)               |
-| system  | any   | stranger-test-protocol                                   | SOP: Stranger Test Protocol                                                  |
-| system  | any   | strategic-foresight-and-futures                          | SOP: Strategic Foresight & Futures (The Telescope)                           |
-| system  | any   | styx-pipeline-traversal                                  | SOP: Styx Pipeline Traversal (The 7-Organ Transmutation)                     |
-| system  | any   | system-dashboard-telemetry                               | SOP: System Dashboard Telemetry (The Panopticon Protocol)                    |
-| system  | any   | the-descent-protocol                                     | the-descent-protocol                                                         |
-| system  | any   | the-membrane-protocol                                    | the-membrane-protocol                                                        |
-| system  | any   | theoretical-concept-versioning                           | SOP: Theoretical Concept Versioning (The Epistemic Protocol)                 |
-| system  | any   | theory-to-concrete-gate                                  | theory-to-concrete-gate                                                      |
-| system  | any   | typological-hermeneutic-analysis                         | SOP: Typological & Hermeneutic Analysis (The Archaeology)                    |
-| unknown | any   | SOP-SS-ATM-001_001-atomic-decomposition                  | SOP-SS-ATM-001_001: Atomic Decomposition & Coverage Proof                    |
-| unknown | any   | SOP-SS-CLT-001_001-ontology_client_decisions             | SOP-SS-CLT-001_001-ontology_client_decisions                                 |
-| unknown | any   | SOP-SS-CNT-001_001-content-extraction-and-node-injection | SOP-SS-CNT-001_001: Content Extraction & Node Injection                      |
-| unknown | any   | SOP-SS-ISS-001-001-ontology-issue-specification          | SOP-SS-ISS-001-001-ontology-issue-specification                              |
-| unknown | any   | SOP-SS-PRC-001_001-ontology_meta_process                 | SOP-SS-PRC-001-001-ontology-meta-process                                     |
-| unknown | any   | SOP-SS-QAB-001_001-project-board-qa                      | SOP-SS-QAB-001_001-project-board-qa                                          |
-| unknown | any   | SOP-SS-TRK-001_001-ontology_issue_tracking               | SOP-SS-TRK-001_001-ontology_issue_tracking                                   |
-| unknown | any   | registry                                                 | SOP Registry — Sovereign Systems                                             |
+| Scope | Phase | Name | Description |
+|-------|-------|------|-------------|
+| system | any | atomic-clock | The Atomic Clock |
+| system | any | execution-sequence | Execution Sequence |
+| system | any | multi-agent-dispatch | Multi-Agent Dispatch |
+| system | any | session-handoff-avalanche | Session Handoff Avalanche |
+| system | any | system-loops | System Loops |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | prompting-standards | Prompting Standards |
+| system | any | background-task-resilience | background-task-resilience |
+| system | any | context-window-conservation | context-window-conservation |
+| system | any | session-self-critique | session-self-critique |
+| system | any | the-descent-protocol | the-descent-protocol |
+| system | any | the-membrane-protocol | the-membrane-protocol |
+| system | any | theory-to-concrete-gate | theory-to-concrete-gate |
+| system | any | triangulation-protocol | triangulation-protocol |
 
-Linked skills: cicd-resilience-and-recovery, continuous-learning-agent, evaluation-to-growth, genesis-dna, multi-agent-workforce-planner, promotion-and-state-transitions, quality-gate-baseline-calibration, repo-onboarding-and-habitat-creation, structural-integrity-audit
+Linked skills: SOP-TRIADIC-REVIEW-PROTOCOL, cicd-resilience-and-recovery, continuous-learning-agent, evaluation-to-growth, genesis-dna, multi-agent-workforce-planner, promotion-and-state-transitions, quality-gate-baseline-calibration, repo-onboarding-and-habitat-creation, session-self-critique, structural-integrity-audit, the-membrane-protocol, triple-reference
+
 
 **Prompting (Google)**: context 1M tokens (Gemini 1.5 Pro), format: markdown, thinking: thinking mode (thinkingConfig)
 
-## Ecosystem Status
 
-- **delivery**: 0/2 live, 0 planned
-- **revenue**: 0/1 live, 1 planned
-- **marketing**: 0/2 live, 1 planned
-- **community**: 0/1 live, 0 planned
-- **content**: 0/2 live, 1 planned
-- **listings**: 0/1 live, 1 planned
+## Atomization Pipeline
 
-Run: `organvm ecosystem show public-record-data-scrapper` | `organvm ecosystem validate --organ III`
+Run `organvm atoms pipeline --write && organvm atoms fanout --write` to generate task queue.
 
-## External Mirrors (Network Testament)
-
-- **technical** (7): facebook/react, eslint/eslint, prettier/prettier, tailwindlabs/tailwindcss, microsoft/TypeScript +2 more
-
-Convergences: 20 | Run: `organvm network map --repo public-record-data-scrapper` | `organvm network suggest`
-
-## Entity Identity (Ontologia)
-
-**UID:** `ent_repo_01KKKX3RVM84W1V9XGANHNW54G` | **Matched by:** primary_name
-
-Resolve: `organvm ontologia resolve public-record-data-scrapper` | History: `organvm ontologia history ent_repo_01KKKX3RVM84W1V9XGANHNW54G`
-
-## Live System Variables (Ontologia)
-
-| Variable                | Value | Scope  | Updated    |
-| ----------------------- | ----- | ------ | ---------- |
-| `active_repos`          | 89    | global | 2026-04-14 |
-| `archived_repos`        | 54    | global | 2026-04-14 |
-| `ci_workflows`          | 107   | global | 2026-04-14 |
-| `code_files`            | 0     | global | 2026-04-14 |
-| `dependency_edges`      | 60    | global | 2026-04-14 |
-| `operational_organs`    | 10    | global | 2026-04-14 |
-| `published_essays`      | 29    | global | 2026-04-14 |
-| `repos_with_tests`      | 0     | global | 2026-04-14 |
-| `sprints_completed`     | 33    | global | 2026-04-14 |
-| `test_files`            | 0     | global | 2026-04-14 |
-| `total_organs`          | 10    | global | 2026-04-14 |
-| `total_repos`           | 145   | global | 2026-04-14 |
-| `total_words_formatted` | 0     | global | 2026-04-14 |
-| `total_words_numeric`   | 0     | global | 2026-04-14 |
-| `total_words_short`     | 0K+   | global | 2026-04-14 |
-
-Metrics: 9 registered | Observations: 32128 recorded
-Resolve: `organvm ontologia status` | Refresh: `organvm refresh`
 
 ## System Density (auto-generated)
 
-AMMOI: 58% | Edges: 42 | Tensions: 33 | Clusters: 5 | Adv: 23 | Events(24h): 32336
-Structure: 8 organs / 145 repos / 1654 components (depth 17) | Inference: 98% | Organs: META-ORGANVM:65%, ORGAN-I:53%, ORGAN-II:48%, ORGAN-III:54% +5 more
-Last pulse: 2026-04-14T21:31:36 | Δ24h: -1.0% | Δ7d: n/a
+AMMOI: 25% | Edges: 0 | Tensions: 0 | Clusters: 0 | Adv: 27 | Events(24h): 38774
+Structure: 8 organs / 149 repos / 1654 components (depth 17) | Inference: 0% | Organs: META-ORGANVM:63%, ORGAN-I:53%, ORGAN-II:48%, ORGAN-III:55% +5 more
+Last pulse: 2026-06-06T01:01:02 | Δ24h: n/a | Δ7d: n/a
+
 
 ## Dialect Identity (Trivium)
 
@@ -189,6 +102,7 @@ Strongest translations: I (formal), II (structural), VII (structural)
 
 Scan: `organvm trivium scan III <OTHER>` | Matrix: `organvm trivium matrix` | Synthesize: `organvm trivium synthesize`
 
+
 ## Logos Documentation Layer
 
 **Status:** MISSING | **Symmetry:** 0.0 (VACUUM)
@@ -196,18 +110,16 @@ Scan: `organvm trivium scan III <OTHER>` | Matrix: `organvm trivium matrix` | Sy
 Nature demands a documentation counterpart. This formation maintains its narrative record in `docs/logos/`.
 
 ### The Tetradic Counterpart
-
 - **[Telos (Idealized Form)](../docs/logos/telos.md)** — The dream and theoretical grounding.
 - **[Pragma (Concrete State)](../docs/logos/pragma.md)** — The honest account of what exists.
 - **[Praxis (Remediation Plan)](../docs/logos/praxis.md)** — The attack vectors for evolution.
 - **[Receptio (Reception)](../docs/logos/receptio.md)** — The account of the constructed polis.
 
 ### Alchemical I/O
-
 - **[Source & Transmutation](../docs/logos/alchemical-io.md)** — Narrative of inputs, process, and returns.
 
 - **[Public Essay](https://organvm-v-logos.github.io/public-process/)** — System-wide narrative entry.
 
-_Compliance: Formation is currently void._
+*Compliance: Formation is currently void.*
 
 <!-- ORGANVM:AUTO:END -->


### PR DESCRIPTION
Commits the `organvm refresh` regen output (ORGANVM:AUTO blocks in AGENTS/CLAUDE/GEMINI.md, synced 2026-06-06) that was sitting uncommitted in the main checkout — IRF-OPS-092(a) disposition: preserve, don't restore. Adds `.lh/` (VSCode Local History) to .gitignore.

No hand-written content touched; diff is auto-generated fences only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)