### PR TITLE
[limen REV-scrapper-tier-gate] Add server/middleware/tierGate

### DIFF
--- a/server/__tests__/helpers/testApp.ts
+++ b/server/__tests__/helpers/testApp.ts
@@ -45,12 +45,12 @@ export function createTestApp(): Express {
  * Generates a valid JWT token for testing.
  *
  * @param userId - The user ID to embed in the token
- * @param options - Optional email, role, and orgId
+ * @param options - Optional email, role, orgId, and tier
  * @returns A valid JWT token string
  */
 export function generateTestToken(
   userId: string = 'test-user-123',
-  options: { email?: string; role?: string; orgId?: string | null } = {}
+  options: { email?: string; role?: string; orgId?: string | null; tier?: string } = {}
 ): string {
   const payload: Record<string, unknown> = {
     sub: userId,
@@ -64,6 +64,10 @@ export function generateTestToken(
     payload.org_id = options.orgId || 'test-org'
   }
 
+  if (options.tier) {
+    payload.tier = options.tier
+  }
+
   return jwt.sign(payload, config.jwt.secret, {
     expiresIn: '1h'
   })
@@ -73,12 +77,12 @@ export function generateTestToken(
  * Creates an authorization header value for testing.
  *
  * @param userId - The user ID for the token
- * @param options - Optional email, role, and orgId
+ * @param options - Optional email, role, orgId, and tier
  * @returns Authorization header value (Bearer token)
  */
 export function createAuthHeader(
   userId: string = 'test-user-123',
-  options: { email?: string; role?: string; orgId?: string | null } = {}
+  options: { email?: string; role?: string; orgId?: string | null; tier?: string } = {}
 ): string {
   return `Bearer ${generateTestToken(userId, options)}`
 }

--- a/server/__tests__/middleware/tierGate.test.ts
+++ b/server/__tests__/middleware/tierGate.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { NextFunction, Request, Response } from 'express'
+import type { AuthenticatedRequest } from '../../middleware/authMiddleware'
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn()
+}))
+
+vi.mock('../../database/connection', () => ({
+  database: {
+    query: mockQuery
+  }
+}))
+
+import {
+  FREE_TIER_PROSPECT_LIMIT,
+  requestsFullEnrichedProspect,
+  tierGate
+} from '../../middleware/tierGate'
+
+function makeReq(overrides: Partial<AuthenticatedRequest> = {}): Request {
+  return {
+    headers: {},
+    body: {},
+    ...overrides
+  } as Request
+}
+
+type MockResponse = Partial<Response> & {
+  status: ReturnType<typeof vi.fn>
+  json: ReturnType<typeof vi.fn>
+}
+
+function makeRes(): MockResponse {
+  const res = {} as MockResponse
+  res.status = vi.fn(() => res)
+  res.json = vi.fn(() => res)
+  return res
+}
+
+describe('tierGate middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('requestsFullEnrichedProspect', () => {
+    it('allows minimal and OSS-only create payloads', () => {
+      expect(
+        requestsFullEnrichedProspect({
+          company_name: 'Acme LLC',
+          state: 'CA',
+          industry: 'technology'
+        })
+      ).toBe(false)
+
+      expect(
+        requestsFullEnrichedProspect({
+          company_name: 'Acme LLC',
+          state: 'CA',
+          industry: 'technology',
+          dataTier: 'oss',
+          sources: ['sec-edgar', 'state-ucc']
+        })
+      ).toBe(false)
+    })
+
+    it('detects paid/full enrichment intent', () => {
+      expect(
+        requestsFullEnrichedProspect({
+          company_name: 'Acme LLC',
+          state: 'CA',
+          industry: 'technology',
+          enrichment: { mode: 'full', sources: ['dnb'] }
+        })
+      ).toBe(true)
+
+      expect(
+        requestsFullEnrichedProspect({
+          company_name: 'Acme LLC',
+          state: 'CA',
+          industry: 'technology',
+          dataSources: ['clearbit']
+        })
+      ).toBe(true)
+    })
+  })
+
+  it('allows Starter/Pro users to create full enriched prospects', async () => {
+    const req = makeReq({
+      body: { enrichment: { mode: 'full', sources: ['dnb'] } },
+      user: { id: 'user-1', orgId: 'org-1', tier: 'professional' }
+    })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await tierGate(req, res as Response, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('allows free users below quota to create OSS-only prospects', async () => {
+    mockQuery.mockResolvedValueOnce([{ count: FREE_TIER_PROSPECT_LIMIT - 1 }])
+    const req = makeReq({
+      body: { dataTier: 'oss', sources: ['sec-edgar'] },
+      user: { id: 'user-1', orgId: 'org-1', tier: 'free' }
+    })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await tierGate(req, res as Response, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT COUNT(*)::int AS count FROM prospects WHERE org_id = $1',
+      ['org-1']
+    )
+  })
+
+  it('returns an upsell CTA when free users hit the prospect cap', async () => {
+    mockQuery.mockResolvedValueOnce([{ count: FREE_TIER_PROSPECT_LIMIT }])
+    const req = makeReq({
+      body: { dataTier: 'oss' },
+      user: { id: 'user-1', orgId: 'org-1', tier: 'free' }
+    })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await tierGate(req, res as Response, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(402)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'TIER_UPGRADE_REQUIRED',
+          details: expect.objectContaining({
+            reason: 'free_quota_exhausted',
+            freeTier: expect.objectContaining({
+              prospectLimit: FREE_TIER_PROSPECT_LIMIT,
+              currentProspects: FREE_TIER_PROSPECT_LIMIT
+            }),
+            cta: expect.objectContaining({
+              action: 'upgrade_plan',
+              href: '/pricing'
+            })
+          })
+        })
+      })
+    )
+  })
+
+  it('returns an upsell CTA when free users request full enrichment', async () => {
+    const req = makeReq({
+      body: { enrichmentMode: 'full' },
+      user: { id: 'user-1', orgId: 'org-1', tier: 'free' }
+    })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await tierGate(req, res as Response, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(mockQuery).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(402)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          details: expect.objectContaining({
+            reason: 'full_enrichment_requires_paid'
+          })
+        })
+      })
+    )
+  })
+
+  it('uses the org subscription when the JWT has no tier claim', async () => {
+    mockQuery.mockResolvedValueOnce([{ subscription_tier: 'starter' }])
+    const req = makeReq({
+      body: { enrichmentMode: 'full' },
+      user: { id: 'user-1', orgId: 'org-1' }
+    })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await tierGate(req, res as Response, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT subscription_tier FROM organizations WHERE id = $1',
+      ['org-1']
+    )
+  })
+})

