### PR TITLE
[limen BLD-public-record-data-scrapper-next-rev] public-record-data-scrapper: next-rev — Implement the next revenue increment per the product's path-

### DIFF
--- a/apps/web/src/features/pricing/PricingPage.tsx
+++ b/apps/web/src/features/pricing/PricingPage.tsx
@@ -70,10 +70,11 @@ export function PricingPage() {
       .catch(() => setStatus({ configured: false, provider: 'none' }))
   }, [])
 
-  async function handleCheckout() {
+  async function handleCheckout(tierName: string) {
     setLoading(true)
     try {
-      const res = await fetch('/api/billing/checkout', { method: 'POST' })
+      const tier = encodeURIComponent(tierName.toLowerCase())
+      const res = await fetch(`/api/billing/checkout?tier=${tier}`, { method: 'POST' })
       const data = await res.json()
       if (data.url) {
         window.location.href = data.url
@@ -121,7 +122,7 @@ export function PricingPage() {
               ))}
             </ul>
             <button
-              onClick={tier.name === 'Enterprise' ? undefined : handleCheckout}
+              onClick={tier.name === 'Enterprise' ? undefined : () => handleCheckout(tier.name)}
               disabled={loading || !status?.configured}
               style={{
                 width: '100%',

--- a/server/__tests__/integrations/stripe.tierMapping.test.ts
+++ b/server/__tests__/integrations/stripe.tierMapping.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  mapPriceToTier,
+  mapTierToPrice,
+  normalizeCheckoutTier
+} from '../../integrations/stripe'
+
+const PRICE_ENV = [
+  'STRIPE_PRICE_ID',
+  'STRIPE_PRICE_STARTER',
+  'STRIPE_PRICE_PROFESSIONAL',
+  'STRIPE_PRICE_ENTERPRISE'
+] as const
+
+describe('normalizeCheckoutTier', () => {
+  it('maps canonical tier names', () => {
+    expect(normalizeCheckoutTier('starter')).toBe('starter')
+    expect(normalizeCheckoutTier('professional')).toBe('professional')
+    expect(normalizeCheckoutTier('enterprise')).toBe('enterprise')
+  })
+
+  it('is case- and whitespace-insensitive and resolves common aliases', () => {
+    expect(normalizeCheckoutTier('  Pro ')).toBe('professional')
+    expect(normalizeCheckoutTier('GROWTH')).toBe('professional')
+    expect(normalizeCheckoutTier('Scale')).toBe('enterprise')
+    expect(normalizeCheckoutTier('Basic')).toBe('starter')
+  })
+
+  it('returns null for unknown or non-string values', () => {
+    expect(normalizeCheckoutTier('platinum')).toBeNull()
+    expect(normalizeCheckoutTier('')).toBeNull()
+    expect(normalizeCheckoutTier(undefined)).toBeNull()
+    expect(normalizeCheckoutTier(42)).toBeNull()
+    expect(normalizeCheckoutTier(['starter'])).toBeNull()
+  })
+})
+
+describe('mapTierToPrice', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of PRICE_ENV) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of PRICE_ENV) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  })
+
+  it('resolves each tier to its dedicated price env var', () => {
+    process.env.STRIPE_PRICE_STARTER = 'price_s'
+    process.env.STRIPE_PRICE_PROFESSIONAL = 'price_p'
+    process.env.STRIPE_PRICE_ENTERPRISE = 'price_e'
+
+    expect(mapTierToPrice('starter')).toBe('price_s')
+    expect(mapTierToPrice('professional')).toBe('price_p')
+    expect(mapTierToPrice('enterprise')).toBe('price_e')
+  })
+
+  it('falls back to STRIPE_PRICE_ID for starter when no starter price is set', () => {
+    process.env.STRIPE_PRICE_ID = 'price_legacy'
+    expect(mapTierToPrice('starter')).toBe('price_legacy')
+  })
+
+  it('returns null when a tier has no configured price', () => {
+    expect(mapTierToPrice('professional')).toBeNull()
+    expect(mapTierToPrice('enterprise')).toBeNull()
+    expect(mapTierToPrice('starter')).toBeNull()
+  })
+
+  it('round-trips with mapPriceToTier so buy and webhook sides agree', () => {
+    process.env.STRIPE_PRICE_STARTER = 'price_s'
+    process.env.STRIPE_PRICE_PROFESSIONAL = 'price_p'
+    process.env.STRIPE_PRICE_ENTERPRISE = 'price_e'
+
+    expect(mapPriceToTier(mapTierToPrice('starter'))).toBe('starter')
+    expect(mapPriceToTier(mapTierToPrice('professional'))).toBe('professional')
+    expect(mapPriceToTier(mapTierToPrice('enterprise'))).toBe('enterprise')
+  })
+})

