### PR TITLE
[limen REV-scrapper-equipment-scoring] Add server/services/EquipmentLifecycleDetector

### DIFF
--- a/server/__tests__/services/EquipmentLifecycleDetector.test.ts
+++ b/server/__tests__/services/EquipmentLifecycleDetector.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  EquipmentLifecycleDetector,
+  EquipmentFilingInput
+} from '../../services/EquipmentLifecycleDetector'
+
+// Mock the database module (used only by detectForProspect)
+vi.mock('../../database/connection', () => ({
+  database: {
+    query: vi.fn()
+  }
+}))
+
+import { database } from '../../database/connection'
+
+const mockQuery = vi.mocked(database.query)
+
+// Fixed reference date so recency math is deterministic.
+const NOW = new Date('2026-06-01T00:00:00Z')
+const daysAgo = (n: number) =>
+  new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString()
+
+describe('EquipmentLifecycleDetector', () => {
+  let detector: EquipmentLifecycleDetector
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    detector = new EquipmentLifecycleDetector()
+  })
+
+  describe('detectEquipment', () => {
+    it('detects specific equipment collateral and its category', () => {
+      const result = detector.detectEquipment('One (1) 2024 CNC milling machine, serial #12345')
+      expect(result.isEquipment).toBe(true)
+      expect(result.categories).toContain('machinery')
+    })
+
+    it('detects vehicle equipment', () => {
+      const result = detector.detectEquipment('2023 Freightliner truck and trailer')
+      expect(result.isEquipment).toBe(true)
+      expect(result.categories).toContain('vehicle')
+    })
+
+    it('excludes blanket "all assets" liens even when equipment is listed', () => {
+      const result = detector.detectEquipment(
+        'All assets including equipment, inventory, and accounts receivable now owned or hereafter acquired'
+      )
+      expect(result.isEquipment).toBe(false)
+      expect(result.categories).toHaveLength(0)
+    })
+
+    it('returns false for empty / undefined descriptions', () => {
+      expect(detector.detectEquipment(undefined).isEquipment).toBe(false)
+      expect(detector.detectEquipment('').isEquipment).toBe(false)
+      expect(detector.detectEquipment('future receivables').isEquipment).toBe(false)
+    })
+  })
+
+  describe('classifySecuredPartyType', () => {
+    it('classifies a known equipment lender', () => {
+      expect(detector.classifySecuredPartyType('De Lage Landen Financial Services')).toBe('equipment')
+      expect(detector.classifySecuredPartyType('Balboa Capital Corporation')).toBe('equipment')
+    })
+
+    it('classifies a known MCA funder', () => {
+      expect(detector.classifySecuredPartyType('OnDeck Capital, Inc.')).toBe('mca')
+      expect(detector.classifySecuredPartyType('Forward Financing LLC')).toBe('mca')
+    })
+
+    it('classifies auto captive finance', () => {
+      expect(detector.classifySecuredPartyType('Ford Motor Credit Company')).toBe('auto')
+    })
+
+    it('falls back to bank via heuristic', () => {
+      expect(detector.classifySecuredPartyType('First National Bank')).toBe('bank')
+    })
+
+    it('does not false-match short tokens mid-word (cit vs capacity)', () => {
+      expect(detector.classifySecuredPartyType('Capacity Builders LLC')).not.toBe('equipment')
+      expect(detector.classifySecuredPartyType('CIT Group')).toBe('equipment')
+    })
+
+    it('returns unknown for empty or unrecognized names', () => {
+      expect(detector.classifySecuredPartyType(undefined)).toBe('unknown')
+      expect(detector.classifySecuredPartyType('Zephyr Holdings')).toBe('unknown')
+    })
+  })
+
+  describe('analyzeFilings', () => {
+    it('flags a recent equipment purchase from a non-MCA lender as MCA-adjacent (+10)', () => {
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(30),
+          collateralDescription: 'One 2024 CNC lathe machine',
+          securedParty: 'Balboa Capital',
+          status: 'active'
+        }
+      ]
+
+      const signal = detector.analyzeFilings(filings, NOW)
+
+      expect(signal.hasRecentEquipmentPurchase).toBe(true)
+      expect(signal.recentEquipmentFilingCount).toBe(1)
+      expect(signal.securedPartyType).toBe('equipment')
+      expect(signal.isMcaAdjacent).toBe(true)
+      expect(signal.scoreBoost).toBe(10)
+    })
+
+    it('does NOT boost when the equipment was financed by an MCA funder', () => {
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(30),
+          collateralDescription: 'Restaurant kitchen equipment and ovens',
+          securedParty: 'OnDeck Capital',
+          status: 'active'
+        }
+      ]
+
+      const signal = detector.analyzeFilings(filings, NOW)
+
+      expect(signal.hasRecentEquipmentPurchase).toBe(true)
+      expect(signal.securedPartyType).toBe('mca')
+      expect(signal.isMcaAdjacent).toBe(false)
+      expect(signal.scoreBoost).toBe(0)
+    })
+
+    it('does not treat old equipment filings as recent', () => {
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(400),
+          collateralDescription: 'Forklift and warehouse machinery',
+          securedParty: 'CIT Group',
+          status: 'active'
+        }
+      ]
+
+      const signal = detector.analyzeFilings(filings, NOW)
+
+      expect(signal.totalEquipmentFilingCount).toBe(1)
+      expect(signal.hasRecentEquipmentPurchase).toBe(false)
+      expect(signal.recentEquipmentFilingCount).toBe(0)
+      expect(signal.isMcaAdjacent).toBe(false)
+      expect(signal.scoreBoost).toBe(0)
+    })
+
+    it('ignores terminated/lapsed liens', () => {
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(20),
+          collateralDescription: '2024 excavator',
+          securedParty: 'Balboa Capital',
+          status: 'terminated'
+        }
+      ]
+
+      const signal = detector.analyzeFilings(filings, NOW)
+
+      expect(signal.totalEquipmentFilingCount).toBe(0)
+      expect(signal.scoreBoost).toBe(0)
+    })
+
+    it('ignores blanket liens entirely', () => {
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(10),
+          collateralDescription: 'All assets and future receivables',
+          securedParty: 'Pearl Capital',
+          status: 'active'
+        }
+      ]
+
+      const signal = detector.analyzeFilings(filings, NOW)
+
+      expect(signal.totalEquipmentFilingCount).toBe(0)
+      expect(signal.hasRecentEquipmentPurchase).toBe(false)
+    })
+
+    it('returns a neutral signal when there are no filings', () => {
+      const signal = detector.analyzeFilings([], NOW)
+      expect(signal.hasRecentEquipmentPurchase).toBe(false)
+      expect(signal.securedPartyType).toBe('unknown')
+      expect(signal.scoreBoost).toBe(0)
+    })
+
+    it('respects a custom recency window and boost via config', () => {
+      const custom = new EquipmentLifecycleDetector({ recentWindowDays: 30, mcaAdjacencyBoost: 5 })
+      const filings: EquipmentFilingInput[] = [
+        {
+          filingDate: daysAgo(45),
+          collateralDescription: '2024 delivery van',
+          securedParty: 'Wells Fargo Equipment Finance',
+          status: 'active'
+        }
+      ]
+
+      const signal = custom.analyzeFilings(filings, NOW)
+      // 45 days > 30-day window → not recent
+      expect(signal.hasRecentEquipmentPurchase).toBe(false)
+      expect(signal.scoreBoost).toBe(0)
+    })
+  })
+
+  describe('detectForProspect', () => {
+    it('fetches filings and produces a signal', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          status: 'active',
+          filing_date: daysAgo(15),
+          secured_party: 'De Lage Landen',
+          collateral_description: 'CNC machine and tooling'
+        }
+      ])
+
+      const signal = await detector.detectForProspect('prospect-1')
+
+      expect(mockQuery).toHaveBeenCalledTimes(1)
+      expect(signal.isMcaAdjacent).toBe(true)
+      expect(signal.scoreBoost).toBe(10)
+    })
+  })
+})