--- a/server/__tests__/routes/prospects.test.ts
+++ b/server/__tests__/routes/prospects.test.ts
@@ -5,12 +5,21 @@ import type { Express } from 'express'
 import { NotFoundError } from '../../errors'
 
 // Use vi.hoisted to ensure mocks are available when vi.mock runs
-const { mockList, mockGetById, mockCreate, mockUpdate, mockDelete } = vi.hoisted(() => ({
-  mockList: vi.fn(),
-  mockGetById: vi.fn(),
-  mockCreate: vi.fn(),
-  mockUpdate: vi.fn(),
-  mockDelete: vi.fn()
+const { mockList, mockGetById, mockCreate, mockUpdate, mockDelete, mockQuery } = vi.hoisted(
+  () => ({
+    mockList: vi.fn(),
+    mockGetById: vi.fn(),
+    mockCreate: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockDelete: vi.fn(),
+    mockQuery: vi.fn()
+  })
+)
+
+vi.mock('../../database/connection', () => ({
+  database: {
+    query: mockQuery
+  }
 }))
 
 // Mock the ProspectsService
@@ -31,7 +40,7 @@ describe('Prospects API', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     app = createTestApp()
-    authHeader = createAuthHeader()
+    authHeader = createAuthHeader('test-user-123', { tier: 'professional' })
   })
 
   describe('GET /api/prospects', () => {
@@ -276,6 +285,33 @@ describe('Prospects API', () => {
         })
 
       expect(response.status).toBe(400)
+    })
+
+    it('should return an upsell CTA for free users at the prospect cap', async () => {
+      mockQuery.mockResolvedValueOnce([{ count: 10 }])
+      const freeAuthHeader = createAuthHeader('free-user', { orgId: 'free-org', tier: 'free' })
+
+      const response = await request(app)
+        .post('/api/prospects')
+        .set('Authorization', freeAuthHeader)
+        .send({
+          company_name: 'Test',
+          state: 'NY',
+          industry: 'technology'
+        })
+
+      expect(response.status).toBe(402)
+      expect(response.body.error.code).toBe('TIER_UPGRADE_REQUIRED')
+      expect(response.body.error.details).toEqual(
+        expect.objectContaining({
+          reason: 'free_quota_exhausted',
+          cta: expect.objectContaining({
+            action: 'upgrade_plan',
+            href: '/pricing'
+          })
+        })
+      )
+      expect(mockCreate).not.toHaveBeenCalled()
     })
   })
 

