### PR TITLE
fix(db): record every applied migration

### DIFF
--- a/scripts/db-test.ts
+++ b/scripts/db-test.ts
@@ -7,6 +7,7 @@
  */
 
 import { config } from 'dotenv'
+import { fileURLToPath } from 'url'
 import { testConnection, query, closePool } from '../apps/web/src/lib/db'
 
 // Load environment variables
@@ -88,7 +89,9 @@ async function main() {
 }
 
 // Run if executed directly
-if (require.main === module) {
+const invokedDirectly = process.argv[1] === fileURLToPath(import.meta.url)
+
+if (invokedDirectly) {
   main()
 }
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -46,6 +46,17 @@ async function getAppliedMigrations(): Promise<Set<string>> {
   }
 }
 
+async function recordMigration(migration: Migration): Promise<void> {
+  await pool.query(
+    `
+      INSERT INTO schema_migrations (version, name)
+      VALUES ($1, $2)
+      ON CONFLICT (version) DO NOTHING
+    `,
+    [migration.version, migration.name]
+  )
+}
+
 function getPendingMigrations(migrationsDir: string, appliedVersions: Set<string>): Migration[] {
   const files = readdirSync(migrationsDir)
     .filter((f) => f.endsWith('.sql') && !f.includes('_down.sql'))
@@ -84,6 +95,7 @@ async function runMigration(migration: Migration): Promise<void> {
   try {
     // Run the migration SQL
     await pool.query(sql)
+    await recordMigration(migration)
     console.log(`✓ Migration ${migration.version} completed successfully`)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary
- record every successfully executed migration in schema_migrations, not just migration 001
- replace the CommonJS require.main guard in scripts/db-test.ts with an ESM-safe import.meta.url guard
- repair path found during post-merge finish-line verification: a rerun after fresh migration no longer tries to reapply 002-022

## Verification
- npx eslint scripts/migrate.ts scripts/db-test.ts
- npx tsc -p tsconfig.json --noEmit
- npm run build
- DB_NAME=ucc_mca_migration_verify DOTENV_CONFIG_PATH=/Users/4jp/Code/organvm/public-record-data-scrapper/.env.local npx tsx -r dotenv/config scripts/migrate.ts
- DB_NAME=ucc_mca_migration_verify DOTENV_CONFIG_PATH=/Users/4jp/Code/organvm/public-record-data-scrapper/.env.local npx tsx -r dotenv/config scripts/migrate.ts (second run: 22 applied, no pending)
- DOTENV_CONFIG_PATH=/Users/4jp/Code/organvm/public-record-data-scrapper/.env.local npx tsx -r dotenv/config scripts/migrate.ts
- DOTENV_CONFIG_PATH=/Users/4jp/Code/organvm/public-record-data-scrapper/.env.local npx tsx -r dotenv/config scripts/db-test.ts