### PR TITLE
[limen CIFIX-a-organvm-public-record-data-scrapper] Fix pre-existing CI breakage (tsc/test-matrix errors) blocking all open PRs in a-organvm/public-record-data-scrapper

### DIFF
--- a/scripts/scrapers/ca-ucc-scraper-puppeteer.ts
+++ b/scripts/scrapers/ca-ucc-scraper-puppeteer.ts
@@ -13,9 +13,7 @@
 import type { Browser, Page } from 'puppeteer'
 import { BaseScraper, ScraperConfig, ScraperResult, UCCFiling } from './base-scraper'
 
-// @ts-expect-error - puppeteer-extra types are not included
 import puppeteerExtra from 'puppeteer-extra'
-// @ts-expect-error - puppeteer-extra-plugin-stealth types are not included
 import StealthPlugin from 'puppeteer-extra-plugin-stealth'
 
 // Enable stealth mode

--- a/scripts/scrapers/jsdom.d.ts
+++ b/scripts/scrapers/jsdom.d.ts
@@ -1,0 +1,9 @@
+declare module 'jsdom' {
+  export class JSDOM {
+    constructor(html?: string, options?: Record<string, unknown>)
+
+    window: Window & typeof globalThis
+
+    reconfigure(options: Record<string, unknown>): void
+  }
+}


### PR DESCRIPTION
Autonomous **limen** dispatch of task `CIFIX-a-organvm-public-record-data-scrapper`.

The test-matrix CI job fails with tsc/type errors on EVERY open PR (pre-existing on the default branch, not introduced by the PRs). Run the type-check/tests, fix the errors with minimal type-only changes so CI goes green; this unblocks the repo's open PR stack. Don't change runtime behavior.

_Produced in an isolated worktree off origin — review before merge._