--- a/server/middleware/tierGate.ts
+++ b/server/middleware/tierGate.ts
@@ -1,0 +1,276 @@
+import type { NextFunction, Request, Response } from 'express'
+import { database } from '../database/connection'
+import type { AuthenticatedRequest } from './authMiddleware'
+import {
+  getResolvedDataTier,
+  mapSubscriptionTierToDataTier,
+  type ResolvedDataTier
+} from './dataTier'
+
+export const FREE_TIER_PROSPECT_LIMIT = 10
+
+type TierGateReason = 'free_quota_exhausted' | 'full_enrichment_requires_paid'
+
+interface TierGateContext {
+  reason: TierGateReason
+  currentProspects?: number
+}
+
+const FREE_TIER_ALIASES = new Set(['free', 'free-tier', 'oss', 'open', 'community', 'base'])
+
+const PAID_TIER_ALIASES = new Set([
+  'paid',
+  'starter',
+  'starter-tier',
+  'pro',
+  'professional',
+  'enterprise',
+  'premium'
+])
+
+const OSS_SOURCE_ALIASES = new Set([
+  'oss',
+  'open',
+  'free',
+  'public',
+  'public-records',
+  'state-ucc',
+  'ucc',
+  'sec-edgar',
+  'osha',
+  'uspto',
+  'census',
+  'sam-gov',
+  'sam.gov'
+])
+
+const FULL_ENRICHMENT_VALUES = new Set([
+  'full',
+  'full-enriched',
+  'full_enriched',
+  'enriched',
+  'paid',
+  'starter',
+  'starter-tier',
+  'pro',
+  'professional',
+  'enterprise',
+  'premium',
+  'commercial'
+])
+
+const ENRICHMENT_MODE_FIELDS = [
+  'dataTier',
+  'data_tier',
+  'tier',
+  'sourceTier',
+  'source_tier',
+  'enrichmentTier',
+  'enrichment_tier',
+  'enrichmentMode',
+  'enrichment_mode',
+  'mode',
+  'type',
+  'level',
+  'plan'
+] as const
+
+const BOOLEAN_FULL_ENRICHMENT_FIELDS = [
+  'enrich',
+  'enriched',
+  'fullEnrichment',
+  'full_enrichment',
+  'full',
+  'deepEnrichment',
+  'deep_enrichment',
+  'requireEnrichment',
+  'require_enrichment',
+  'requiresEnrichment',
+  'requires_enrichment'
+] as const
+
+const SOURCE_LIST_FIELDS = ['sources', 'dataSources', 'data_sources'] as const
+
+function normalizePlanValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function mapTierValue(value: unknown): ResolvedDataTier | undefined {
+  const normalized = normalizePlanValue(value)
+  if (!normalized) return undefined
+  if (FREE_TIER_ALIASES.has(normalized)) return 'free-tier'
+  if (PAID_TIER_ALIASES.has(normalized)) return 'starter-tier'
+  return mapSubscriptionTierToDataTier(normalized)
+}
+
+function getAuthenticatedUser(req: Request): AuthenticatedRequest['user'] {
+  return (req as AuthenticatedRequest).user
+}
+
+async function resolveTierForGate(req: Request): Promise<ResolvedDataTier> {
+  const user = getAuthenticatedUser(req)
+  const claimTier = mapTierValue(user?.tier)
+  if (claimTier) return claimTier
+
+  if (user?.orgId) {
+    const rows = await database.query<{ subscription_tier: string | null }>(
+      'SELECT subscription_tier FROM organizations WHERE id = $1',
+      [user.orgId]
+    )
+    return mapSubscriptionTierToDataTier(rows[0]?.subscription_tier)
+  }
+
+  return getResolvedDataTier(req)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requestsPaidSource(value: unknown): boolean {
+  if (typeof value === 'string') {
+    const normalized = normalizePlanValue(value)
+    if (!normalized) return false
+    return !OSS_SOURCE_ALIASES.has(normalized)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((source) => requestsPaidSource(source))
+  }
+
+  if (isPlainObject(value)) {
+    return ['name', 'source', 'id', 'slug'].some((field) => requestsPaidSource(value[field]))
+  }
+
+  return false
+}
+
+function requestsFullEnrichmentValue(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+
+  if (typeof value === 'string') {
+    const normalized = normalizePlanValue(value)
+    return normalized ? FULL_ENRICHMENT_VALUES.has(normalized) : false
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => requestsFullEnrichmentValue(item) || requestsPaidSource(item))
+  }
+
+  if (!isPlainObject(value)) return false
+
+  for (const field of ENRICHMENT_MODE_FIELDS) {
+    if (requestsFullEnrichmentValue(value[field])) return true
+  }
+
+  for (const field of BOOLEAN_FULL_ENRICHMENT_FIELDS) {
+    if (value[field] === true) return true
+  }
+
+  for (const field of SOURCE_LIST_FIELDS) {
+    if (requestsPaidSource(value[field])) return true
+  }
+
+  return false
+}
+
+export function requestsFullEnrichedProspect(body: unknown): boolean {
+  if (!isPlainObject(body)) return false
+
+  for (const field of ENRICHMENT_MODE_FIELDS) {
+    if (requestsFullEnrichmentValue(body[field])) return true
+  }
+
+  for (const field of BOOLEAN_FULL_ENRICHMENT_FIELDS) {
+    if (body[field] === true) return true
+  }
+
+  for (const field of SOURCE_LIST_FIELDS) {
+    if (requestsPaidSource(body[field])) return true
+  }
+
+  const enrichment = body.enrichment
+  if (requestsFullEnrichmentValue(enrichment)) return true
+
+  return false
+}
+
+async function countOrgProspects(orgId: string): Promise<number> {
+  const rows = await database.query<{ count: string | number }>(
+    'SELECT COUNT(*)::int AS count FROM prospects WHERE org_id = $1',
+    [orgId]
+  )
+  return Number(rows[0]?.count ?? 0)
+}
+
+function buildUpsellPayload(context: TierGateContext) {
+  return {
+    error: {
+      message:
+        'Free tier includes up to 10 OSS-only prospects. Upgrade to Starter or Pro for full enriched prospects.',
+      code: 'TIER_UPGRADE_REQUIRED',
+      statusCode: 402,
+      details: {
+        reason: context.reason,
+        currentTier: 'free',
+        requiredTier: 'starter',
+        upgradeTiers: ['starter', 'pro'],
+        freeTier: {
+          prospectLimit: FREE_TIER_PROSPECT_LIMIT,
+          dataAccess: 'oss-only',
+          ...(context.currentProspects !== undefined && {
+            currentProspects: context.currentProspects
+          })
+        },
+        cta: {
+          action: 'upgrade_plan',
+          label: 'Upgrade to Starter',
+          href: '/pricing',
+          headline: 'Unlock full enriched prospects',
+          description:
+            'Starter and Pro include full enriched prospect creation beyond the free 10-prospect OSS cap.'
+        }
+      }
+    }
+  }
+}
+
+function sendUpsell(res: Response, context: TierGateContext): Response {
+  return res.status(402).json(buildUpsellPayload(context))
+}
+
+export async function tierGate(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const resolvedTier = await resolveTierForGate(req)
+    if (resolvedTier !== 'free-tier') {
+      next()
+      return
+    }
+
+    if (requestsFullEnrichedProspect(req.body)) {
+      sendUpsell(res, { reason: 'full_enrichment_requires_paid' })
+      return
+    }
+
+    const orgId = getAuthenticatedUser(req)?.orgId
+    if (!orgId) {
+      sendUpsell(res, {
+        reason: 'free_quota_exhausted',
+        currentProspects: FREE_TIER_PROSPECT_LIMIT
+      })
+      return
+    }
+
+    const currentProspects = await countOrgProspects(orgId)
+    if (currentProspects >= FREE_TIER_PROSPECT_LIMIT) {
+      sendUpsell(res, { reason: 'free_quota_exhausted', currentProspects })
+      return
+    }
+
+    next()
+  } catch (error) {
+    next(error)
+  }
+}

--- a/server/routes/prospects.ts
+++ b/server/routes/prospects.ts
@@ -8,6 +8,7 @@ import { QualificationService } from '../services/QualificationService'
 import { UnderwritingService } from '../services/UnderwritingService'
 import type { UnderwritingFeatures } from '../services/UnderwritingService'
 import { getResolvedDataTier, type ResolvedDataTier } from '../middleware/dataTier'
+import { tierGate } from '../middleware/tierGate'
 
 const router = Router()
 
@@ -236,6 +237,7 @@ router.get(
 // POST /api/prospects - Create prospect
 router.post(
   '/',
+  tierGate,
   validateRequest({ body: createProspectSchema }),
   asyncHandler(async (req, res) => {
     const prospectsService = new ProspectsService()


### PR DESCRIPTION
Autonomous **limen** dispatch of task `REV-scrapper-tier-gate`.

Add server/middleware/tierGate.ts gating POST /api/prospects by tier (free=10 OSS-only prospects, Starter/Pro=full enriched), with an upsell CTA payload. New middleware + wire into the prospects route.

_Produced in an isolated worktree off origin — review before merge._