--- a/server/__tests__/services/ScoringService.test.ts
+++ b/server/__tests__/services/ScoringService.test.ts
@@ -342,6 +342,35 @@ describe('ScoringService', () => {
 
       expect(nyScore).toBeGreaterThan(baseScore)
     })
+
+    it('should add the MCA-adjacency boost additively', () => {
+      const baseInput = {
+        intentScore: 60,
+        healthScore: 60,
+        positionScore: 60
+      }
+
+      const boostedInput = {
+        ...baseInput,
+        mcaAdjacencyBoost: 10
+      }
+
+      const baseScore = service.calculateCompositeScore(baseInput)
+      const boostedScore = service.calculateCompositeScore(boostedInput)
+
+      expect(boostedScore).toBe(baseScore + 10)
+    })
+
+    it('should clamp the boost at 100', () => {
+      const score = service.calculateCompositeScore({
+        intentScore: 100,
+        healthScore: 100,
+        positionScore: 100,
+        mcaAdjacencyBoost: 10
+      })
+
+      expect(score).toBe(100)
+    })
   })
 
   describe('getGrade', () => {
@@ -460,6 +489,49 @@ describe('ScoringService', () => {
       mockQuery.mockResolvedValueOnce([])
 
       await expect(service.scoreProspect('non-existent')).rejects.toThrow()
+    })
+
+    it('should boost MCA-adjacent prospects with a recent equipment purchase', async () => {
+      const recentDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10)
+
+      const mockProspect = {
+        company_name: 'Growth Mfg Co',
+        industry: 'manufacturing',
+        state: 'CA',
+        default_date: null,
+        time_since_default: null
+      }
+
+      // Filing with equipment collateral financed by a non-MCA lender.
+      const equipmentFilings = [
+        {
+          status: 'active',
+          filing_date: recentDate,
+          secured_party: 'Balboa Capital',
+          collateral_description: 'One 2024 CNC milling machine'
+        }
+      ]
+      // Same filing but without the equipment signal (no secured party / desc).
+      const plainFilings = [{ status: 'active', filing_date: recentDate }]
+
+      // Score WITH the equipment signal.
+      mockQuery
+        .mockResolvedValueOnce([mockProspect])
+        .mockResolvedValueOnce(equipmentFilings)
+        .mockResolvedValueOnce([])
+      const boosted = await service.scoreProspect('prospect-eq')
+
+      // Score WITHOUT the equipment signal.
+      mockQuery
+        .mockResolvedValueOnce([mockProspect])
+        .mockResolvedValueOnce(plainFilings)
+        .mockResolvedValueOnce([])
+      const plain = await service.scoreProspect('prospect-eq')
+
+      expect(boosted.compositeScore).toBeGreaterThan(plain.compositeScore)
+      expect(boosted.factors.some((f) => f.name.includes('Equipment'))).toBe(true)
     })
 
     it('should handle prospect without health data', async () => {

--- a/server/services/EquipmentLifecycleDetector.ts
+++ b/server/services/EquipmentLifecycleDetector.ts
@@ -1,0 +1,445 @@
+/**
+ * Equipment Lifecycle Detector
+ *
+ * Parses UCC collateral descriptions and secured-party names to surface a
+ * commercially valuable signal: a business that has *recently financed
+ * equipment* is investing in growth and frequently needs working capital
+ * shortly after — making it a prime, MCA-adjacent lead.
+ *
+ * Two outputs justify the analysis:
+ *   1. `hasRecentEquipmentPurchase` — a specific (non-blanket) equipment lien
+ *      filed inside the recency window.
+ *   2. `securedPartyType` — classifies the lien holder (equipment lender vs.
+ *      MCA funder vs. bank vs. auto/SBA), so we can tell genuine equipment
+ *      acquisition apart from an MCA dressed up with an "all equipment" blanket.
+ *
+ * The detector is deliberately DB-agnostic at its core: `analyzeFilings` and
+ * the classifiers are pure functions and can be unit-tested in isolation
+ * (mirroring FilingVelocityService). `detectForProspect` adds an optional
+ * persistence-backed convenience layer.
+ */
+
+import { database } from '../database/connection'
+
+/** Classification of the lien holder behind an equipment filing. */
+export type SecuredPartyType =
+  | 'equipment' // Captive/independent equipment finance & leasing companies
+  | 'bank' // Depository banks / credit unions
+  | 'mca' // Merchant cash advance / alternative working-capital funders
+  | 'factor' // Receivables factoring companies
+  | 'sba' // SBA / SBA-guaranteed lenders
+  | 'auto' // Auto & truck captive finance (vehicle acquisition)
+  | 'unknown'
+
+/** Minimal UCC filing shape the detector needs. */
+export interface EquipmentFilingInput {
+  filingDate: string | Date
+  collateralDescription?: string | null
+  securedParty?: string | null
+  status?: string | null
+}
+
+/** Result of analyzing one prospect's filings for equipment lifecycle signals. */
+export interface EquipmentLifecycleSignal {
+  hasRecentEquipmentPurchase: boolean
+  recentEquipmentFilingCount: number
+  totalEquipmentFilingCount: number
+  mostRecentEquipmentDate: string | null
+  daysSinceMostRecentEquipment: number | null
+  equipmentCategories: string[]
+  /** Dominant secured-party type across the equipment filings. */
+  securedPartyType: SecuredPartyType
+  /**
+   * True when a recent equipment purchase was financed by a NON-MCA lender —
+   * the business is growing and likely has untapped working-capital capacity.
+   */
+  isMcaAdjacent: boolean
+  /** Points to add to a prospect's MCA score (+10 when MCA-adjacent, else 0). */
+  scoreBoost: number
+  rationale: string
+}
+
+export interface EquipmentDetectorConfig {
+  /** A filing is "recent" if filed within this many days. Default 180. */
+  recentWindowDays: number
+  /** Score points awarded to an MCA-adjacent prospect. Default 10. */
+  mcaAdjacencyBoost: number
+}
+
+const DEFAULT_CONFIG: EquipmentDetectorConfig = {
+  recentWindowDays: 180,
+  mcaAdjacencyBoost: 10
+}
+
+/**
+ * Collateral phrases that indicate a *blanket* lien rather than a specific
+ * equipment acquisition. A blanket lien may mention "equipment" while really
+ * encumbering all assets — that is an MCA/working-capital signature, not an
+ * equipment purchase, so we exclude it from equipment detection.
+ */
+const BLANKET_COLLATERAL_PATTERNS = [
+  'all assets',
+  'all business assets',
+  'all present and future',
+  'all personal property',
+  'accounts receivable',
+  'future receivables',
+  'credit card receivables',
+  'merchant accounts',
+  'all inventory and accounts'
+]
+
+/**
+ * Equipment categories keyed to detection keywords. Order matters only for the
+ * reported category list; a description can match several categories.
+ */
+const EQUIPMENT_CATEGORIES: { category: string; keywords: string[] }[] = [
+  { category: 'vehicle', keywords: ['vehicle', 'truck', 'trailer', 'tractor', 'van', 'fleet', 'automobile'] },
+  {
+    category: 'construction',
+    keywords: ['excavator', 'bulldozer', 'forklift', 'backhoe', 'loader', 'crane', 'skid steer', 'compactor']
+  },
+  { category: 'machinery', keywords: ['machinery', 'machine', 'cnc', 'lathe', 'press', 'mill'] },
+  {
+    category: 'restaurant',
+    keywords: ['oven', 'refrigerator', 'freezer', 'kitchen equipment', 'point of sale', 'pos system', 'fryer']
+  },
+  { category: 'medical', keywords: ['medical equipment', 'imaging', 'x-ray', 'xray', 'dental', 'ultrasound', 'mri'] },
+  { category: 'office', keywords: ['copier', 'printer', 'computer', 'server', 'workstation', 'phone system'] },
+  { category: 'general', keywords: ['equipment', 'machinery', 'tools', 'apparatus', 'furniture and fixtures'] }
+]
+
+/**
+ * Known lien holders → secured-party type. Matched on whole-word tokens (and
+ * multi-word phrases) so short tokens like "cit" don't false-match "capacity".
+ */
+const KNOWN_SECURED_PARTIES: { type: SecuredPartyType; patterns: string[] }[] = [
+  {
+    type: 'equipment',
+    patterns: [
+      'de lage landen',
+      'dll finance',
+      'cit',
+      'balboa capital',
+      'leaf commercial',
+      'leaf capital',
+      'wells fargo equipment',
+      'us bank equipment',
+      'pnc equipment',
+      'key equipment',
+      'equipment finance',
+      'equipment leasing',
+      'leasing'
+    ]
+  },
+  {
+    type: 'auto',
+    patterns: [
+      'ford motor credit',
+      'toyota financial',
+      'toyota motor credit',
+      'gm financial',
+      'ally financial',
+      'ally bank',
+      'paccar financial',
+      'daimler truck',
+      'navistar financial',
+      'ryder'
+    ]
+  },
+  {
+    type: 'mca',
+    patterns: [
+      'ondeck',
+      'kabbage',
+      'bluevine',
+      'credibly',
+      'fundbox',
+      'national funding',
+      'forward financing',
+      'rapid finance',
+      'greenbox',
+      'libertas',
+      'reliant funding',
+      'fora financial',
+      'pearl capital',
+      'merchant cash',
+      'strategic funding',
+      'cfg merchant',
+      'world business lenders',
+      'quickbridge'
+    ]
+  },
+  {
+    type: 'sba',
+    patterns: ['small business administration', 'sba', 'lendio']
+  }
+]
+
+/**
+ * Generic name-pattern fallbacks, evaluated in order when no known funder
+ * matches. Each entry: a secured-party type and the substrings/tokens that
+ * imply it. More specific types are listed first.
+ */
+const SECURED_PARTY_HEURISTICS: { type: SecuredPartyType; tokens: string[] }[] = [
+  { type: 'equipment', tokens: ['equipment finance', 'equipment leasing', 'leasing', 'credit corp'] },
+  { type: 'auto', tokens: ['motor credit', 'auto finance', 'truck financial'] },
+  { type: 'factor', tokens: ['factoring', 'factors', 'receivables funding'] },
+  { type: 'sba', tokens: ['sba'] },
+  { type: 'bank', tokens: ['bank', 'national association', 'n a', 'credit union', 'savings', 'trust company'] },
+  // MCA heuristics last: "capital"/"funding"/"advance" are noisy and also occur
+  // in equipment/bank names, so only fall back to MCA when nothing else fits.
+  { type: 'mca', tokens: ['merchant cash', 'cash advance', 'merchant funding', 'working capital'] }
+]
+
+export class EquipmentLifecycleDetector {
+  private config: EquipmentDetectorConfig
+
+  constructor(config: Partial<EquipmentDetectorConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  /**
+   * Detect whether a collateral description represents a *specific* equipment
+   * acquisition (excluding blanket liens that merely list "equipment").
+   */
+  detectEquipment(description?: string | null): { isEquipment: boolean; categories: string[] } {
+    if (!description) return { isEquipment: false, categories: [] }
+    const lower = description.toLowerCase()
+
+    // A blanket / all-assets lien is a working-capital signature, not an
+    // equipment purchase — even when it enumerates "equipment".
+    if (BLANKET_COLLATERAL_PATTERNS.some((p) => lower.includes(p))) {
+      return { isEquipment: false, categories: [] }
+    }
+
+    const categories = new Set<string>()
+    for (const { category, keywords } of EQUIPMENT_CATEGORIES) {
+      if (keywords.some((kw) => lower.includes(kw))) {
+        categories.add(category)
+      }
+    }
+
+    return { isEquipment: categories.size > 0, categories: Array.from(categories) }
+  }
+
+  /**
+   * Classify the lien holder type from the secured-party name.
+   */
+  classifySecuredPartyType(securedParty?: string | null): SecuredPartyType {
+    if (!securedParty) return 'unknown'
+    const normalized = this.normalize(securedParty)
+    const tokens = new Set(normalized.split(' ').filter(Boolean))
+
+    // 1. Known funders — most specific phrase wins (longest-first).
+    const knownMatches: { type: SecuredPartyType; pattern: string }[] = []
+    for (const { type, patterns } of KNOWN_SECURED_PARTIES) {
+      for (const pattern of patterns) {
+        if (this.matchesAsWords(pattern, normalized, tokens)) {
+          knownMatches.push({ type, pattern })
+        }
+      }
+    }
+    if (knownMatches.length > 0) {
+      knownMatches.sort((a, b) => b.pattern.length - a.pattern.length)
+      return knownMatches[0].type
+    }
+
+    // 2. Generic heuristics, in priority order.
+    for (const { type, tokens: heuristicTokens } of SECURED_PARTY_HEURISTICS) {
+      if (heuristicTokens.some((t) => this.matchesAsWords(t, normalized, tokens))) {
+        return type
+      }
+    }
+
+    return 'unknown'
+  }
+
+  /**
+   * Analyze a set of filings (pure — no I/O) and produce the lifecycle signal.
+   */
+  analyzeFilings(
+    filings: EquipmentFilingInput[],
+    now: Date = new Date()
+  ): EquipmentLifecycleSignal {
+    const equipmentFilings: {
+      date: Date
+      categories: string[]
+      securedPartyType: SecuredPartyType
+      isRecent: boolean
+    }[] = []
+
+    for (const filing of filings) {
+      // Terminated/lapsed liens reflect *past* equipment that may already be
+      // paid off; only standing (active or unspecified) liens signal a live
+      // acquisition. Treat missing status as active so the pure path stays usable.
+      const status = (filing.status ?? 'active').toLowerCase()
+      if (status === 'terminated' || status === 'lapsed') continue
+
+      const { isEquipment, categories } = this.detectEquipment(filing.collateralDescription)
+      if (!isEquipment) continue
+
+      const date = filing.filingDate instanceof Date ? filing.filingDate : new Date(filing.filingDate)
+      if (Number.isNaN(date.getTime())) continue
+
+      const ageDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24))
+      equipmentFilings.push({
+        date,
+        categories,
+        securedPartyType: this.classifySecuredPartyType(filing.securedParty),
+        isRecent: ageDays >= 0 && ageDays <= this.config.recentWindowDays
+      })
+    }
+
+    if (equipmentFilings.length === 0) {
+      return {
+        hasRecentEquipmentPurchase: false,
+        recentEquipmentFilingCount: 0,
+        totalEquipmentFilingCount: 0,
+        mostRecentEquipmentDate: null,
+        daysSinceMostRecentEquipment: null,
+        equipmentCategories: [],
+        securedPartyType: 'unknown',
+        isMcaAdjacent: false,
+        scoreBoost: 0,
+        rationale: 'No active equipment-specific UCC filings detected.'
+      }
+    }
+
+    const recent = equipmentFilings.filter((f) => f.isRecent)
+    const hasRecentEquipmentPurchase = recent.length > 0
+
+    // Most recent equipment filing overall (for reporting).
+    const mostRecent = equipmentFilings.reduce((a, b) => (b.date > a.date ? b : a))
+    const daysSinceMostRecentEquipment = Math.floor(
+      (now.getTime() - mostRecent.date.getTime()) / (1000 * 60 * 60 * 24)
+    )
+
+    // Dominant secured-party type across the *relevant* (recent if any, else
+    // all) equipment filings.
+    const relevant = hasRecentEquipmentPurchase ? recent : equipmentFilings
+    const securedPartyType = this.dominantType(relevant.map((f) => f.securedPartyType))
+
+    const categories = Array.from(new Set(relevant.flatMap((f) => f.categories)))
+
+    // MCA-adjacent: recently bought equipment, and NOT via an MCA funder. Such
+    // a business is expanding and typically has fresh working-capital appetite.
+    const isMcaAdjacent = hasRecentEquipmentPurchase && securedPartyType !== 'mca'
+    const scoreBoost = isMcaAdjacent ? this.config.mcaAdjacencyBoost : 0
+
+    return {
+      hasRecentEquipmentPurchase,
+      recentEquipmentFilingCount: recent.length,
+      totalEquipmentFilingCount: equipmentFilings.length,
+      mostRecentEquipmentDate: mostRecent.date.toISOString(),
+      daysSinceMostRecentEquipment,
+      equipmentCategories: categories,
+      securedPartyType,
+      isMcaAdjacent,
+      scoreBoost,
+      rationale: this.buildRationale(
+        hasRecentEquipmentPurchase,
+        recent.length,
+        securedPartyType,
+        categories,
+        isMcaAdjacent
+      )
+    }
+  }
+
+  /**
+   * Convenience: fetch a prospect's filings and analyze them.
+   */
+  async detectForProspect(prospectId: string): Promise<EquipmentLifecycleSignal> {
+    const rows = await database.query<{
+      status: string
+      filing_date: string
+      secured_party: string
+      collateral_description: string | null
+    }>(
+      `SELECT uf.status, uf.filing_date, uf.secured_party,
+              COALESCE(
+                uf.raw_data->>'collateral_description',
+                uf.raw_data->>'collateral',
+                uf.raw_data->>'description'
+              ) AS collateral_description
+       FROM ucc_filings uf
+       JOIN prospect_ucc_filings puf ON uf.id = puf.ucc_filing_id
+       WHERE puf.prospect_id = $1
+       ORDER BY uf.filing_date DESC`,
+      [prospectId]
+    )
+
+    return this.analyzeFilings(
+      rows.map((r) => ({
+        filingDate: r.filing_date,
+        collateralDescription: r.collateral_description,
+        securedParty: r.secured_party,
+        status: r.status
+      }))
+    )
+  }
+
+  /** Pick the most frequent secured-party type, preferring non-unknown. */
+  private dominantType(types: SecuredPartyType[]): SecuredPartyType {
+    const counts = new Map<SecuredPartyType, number>()
+    for (const t of types) counts.set(t, (counts.get(t) ?? 0) + 1)
+
+    let best: SecuredPartyType = 'unknown'
+    let bestCount = -1
+    for (const [type, count] of counts) {
+      // Prefer a known type over 'unknown' on ties so the signal stays useful.
+      if (count > bestCount || (count === bestCount && best === 'unknown' && type !== 'unknown')) {
+        best = type
+        bestCount = count
+      }
+    }
+    return best
+  }
+
+  private buildRationale(
+    hasRecent: boolean,
+    recentCount: number,
+    securedPartyType: SecuredPartyType,
+    categories: string[],
+    isMcaAdjacent: boolean
+  ): string {
+    if (!hasRecent) {
+      return 'Equipment financing on file but none within the recency window; no MCA-adjacency boost.'
+    }
+    const cats = categories.length > 0 ? categories.join(', ') : 'equipment'
+    const via = securedPartyType === 'unknown' ? 'an unidentified lender' : `a(n) ${securedPartyType} lender`
+    if (isMcaAdjacent) {
+      return `${recentCount} recent equipment purchase(s) (${cats}) financed via ${via} — business is expanding and likely has working-capital appetite. MCA-adjacent: +score boost.`
+    }
+    return `${recentCount} recent equipment filing(s) (${cats}) but financed by an MCA funder — already in-market, no adjacency boost.`
+  }
+
+  /**
+   * Whether a pattern matches a normalized name on word boundaries. Multi-word
+   * patterns must appear as a contiguous phrase; single-word patterns must be a
+   * whole token (so "cit" matches "cit group" but not "capacity").
+   */
+  private matchesAsWords(pattern: string, normalizedName: string, nameTokens: Set<string>): boolean {
+    if (!pattern) return false
+    if (pattern.includes(' ')) {
+      return new RegExp(`(^|\\s)${this.escapeRegExp(pattern)}(\\s|$)`).test(normalizedName)
+    }
+    return nameTokens.has(pattern)
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  private normalize(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+}
+
+// Export singleton instance
+export const equipmentLifecycleDetector = new EquipmentLifecycleDetector()

--- a/server/services/ScoringService.ts
+++ b/server/services/ScoringService.ts
@@ -11,6 +11,7 @@
  */
 
 import { database } from '../database/connection'
+import { EquipmentLifecycleDetector } from './EquipmentLifecycleDetector'
 
 export interface IntentScoreInput {
   daysSinceLastFiling: number
@@ -44,6 +45,12 @@ export interface CompositeScoreInput {
   positionScore: number
   industryRiskModifier?: number
   stateModifier?: number
+  /**
+   * Additive boost (points) for MCA-adjacent signals such as a recent
+   * equipment purchase financed outside the MCA channel. Applied after
+   * multiplicative modifiers and before the 0-100 clamp.
+   */
+  mcaAdjacencyBoost?: number
 }
 
 export interface ScoringResult {
@@ -128,9 +135,11 @@ const STATE_MODIFIERS: Record<string, number> = {
 
 export class ScoringService {
   private config: ScoringConfig
+  private equipmentDetector: EquipmentLifecycleDetector
 
   constructor(config: Partial<ScoringConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
+    this.equipmentDetector = new EquipmentLifecycleDetector()
   }
 
   /**
@@ -291,6 +300,13 @@ export class ScoringService {
       modified *= input.stateModifier
     }
 
+    // MCA-adjacency boost is additive (points), applied after the
+    // multiplicative modifiers so a fixed +10 stays a fixed +10 regardless of
+    // industry/state scaling.
+    if (input.mcaAdjacencyBoost) {
+      modified += input.mcaAdjacencyBoost
+    }
+
     return Math.min(100, Math.max(0, Math.round(modified)))
   }
 
@@ -405,12 +421,21 @@ export class ScoringService {
       throw new Error(`Prospect not found: ${prospectId}`)
     }
 
-    // Fetch UCC filings
+    // Fetch UCC filings. We also pull secured_party and the collateral
+    // description (stored in raw_data JSONB) so the equipment-lifecycle
+    // detector can run off this single query — no extra round-trip.
     const filings = await database.query<{
       status: string
       filing_date: string
+      secured_party?: string
+      collateral_description?: string | null
     }>(
-      `SELECT uf.status, uf.filing_date
+      `SELECT uf.status, uf.filing_date, uf.secured_party,
+              COALESCE(
+                uf.raw_data->>'collateral_description',
+                uf.raw_data->>'collateral',
+                uf.raw_data->>'description'
+              ) AS collateral_description
        FROM ucc_filings uf
        JOIN prospect_ucc_filings puf ON uf.id = puf.ucc_filing_id
        WHERE puf.prospect_id = $1
@@ -497,12 +522,25 @@ export class ScoringService {
     const industryModifier = INDUSTRY_RISK_MODIFIERS[industry] || 1
     const stateModifier = STATE_MODIFIERS[state] || 1
 
+    // Detect equipment-lifecycle signals from the filings already fetched.
+    // A recent equipment purchase financed outside the MCA channel marks an
+    // MCA-adjacent prospect that warrants a score boost.
+    const equipmentSignal = this.equipmentDetector.analyzeFilings(
+      filings.map((f) => ({
+        filingDate: f.filing_date,
+        collateralDescription: f.collateral_description,
+        securedParty: f.secured_party,
+        status: f.status
+      }))
+    )
+
     const compositeScore = this.calculateCompositeScore({
       intentScore,
       healthScore,
       positionScore,
       industryRiskModifier: industryModifier,
-      stateModifier: stateModifier
+      stateModifier: stateModifier,
+      mcaAdjacencyBoost: equipmentSignal.scoreBoost
     })
 
     const grade = this.getGrade(compositeScore)
@@ -534,6 +572,15 @@ export class ScoringService {
         weight: this.config.compositePositionWeight
       }
     ]
+
+    if (equipmentSignal.isMcaAdjacent) {
+      factors.push({
+        name: 'Recent Equipment Purchase (MCA-adjacent)',
+        value: equipmentSignal.recentEquipmentFilingCount,
+        impact: 'positive',
+        weight: equipmentSignal.scoreBoost
+      })
+    }
 
     if (healthData) {
       factors.push({


### PR DESCRIPTION
Autonomous **limen** dispatch of task `REV-scrapper-equipment-scoring`.

Add server/services/EquipmentLifecycleDetector.ts that parses UCC descriptions to flag recent equipment purchases + a secured_party_type field; boost MCA-adjacent lead scores +10 in ScoringService. Justifies the price.

_Produced in an isolated worktree off origin — review before merge._