--- a/server/__tests__/routes/billing.checkout.test.ts
+++ b/server/__tests__/routes/billing.checkout.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+
+// Mock the Stripe integration before importing the router. The tier→price
+// mapping is exercised through the real env-backed implementation in a separate
+// unit test; here we mock it so route behavior (status codes, session creation)
+// is tested in isolation.
+vi.mock('../../integrations/stripe', () => ({
+  createCheckoutSession: vi.fn(async () => ({ url: 'https://checkout.stripe.test/session' })),
+  constructWebhookEvent: vi.fn(),
+  isStripeConfigured: vi.fn(() => true),
+  mapPriceToTier: vi.fn(() => null),
+  mapTierToPrice: vi.fn((tier: string) => {
+    const prices: Record<string, string | null> = {
+      starter: 'price_starter',
+      professional: 'price_pro',
+      enterprise: null // recognized tier, deliberately not wired up
+    }
+    return prices[tier] ?? null
+  }),
+  normalizeCheckoutTier: vi.fn((value: unknown) => {
+    if (typeof value !== 'string') return null
+    const v = value.trim().toLowerCase()
+    const map: Record<string, string> = {
+      starter: 'starter',
+      pro: 'professional',
+      professional: 'professional',
+      enterprise: 'enterprise'
+    }
+    return map[v] ?? null
+  })
+}))
+
+vi.mock('../../config', async () => {
+  const actual = await vi.importActual<typeof import('../../config')>('../../config')
+  return {
+    ...actual,
+    config: {
+      ...actual.config,
+      stripe: { secretKey: 'sk_test', webhookSecret: 'whsec_test' },
+      cors: { origin: ['https://app.example.com'] }
+    }
+  }
+})
+
+import {
+  createCheckoutSession,
+  isStripeConfigured,
+  mapTierToPrice
+} from '../../integrations/stripe'
+import billingRouter from '../../routes/billing'
+
+function buildApp(): Express {
+  const app = express()
+  // Match production mounting: raw body for the Stripe webhook.
+  app.use('/api/billing', express.raw({ type: 'application/json', limit: '1mb' }))
+  app.use('/api/billing', billingRouter)
+  return app
+}
+
+const mockedCreate = vi.mocked(createCheckoutSession)
+const mockedConfigured = vi.mocked(isStripeConfigured)
+const mockedMapTier = vi.mocked(mapTierToPrice)
+
+describe('Billing checkout — tier selection', () => {
+  let app: Express
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedConfigured.mockReturnValue(true)
+    app = buildApp()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('defaults to the starter plan when no tier is given (backward compatible)', async () => {
+    const res = await request(app)
+      .post('/api/billing/checkout')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(200)
+    expect(res.body.url).toBe('https://checkout.stripe.test/session')
+    expect(mockedMapTier).toHaveBeenCalledWith('starter')
+    expect(mockedCreate).toHaveBeenCalledTimes(1)
+    const opts = mockedCreate.mock.calls[0][0]
+    expect(opts.priceId).toBe('price_starter')
+    expect(opts.metadata).toMatchObject({ tier: 'starter' })
+  })
+
+  it('resolves the requested tier to its configured price', async () => {
+    const res = await request(app)
+      .post('/api/billing/checkout?tier=professional')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(200)
+    expect(mockedMapTier).toHaveBeenCalledWith('professional')
+    expect(mockedCreate.mock.calls[0][0].priceId).toBe('price_pro')
+    expect(mockedCreate.mock.calls[0][0].metadata).toMatchObject({ tier: 'professional' })
+  })
+
+  it('accepts the `plan` alias as well as `tier`', async () => {
+    const res = await request(app)
+      .post('/api/billing/checkout?plan=pro')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(200)
+    expect(mockedMapTier).toHaveBeenCalledWith('professional')
+  })
+
+  it('rejects an unknown plan with 400 and never creates a session', async () => {
+    const res = await request(app)
+      .post('/api/billing/checkout?tier=platinum')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('Unknown plan')
+    expect(res.body.details.supportedTiers).toContain('professional')
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 503 when the tier is recognized but no price is configured', async () => {
+    const res = await request(app)
+      .post('/api/billing/checkout?tier=enterprise')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(503)
+    expect(res.body.error).toMatch(/enterprise/)
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 503 when Stripe is not configured', async () => {
+    mockedConfigured.mockReturnValue(false)
+
+    const res = await request(app)
+      .post('/api/billing/checkout?tier=starter')
+      .set('origin', 'https://app.example.com')
+
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('Billing not configured')
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+})

--- a/server/integrations/stripe/index.ts
+++ b/server/integrations/stripe/index.ts
@@ -58,6 +58,69 @@ export async function createCheckoutSession(
 export type SubscriptionTier = 'free' | 'starter' | 'professional' | 'enterprise'
 
 /**
+ * The paid tiers a customer can self-select at checkout. 'free' is excluded —
+ * it is the unentitled baseline, not something you purchase.
+ */
+export const CHECKOUT_TIERS = ['starter', 'professional', 'enterprise'] as const
+
+export type CheckoutTier = (typeof CHECKOUT_TIERS)[number]
+
+/**
+ * Aliases customers / the UI may send for each purchasable tier. Normalized to
+ * lower-case before lookup so casing and common synonyms resolve cleanly.
+ */
+const CHECKOUT_TIER_ALIASES: Record<string, CheckoutTier> = {
+  starter: 'starter',
+  start: 'starter',
+  basic: 'starter',
+  professional: 'professional',
+  pro: 'professional',
+  growth: 'professional',
+  enterprise: 'enterprise',
+  scale: 'enterprise',
+  business: 'enterprise'
+}
+
+/**
+ * Normalize an arbitrary requested-tier value (query param, body field) to a
+ * recognized purchasable tier, or `null` when it is missing/unrecognized.
+ */
+export function normalizeCheckoutTier(value: unknown): CheckoutTier | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+  return CHECKOUT_TIER_ALIASES[normalized] ?? null
+}
+
+/**
+ * Resolve a purchasable tier to its configured Stripe Price id. The reverse of
+ * {@link mapPriceToTier}, reading the same environment variables so the buy
+ * side and the webhook side stay in lock-step:
+ *   STRIPE_PRICE_STARTER (or STRIPE_PRICE_ID), STRIPE_PRICE_PROFESSIONAL,
+ *   STRIPE_PRICE_ENTERPRISE
+ *
+ * Returns `null` when no price is configured for the tier. Callers translate
+ * that into a 503 (tier offered but not wired up yet) so a missing env var
+ * never silently bills the wrong plan.
+ */
+export function mapTierToPrice(tier: CheckoutTier): string | null {
+  switch (tier) {
+    case 'starter':
+      return process.env.STRIPE_PRICE_STARTER || process.env.STRIPE_PRICE_ID || null
+    case 'professional':
+      return process.env.STRIPE_PRICE_PROFESSIONAL || null
+    case 'enterprise':
+      return process.env.STRIPE_PRICE_ENTERPRISE || null
+    default:
+      return null
+  }
+}
+
+/**
  * Map a Stripe Price id to an internal subscription tier.
  *
  * The mapping is configured via environment so that price ids (which differ per

--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -1,7 +1,7 @@
 /**
  * Billing routes — Stripe checkout and webhook handling.
  *
- * POST /api/billing/checkout — create a checkout session
+ * POST /api/billing/checkout — create a checkout session (optional ?tier=)
  * POST /api/billing/webhook  — handle Stripe webhook events
  * GET  /api/billing/status   — check if billing is configured
  *
@@ -18,7 +18,9 @@ import {
   createCheckoutSession,
   constructWebhookEvent,
   isStripeConfigured,
-  mapPriceToTier
+  mapPriceToTier,
+  mapTierToPrice,
+  normalizeCheckoutTier
 } from '../integrations/stripe'
 import { database } from '../database/connection'
 
@@ -283,9 +285,25 @@ router.post(
       return
     }
 
-    const priceId = process.env.STRIPE_PRICE_ID
+    // Which plan is the customer buying? Read from the query string (the router
+    // is mounted with express.raw for the webhook, so req.body is a Buffer here,
+    // not parsed JSON). Default to 'starter' to preserve the prior single-SKU
+    // behavior, which resolves to STRIPE_PRICE_STARTER || STRIPE_PRICE_ID.
+    const requestedTier = req.query.tier ?? req.query.plan
+    const tier = requestedTier === undefined ? 'starter' : normalizeCheckoutTier(requestedTier)
+    if (!tier) {
+      res.status(400).json({
+        error: 'Unknown plan',
+        details: { requestedTier, supportedTiers: ['starter', 'professional', 'enterprise'] }
+      })
+      return
+    }
+
+    const priceId = mapTierToPrice(tier)
     if (!priceId) {
-      res.status(503).json({ error: 'No price configured' })
+      // The tier is recognized but no Stripe price is wired up for it yet —
+      // surface a 503 rather than billing the wrong plan.
+      res.status(503).json({ error: `No price configured for the ${tier} plan` })
       return
     }
 
@@ -302,7 +320,8 @@ router.post(
       successUrl: `${baseUrl}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${baseUrl}/billing/cancel`,
       metadata: {
-        source: 'public-record-data-scrapper'
+        source: 'public-record-data-scrapper',
+        tier
       }
     })
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `BLD-public-record-data-scrapper-next-rev`.

Implement the next revenue increment per the product's path-to-revenue (payment/license gate, auth, or dashboard as applicable) — a bounded, mergeable first slice.

_Produced in an isolated worktree off origin — review before merge._