### PR TITLE
[limen BLD-public-record-data-scrapper-harden] public-record-data-scrapper: harden — Harden the main entry points: input validation, error handli

### DIFF
--- a/scripts/cli-scraper.ts
+++ b/scripts/cli-scraper.ts
@@ -11,6 +11,8 @@ import chalk from 'chalk'
 import ora from 'ora'
 import * as fs from 'fs/promises'
 import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { z, ZodError } from 'zod'
 import { ScraperAgent } from '../apps/web/src/lib/agentic/agents/ScraperAgent'
 import { DataNormalizationAgent } from '../apps/web/src/lib/agentic/agents/DataNormalizationAgent'
 import { EnrichmentOrchestratorAgent } from '../apps/web/src/lib/agentic/agents/EnrichmentOrchestratorAgent'
@@ -18,8 +20,59 @@ import { UCCFiling } from './scrapers/base-scraper'
 import { database } from '../server/database/connection'
 import { LeadExportService, serializeLeadExportCsv } from '../server/services/LeadExportService'
 import type { LeadExportFormat } from '../server/services/LeadExportService'
+import { createServiceLogger } from '../server/utils/logger'
 
 const program = new Command()
+const cliLogger = createServiceLogger('CliScraper')
+const SUPPORTED_CLI_STATES = ['CA', 'TX', 'FL', 'NY'] as const
+const SUPPORTED_TIERS = ['free', 'starter', 'professional'] as const
+const MAX_BATCH_ROWS = 1000
+const MAX_BATCH_INPUT_BYTES = 5 * 1024 * 1024
+
+type SupportedCliState = (typeof SUPPORTED_CLI_STATES)[number]
+
+class CliValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly details?: string[]
+  ) {
+    super(message)
+    this.name = 'CliValidationError'
+  }
+}
+
+const companyNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'company name is required')
+  .max(160, 'company name must be 160 characters or less')
+  .refine((value) => !hasControlCharacters(value), {
+    message: 'company name cannot contain control characters'
+  })
+  .transform((value) => value.replace(/\s+/g, ' '))
+
+const stateCodeSchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toUpperCase())
+  .refine(
+    (value): value is SupportedCliState => {
+      return SUPPORTED_CLI_STATES.includes(value as SupportedCliState)
+    },
+    {
+      message: `state must be one of: ${SUPPORTED_CLI_STATES.join(', ')}`
+    }
+  )
+
+const pathSchema = z
+  .string()
+  .trim()
+  .min(1, 'path is required')
+  .max(4096, 'path is too long')
+  .refine((value) => !value.includes('\0'), { message: 'path cannot contain a NUL byte' })
+  .transform((value) => path.resolve(value))
+
+const tierSchema = z.enum(SUPPORTED_TIERS)
 
 // Configure CLI
 program
@@ -32,60 +85,85 @@ program
   .command('scrape-ucc')
   .description('Scrape UCC filings for a company in a specific state')
   .requiredOption('-c, --company <name>', 'Company name to search')
-  .requiredOption('-s, --state <code>', 'State code (CA, TX, FL)')
+  .requiredOption('-s, --state <code>', `State code (${SUPPORTED_CLI_STATES.join(', ')})`)
   .option('-o, --output <file>', 'Output file path (JSON)', './output.json')
   .option('--csv', 'Export as CSV instead of JSON')
   .action(async (options) => {
+    const parsed = parseCliOptions('scrape-ucc', () => parseScrapeOptions(options))
+    if (!parsed) return
+
     const spinner = ora('Initializing scraper...').start()
+    cliLogger.info('CLI command started', {
+      command: 'scrape-ucc',
+      company: parsed.company,
+      state: parsed.state,
+      outputPath: parsed.outputPath,
+      csv: parsed.csv
+    })
 
     try {
-      spinner.text = `Searching UCC filings for ${options.company} in ${options.state}...`
+      spinner.text = `Searching UCC filings for ${parsed.company} in ${parsed.state}...`
 
       const scraperAgent = new ScraperAgent()
       const result = await scraperAgent.executeTask({
         type: 'scrape-ucc',
         payload: {
-          companyName: options.company,
-          state: options.state.toUpperCase()
+          companyName: parsed.company,
+          state: parsed.state
         }
       })
 
       if (!result.success) {
         spinner.fail(chalk.red('Scraping failed'))
         console.error(chalk.red('Error:'), result.error)
+        cliLogger.warn('CLI command failed', {
+          command: 'scrape-ucc',
+          company: parsed.company,
+          state: parsed.state,
+          error: result.error
+        })
 
-        if (result.data?.searchUrl) {
-          console.log(chalk.yellow('\nManual search URL:'), result.data.searchUrl)
+        const searchUrl = getString(asRecord(result.data).searchUrl)
+        if (searchUrl) {
+          console.log(chalk.yellow('\nManual search URL:'), searchUrl)
         }
 
-        process.exit(1)
+        process.exitCode = 1
+        return
       }
 
+      const data = asScrapeData(result.data, parsed.company, parsed.state)
       spinner.succeed(chalk.green('Scraping completed'))
+      cliLogger.info('CLI command completed', {
+        command: 'scrape-ucc',
+        company: parsed.company,
+        state: parsed.state,
+        filingCount: data.filingCount
+      })
 
       // Display results
       console.log(chalk.cyan('\n=== Results ==='))
-      console.log(chalk.white(`Company: ${options.company}`))
-      console.log(chalk.white(`State: ${result.data.state}`))
-      console.log(chalk.white(`Filings found: ${result.data.filingCount}`))
+      console.log(chalk.white(`Company: ${parsed.company}`))
+      console.log(chalk.white(`State: ${data.state}`))
+      console.log(chalk.white(`Filings found: ${data.filingCount}`))
 
-      if (result.data?.retryCount && result.data.retryCount > 0) {
-        console.log(chalk.yellow(`Retries: ${result.data.retryCount}`))
+      if (data.retryCount && data.retryCount > 0) {
+        console.log(chalk.yellow(`Retries: ${data.retryCount}`))
       }
 
-      if (result.data?.parsingErrors && result.data.parsingErrors.length > 0) {
-        console.log(chalk.yellow(`\n⚠ Parsing warnings (${result.data.parsingErrors.length}):`))
-        result.data.parsingErrors.slice(0, 5).forEach((err: string) => {
+      if (data.parsingErrors && data.parsingErrors.length > 0) {
+        console.log(chalk.yellow(`\n⚠ Parsing warnings (${data.parsingErrors.length}):`))
+        data.parsingErrors.slice(0, 5).forEach((err: string) => {
           console.log(chalk.gray(`  • ${err}`))
         })
-        if (result.data.parsingErrors.length > 5) {
-          console.log(chalk.gray(`  ... and ${result.data.parsingErrors.length - 5} more`))
+        if (data.parsingErrors.length > 5) {
+          console.log(chalk.gray(`  ... and ${data.parsingErrors.length - 5} more`))
         }
       }
 
-      if (result.data?.filingCount > 0) {
+      if (data.filingCount > 0) {
         console.log(chalk.cyan('\n--- Filings ---'))
-        result.data.filings.forEach((filing: UCCFiling, idx: number) => {
+        data.filings.forEach((filing: UCCFiling, idx: number) => {
           console.log(chalk.white(`\n${idx + 1}. Filing #${filing.filingNumber}`))
           console.log(chalk.gray(`   Debtor: ${filing.debtorName}`))
           console.log(chalk.gray(`   Secured Party: ${filing.securedParty}`))
@@ -95,27 +173,29 @@ program
       }
 
       // Save to file
-      const outputPath = path.resolve(options.output)
+      const outputPath = parsed.outputPath
       let fileContent: string
 
-      if (options.csv) {
+      if (parsed.csv) {
         // Convert to CSV
-        fileContent = convertToCSV(result.data)
+        fileContent = convertToCSV(data)
       } else {
         // Save as JSON
-        fileContent = JSON.stringify(result.data, null, 2)
+        fileContent = JSON.stringify(data, null, 2)
       }
 
+      await ensureOutputFileTarget(outputPath)
       await fs.writeFile(outputPath, fileContent, 'utf-8')
       console.log(chalk.green(`\n✓ Results saved to: ${outputPath}`))
 
-      if (result.data.searchUrl) {
-        console.log(chalk.blue(`\nManual verification URL: ${result.data.searchUrl}`))
+      if (data.searchUrl) {
+        console.log(chalk.blue(`\nManual verification URL: ${data.searchUrl}`))
       }
     } catch (error) {
-      spinner.fail(chalk.red('Operation failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exit(1)
+      handleCliFailure('scrape-ucc', spinner, 'Operation failed', error, {
+        company: parsed.company,
+        state: parsed.state
+      })
     }
   })
 
@@ -129,10 +209,21 @@ program
   .option('--tier <level>', 'Subscription tier (free, starter, professional)', 'free')
   .option('--csv', 'Export as CSV instead of JSON')
   .action(async (options) => {
+    const parsed = parseCliOptions('enrich', () => parseEnrichOptions(options))
+    if (!parsed) return
+
     const spinner = ora('Initializing enrichment pipeline...').start()
+    cliLogger.info('CLI command started', {
+      command: 'enrich',
+      company: parsed.company,
+      state: parsed.state,
+      tier: parsed.tier,
+      outputPath: parsed.outputPath,
+      csv: parsed.csv
+    })
 
     try {
-      spinner.text = `Enriching data for ${options.company}...`
+      spinner.text = `Enriching data for ${parsed.company}...`
 
       const orchestrator = new EnrichmentOrchestratorAgent()
       const userId = `cli-user-${Date.now()}`
@@ -140,9 +231,9 @@ program
       const result = await orchestrator.executeTask({
         type: 'enrich-prospect',
         payload: {
-          companyName: options.company,
-          state: options.state.toUpperCase(),
-          tier: options.tier,
+          companyName: parsed.company,
+          state: parsed.state,
+          tier: parsed.tier,
           userId
         }
       })
@@ -150,62 +241,82 @@ program
       if (!result.success) {
         spinner.fail(chalk.red('Enrichment failed'))
         console.error(chalk.red('Error:'), result.error)
-        process.exit(1)
+        cliLogger.warn('CLI command failed', {
+          command: 'enrich',
+          company: parsed.company,
+          state: parsed.state,
+          error: result.error
+        })
+        process.exitCode = 1
+        return
       }
 
+      const data = asEnrichmentData(result.data)
       spinner.succeed(chalk.green('Enrichment completed'))
+      cliLogger.info('CLI command completed', {
+        command: 'enrich',
+        company: parsed.company,
+        state: parsed.state,
+        sourceCount: data.sources.length
+      })
 
       // Display results
       console.log(chalk.cyan('\n=== Enrichment Results ==='))
-      console.log(chalk.white(`Company: ${options.company}`))
-      console.log(chalk.white(`Sources used: ${result.data?.sources?.length || 0}`))
-      console.log(chalk.white(`Total cost: $${result.data?.cost || 0}`))
-      console.log(chalk.white(`Response time: ${result.data?.responseTime || 0}ms`))
+      console.log(chalk.white(`Company: ${parsed.company}`))
+      console.log(chalk.white(`Sources used: ${data.sources.length}`))
+      console.log(chalk.white(`Total cost: $${data.cost || 0}`))
+      console.log(chalk.white(`Response time: ${data.responseTime || 0}ms`))
 
-      if (result.data?.enrichedData) {
+      if (data.enrichedData) {
         console.log(chalk.cyan('\n--- Enriched Data Summary ---'))
-        const data = result.data.enrichedData
+        const enrichedData = data.enrichedData
 
-        if (data.sec) {
+        if (enrichedData.sec) {
+          const sec = enrichedData.sec
           console.log(chalk.white(`\nSEC EDGAR:`))
-          console.log(chalk.gray(`  CIK: ${data.sec.cik || 'N/A'}`))
-          console.log(chalk.gray(`  SIC: ${data.sec.sicCode || 'N/A'}`))
+          console.log(chalk.gray(`  CIK: ${sec.cik || 'N/A'}`))
+          console.log(chalk.gray(`  SIC: ${sec.sicCode || 'N/A'}`))
         }
 
-        if (data.osha) {
+        if (enrichedData.osha) {
+          const osha = enrichedData.osha
           console.log(chalk.white(`\nOSHA:`))
-          console.log(chalk.gray(`  Violations: ${data.osha.violations || 0}`))
-          console.log(chalk.gray(`  Penalties: $${data.osha.totalPenalties || 0}`))
+          console.log(chalk.gray(`  Violations: ${osha.violations || 0}`))
+          console.log(chalk.gray(`  Penalties: $${osha.totalPenalties || 0}`))
         }
 
-        if (data.uspto) {
+        if (enrichedData.uspto) {
+          const uspto = enrichedData.uspto
           console.log(chalk.white(`\nUSPTO:`))
-          console.log(chalk.gray(`  Trademarks: ${data.uspto.trademarkCount || 0}`))
+          console.log(chalk.gray(`  Trademarks: ${uspto.trademarkCount || 0}`))
         }
 
-        if (data.samGov) {
+        if (enrichedData.samGov) {
+          const samGov = enrichedData.samGov
           console.log(chalk.white(`\nSAM.gov:`))
-          console.log(chalk.gray(`  Registered: ${data.samGov.isRegistered ? 'Yes' : 'No'}`))
-          console.log(chalk.gray(`  Contracts: ${data.samGov.contractCount || 0}`))
+          console.log(chalk.gray(`  Registered: ${samGov.isRegistered ? 'Yes' : 'No'}`))
+          console.log(chalk.gray(`  Contracts: ${samGov.contractCount || 0}`))
         }
       }
 
       // Save to file
-      const outputPath = path.resolve(options.output)
+      const outputPath = parsed.outputPath
       let fileContent: string
 
-      if (options.csv) {
-        fileContent = convertEnrichmentToCSV(result.data)
+      if (parsed.csv) {
+        fileContent = convertEnrichmentToCSV(data)
       } else {
-        fileContent = JSON.stringify(result.data, null, 2)
+        fileContent = JSON.stringify(data, null, 2)
       }
 
+      await ensureOutputFileTarget(outputPath)
       await fs.writeFile(outputPath, fileContent, 'utf-8')
       console.log(chalk.green(`\n✓ Results saved to: ${outputPath}`))
     } catch (error) {
-      spinner.fail(chalk.red('Operation failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exit(1)
+      handleCliFailure('enrich', spinner, 'Operation failed', error, {
+        company: parsed.company,
+        state: parsed.state
+      })
     }
   })
 
@@ -215,28 +326,38 @@ program
   .description('Normalize and standardize company name')
   .requiredOption('-n, --name <name>', 'Company name to normalize')
   .action(async (options) => {
+    const name = parseCliOptions('normalize', () => parseCompanyName(options.name, 'name'))
+    if (!name) return
+
     const spinner = ora('Normalizing company name...').start()
+    cliLogger.info('CLI command started', { command: 'normalize', company: name })
 
     try {
       const normAgent = new DataNormalizationAgent()
       const result = await normAgent.executeTask({
         type: 'normalize-company-name',
-        payload: { name: options.name }
+        payload: { name }
       })
 
       if (result.success) {
+        const data = asRecord(result.data)
         spinner.succeed(chalk.green('Normalization completed'))
-        console.log(chalk.cyan('\nOriginal:'), chalk.white(result.data.original))
-        console.log(chalk.cyan('Normalized:'), chalk.white(result.data.normalized))
+        cliLogger.info('CLI command completed', { command: 'normalize', company: name })
+        console.log(chalk.cyan('\nOriginal:'), chalk.white(String(data.original || '')))
+        console.log(chalk.cyan('Normalized:'), chalk.white(String(data.normalized || '')))
       } else {
         spinner.fail(chalk.red('Normalization failed'))
         console.error(chalk.red('Error:'), result.error)
-        process.exit(1)
+        cliLogger.warn('CLI command failed', {
+          command: 'normalize',
+          company: name,
+          error: result.error
+        })
+        process.exitCode = 1
+        return
       }
     } catch (error) {
-      spinner.fail(chalk.red('Operation failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exit(1)
+      handleCliFailure('normalize', spinner, 'Operation failed', error, { company: name })
     }
   })
 
@@ -246,6 +367,7 @@ program
   .description('List all states with available UCC scrapers')
   .action(async () => {
     const spinner = ora('Checking available scrapers...').start()
+    cliLogger.info('CLI command started', { command: 'list-states' })
 
     try {
       const scraperAgent = new ScraperAgent()
@@ -254,17 +376,20 @@ program
         payload: {}
       })
 
+      const data = asListStatesData(result.data)
       spinner.succeed(chalk.green('Available scrapers'))
+      cliLogger.info('CLI command completed', {
+        command: 'list-states',
+        stateCount: data.count
+      })
 
       console.log(chalk.cyan('\n=== Supported States ==='))
-      result.data.states.forEach((state: string) => {
+      data.states.forEach((state: string) => {
         console.log(chalk.white(`  ✓ ${state}`))
       })
-      console.log(chalk.gray(`\nTotal: ${result.data.count} states\n`))
+      console.log(chalk.gray(`\nTotal: ${data.count} states\n`))
     } catch (error) {
-      spinner.fail(chalk.red('Operation failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exit(1)
+      handleCliFailure('list-states', spinner, 'Operation failed', error)
     }
   })
 
@@ -276,12 +401,21 @@ program
   .option('-o, --output <dir>', 'Output directory', './batch-results')
   .option('--enrich', 'Also enrich data for each company')
   .action(async (options) => {
+    const parsed = parseCliOptions('batch', () => parseBatchOptions(options))
+    if (!parsed) return
+
     const spinner = ora('Reading input file...').start()
+    cliLogger.info('CLI command started', {
+      command: 'batch',
+      inputPath: parsed.inputPath,
+      outputDir: parsed.outputDir,
+      enrich: parsed.enrich
+    })
 
     try {
       // Read input file
-      const inputPath = path.resolve(options.input)
-      const inputContent = await fs.readFile(inputPath, 'utf-8')
+      await assertInputFileSafe(parsed.inputPath)
+      const inputContent = await fs.readFile(parsed.inputPath, 'utf-8')
       const lines = inputContent
         .trim()
         .split('\n')
@@ -289,30 +423,55 @@ program
 
       if (lines.length < 2) {
         spinner.fail(chalk.red('Input file must contain header and at least one data row'))
-        process.exit(1)
+        cliLogger.warn('CLI command failed validation', {
+          command: 'batch',
+          reason: 'input_file_empty'
+        })
+        process.exitCode = 1
+        return
+      }
+
+      if (lines.length - 1 > MAX_BATCH_ROWS) {
+        throw new CliValidationError(
+          `Input file exceeds maximum batch size of ${MAX_BATCH_ROWS} rows`
+        )
       }
 
       const companies = lines
         .slice(1)
         .map((line, idx) => {
           // Simple CSV parsing - handles quoted fields
-          const fields = line.match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g) || []
+          const fields = parseCsvLine(line)
           const company = (fields[0] || '').replace(/^"|"$/g, '').trim()
           const state = (fields[1] || '').replace(/^"|"$/g, '').trim()
 
-          if (!company || !state) {
-            console.log(chalk.yellow(`⚠ Skipping invalid line ${idx + 2}: ${line}`))
+          try {
+            return {
+              company: parseCompanyName(company, `line ${idx + 2} company`),
+              state: parseStateCode(state, `line ${idx + 2} state`)
+            }
+          } catch (error) {
+            console.log(
+              chalk.yellow(`⚠ Skipping invalid line ${idx + 2}: ${formatCliError(error)}`)
+            )
+            cliLogger.warn('Skipping invalid batch row', {
+              command: 'batch',
+              lineNumber: idx + 2,
+              error: formatCliError(error)
+            })
             return null
           }
-
-          return { company, state }
         })
         .filter(Boolean) as { company: string; state: string }[]
+
+      if (companies.length === 0) {
+        throw new CliValidationError('Input file did not contain any valid company rows')
+      }
 
       spinner.succeed(chalk.green(`Found ${companies.length} companies to process`))
 
       // Create output directory
-      const outputDir = path.resolve(options.output)
+      const outputDir = parsed.outputDir
       await fs.mkdir(outputDir, { recursive: true })
 
       // Process each company
@@ -327,22 +486,19 @@ program
         const scraperAgent = new ScraperAgent()
         const result = await scraperAgent.executeTask({
           type: 'scrape-ucc',
-          payload: { companyName: company, state: state.toUpperCase() }
+          payload: { companyName: company, state }
         })
 
         if (result.success) {
-          console.log(chalk.green(`  ✓ Found ${result.data.filingCount} filings`))
-          results.push({ company, state, ...result.data })
+          const data = asScrapeData(result.data, company, state)
+          console.log(chalk.green(`  ✓ Found ${data.filingCount} filings`))
+          results.push({ ...data, company, state })
 
           // Save individual result with timestamp to avoid collisions
           const timestamp = Date.now()
           const sanitized = company.replace(/[^a-zA-Z0-9]/g, '-').substring(0, 50)
           const filename = `${sanitized}-${state}-${timestamp}.json`
-          await fs.writeFile(
-            path.join(outputDir, filename),
-            JSON.stringify(result.data, null, 2),
-            'utf-8'
-          )
+          await fs.writeFile(path.join(outputDir, filename), JSON.stringify(data, null, 2), 'utf-8')
         } else {
           console.log(chalk.yellow(`  ⚠ Failed: ${result.error}`))
           results.push({ company, state, error: result.error })
@@ -360,10 +516,17 @@ program
 
       console.log(chalk.green(`\n✓ Batch processing completed`))
       console.log(chalk.white(`Results saved to: ${outputDir}`))
+      cliLogger.info('CLI command completed', {
+        command: 'batch',
+        requestedRows: lines.length - 1,
+        processedRows: companies.length,
+        outputDir
+      })
     } catch (error) {
-      spinner.fail(chalk.red('Batch processing failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exit(1)
+      handleCliFailure('batch', spinner, 'Batch processing failed', error, {
+        inputPath: parsed.inputPath,
+        outputDir: parsed.outputDir
+      })
     }
   })
 
@@ -381,44 +544,57 @@ program
   .option('--limit <count>', 'Batch size', '100')
   .option('--offset <count>', 'Batch offset for pagination', '0')
   .action(async (options) => {
+    const parsed = parseCliOptions('lead-export', () => parseLeadExportOptions(options))
+    if (!parsed) return
+
     const spinner = ora('Connecting to database...').start()
     let connected = false
+    cliLogger.info('CLI command started', {
+      command: 'lead-export',
+      outputDir: parsed.outputDir,
+      format: parsed.format,
+      filters: parsed.filters
+    })
 
     try {
-      const format = parseLeadExportFormat(options.format)
-      const outputDir = path.resolve(options.outputDir)
-
       await database.connect()
       connected = true
 
       spinner.text = 'Building scored MCA lead export...'
       const exportService = new LeadExportService()
       const batch = await exportService.exportLeads({
-        state: options.state ? String(options.state).toUpperCase() : undefined,
-        industry: options.industry,
-        status: options.status,
-        minScore: parseCliInteger(options.minScore, 'min-score'),
-        maxScore: options.maxScore ? parseCliInteger(options.maxScore, 'max-score') : undefined,
-        limit: parseCliInteger(options.limit, 'limit'),
-        offset: parseCliInteger(options.offset, 'offset')
+        state: parsed.filters.state,
+        industry: parsed.filters.industry,
+        status: parsed.filters.status,
+        minScore: parsed.filters.minScore,
+        maxScore: parsed.filters.maxScore,
+        limit: parsed.filters.limit,
+        offset: parsed.filters.offset
       })
 
-      await fs.mkdir(outputDir, { recursive: true })
+      await fs.mkdir(parsed.outputDir, { recursive: true })
 
       const writtenFiles: string[] = []
-      if (format === 'json' || format === 'both') {
-        const jsonPath = path.join(outputDir, `${batch.batch.id}.json`)
+      if (parsed.format === 'json' || parsed.format === 'both') {
+        const jsonPath = path.join(parsed.outputDir, `${batch.batch.id}.json`)
         await fs.writeFile(jsonPath, JSON.stringify(batch, null, 2), 'utf-8')
         writtenFiles.push(jsonPath)
       }
 
-      if (format === 'csv' || format === 'both') {
-        const csvPath = path.join(outputDir, `${batch.batch.id}.csv`)
+      if (parsed.format === 'csv' || parsed.format === 'both') {
+        const csvPath = path.join(parsed.outputDir, `${batch.batch.id}.csv`)
         await fs.writeFile(csvPath, serializeLeadExportCsv(batch), 'utf-8')
         writtenFiles.push(csvPath)
       }
 
       spinner.succeed(chalk.green('Lead export completed'))
+      cliLogger.info('CLI command completed', {
+        command: 'lead-export',
+        batchId: batch.batch.id,
+        leadCount: batch.batch.count,
+        total: batch.batch.total,
+        writtenFiles
+      })
 
       console.log(chalk.cyan('\n=== Lead Export Batch ==='))
       console.log(chalk.white(`Batch: ${batch.batch.id}`))
@@ -431,15 +607,389 @@ program
         console.log(chalk.green(`✓ ${file}`))
       }
     } catch (error) {
-      spinner.fail(chalk.red('Lead export failed'))
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error)
-      process.exitCode = 1
+      handleCliFailure('lead-export', spinner, 'Lead export failed', error, {
+        outputDir: parsed.outputDir,
+        format: parsed.format
+      })
     } finally {
       if (connected) {
         await database.disconnect()
       }
     }
   })
+
+type ScrapeOptions = {
+  company: string
+  state: SupportedCliState
+  outputPath: string
+  csv: boolean
+}
+
+type EnrichOptions = ScrapeOptions & {
+  tier: (typeof SUPPORTED_TIERS)[number]
+}
+
+type BatchOptions = {
+  inputPath: string
+  outputDir: string
+  enrich: boolean
+}
+
+type LeadExportOptions = {
+  outputDir: string
+  format: LeadExportFormat
+  filters: {
+    minScore: number
+    maxScore?: number
+    state?: SupportedCliState
+    industry?: string
+    status?: string
+    limit: number
+    offset: number
+  }
+}
+
+type ScrapeCliData = {
+  state: string
+  companyName: string
+  filings: UCCFiling[]
+  filingCount: number
+  searchUrl?: string
+  retryCount?: number
+  parsingErrors?: string[]
+}
+
+type EnrichmentCliData = Record<string, unknown> & {
+  sources: string[]
+  cost?: number
+  responseTime?: number
+  enrichedData?: Record<string, Record<string, unknown>>
+}
+
+type ListStatesCliData = {
+  states: string[]
+  count: number
+}
+
+function parseCliOptions<T>(command: string, parser: () => T): T | undefined {
+  try {
+    return parser()
+  } catch (error) {
+    handleCliFailure(command, undefined, 'Invalid options', error)
+    return undefined
+  }
+}
+
+function parseScrapeOptions(options: Record<string, unknown>): ScrapeOptions {
+  return {
+    company: parseCompanyName(options.company, 'company'),
+    state: parseStateCode(options.state, 'state'),
+    outputPath: parsePathOption(options.output, 'output'),
+    csv: Boolean(options.csv)
+  }
+}
+
+function parseEnrichOptions(options: Record<string, unknown>): EnrichOptions {
+  return {
+    ...parseScrapeOptions(options),
+    tier: parseSchema(tierSchema, options.tier, 'tier')
+  }
+}
+
+function parseBatchOptions(options: Record<string, unknown>): BatchOptions {
+  return {
+    inputPath: parsePathOption(options.input, 'input'),
+    outputDir: parsePathOption(options.output, 'output'),
+    enrich: Boolean(options.enrich)
+  }
+}
+
+function parseLeadExportOptions(options: Record<string, unknown>): LeadExportOptions {
+  const minScore = parseCliInteger(options.minScore, 'min-score', { min: 0, max: 100 })
+  const maxScore =
+    options.maxScore === undefined || options.maxScore === ''
+      ? undefined
+      : parseCliInteger(options.maxScore, 'max-score', { min: 0, max: 100 })
+
+  if (maxScore !== undefined && maxScore < minScore) {
+    throw new CliValidationError('max-score must be greater than or equal to min-score')
+  }
+
+  return {
+    outputDir: parsePathOption(options.outputDir, 'output-dir'),
+    format: parseLeadExportFormat(options.format),
+    filters: {
+      minScore,
+      maxScore,
+      state:
+        options.state === undefined || options.state === ''
+          ? undefined
+          : parseStateCode(options.state, 'state'),
+      industry: parseOptionalText(options.industry, 'industry'),
+      status: parseOptionalText(options.status, 'status'),
+      limit: parseCliInteger(options.limit, 'limit', { min: 1, max: 1000 }),
+      offset: parseCliInteger(options.offset, 'offset', { min: 0 })
+    }
+  }
+}
+
+function parseCompanyName(value: unknown, label: string): string {
+  return parseSchema(companyNameSchema, value, label)
+}
+
+function parseStateCode(value: unknown, label: string): SupportedCliState {
+  return parseSchema(stateCodeSchema, value, label) as SupportedCliState
+}
+
+function parsePathOption(value: unknown, label: string): string {
+  return parseSchema(pathSchema, value, label)
+}
+
+function parseOptionalText(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined
+  }
+  const text = parseSchema(
+    z
+      .string()
+      .trim()
+      .min(1, `${label} cannot be empty`)
+      .max(120, `${label} must be 120 characters or less`)
+      .refine((current) => !hasControlCharacters(current), {
+        message: `${label} cannot contain control characters`
+      }),
+    value,
+    label
+  )
+  return text
+}
+
+function parseSchema<T>(schema: z.ZodType<T>, value: unknown, label: string): T {
+  const result = schema.safeParse(value)
+  if (result.success) {
+    return result.data
+  }
+
+  throw new CliValidationError(
+    `Invalid ${label}`,
+    result.error.issues.map((issue) => {
+      const field = issue.path.length > 0 ? `${label}.${issue.path.join('.')}` : label
+      return `${field}: ${issue.message}`
+    })
+  )
+}
+
+function hasControlCharacters(value: string): boolean {
+  return Array.from(value).some((char) => {
+    const code = char.charCodeAt(0)
+    return code <= 31 || code === 127
+  })
+}
+
+export function parseLeadExportFormat(value: unknown): LeadExportFormat {
+  if (typeof value !== 'string') {
+    throw new CliValidationError('format must be one of: json, csv, both')
+  }
+
+  const format = value.trim().toLowerCase()
+  if (format === 'json' || format === 'csv' || format === 'both') {
+    return format
+  }
+  throw new CliValidationError('format must be one of: json, csv, both')
+}
+
+export function parseCliInteger(
+  value: unknown,
+  label: string,
+  bounds: { min?: number; max?: number } = {}
+): number {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new CliValidationError(`${label} must be an integer`)
+  }
+
+  const text = String(value).trim()
+  if (!/^-?\d+$/.test(text)) {
+    throw new CliValidationError(`${label} must be an integer`)
+  }
+
+  const parsed = Number(text)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new CliValidationError(`${label} must be a safe integer`)
+  }
+  if (bounds.min !== undefined && parsed < bounds.min) {
+    throw new CliValidationError(`${label} must be at least ${bounds.min}`)
+  }
+  if (bounds.max !== undefined && parsed > bounds.max) {
+    throw new CliValidationError(`${label} must be at most ${bounds.max}`)
+  }
+
+  return parsed
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function asScrapeData(
+  value: unknown,
+  fallbackCompanyName: string,
+  fallbackState: string
+): ScrapeCliData {
+  const record = asRecord(value)
+  const filings = Array.isArray(record.filings) ? (record.filings as UCCFiling[]) : []
+  const parsingErrors = Array.isArray(record.parsingErrors)
+    ? record.parsingErrors.filter((item): item is string => typeof item === 'string')
+    : undefined
+
+  return {
+    state: getString(record.state) || fallbackState,
+    companyName: getString(record.companyName) || fallbackCompanyName,
+    filings,
+    filingCount: getNumber(record.filingCount) ?? filings.length,
+    searchUrl: getString(record.searchUrl),
+    retryCount: getNumber(record.retryCount),
+    parsingErrors
+  }
+}
+
+function asEnrichmentData(value: unknown): EnrichmentCliData {
+  const record = asRecord(value)
+  const enrichedData =
+    record.enrichedData && typeof record.enrichedData === 'object'
+      ? (record.enrichedData as Record<string, Record<string, unknown>>)
+      : undefined
+
+  return {
+    ...record,
+    sources: Array.isArray(record.sources)
+      ? record.sources.filter((item): item is string => typeof item === 'string')
+      : [],
+    cost: getNumber(record.cost),
+    responseTime: getNumber(record.responseTime),
+    enrichedData
+  }
+}
+
+function asListStatesData(value: unknown): ListStatesCliData {
+  const record = asRecord(value)
+  const states = Array.isArray(record.states)
+    ? record.states.filter((item): item is string => typeof item === 'string')
+    : []
+
+  return {
+    states,
+    count: getNumber(record.count) ?? states.length
+  }
+}
+
+async function assertInputFileSafe(inputPath: string): Promise<void> {
+  const stat = await fs.stat(inputPath)
+  if (!stat.isFile()) {
+    throw new CliValidationError('Input path must be a file')
+  }
+  if (stat.size > MAX_BATCH_INPUT_BYTES) {
+    throw new CliValidationError(`Input file must be ${MAX_BATCH_INPUT_BYTES} bytes or smaller`)
+  }
+}
+
+async function ensureOutputFileTarget(outputPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+
+  try {
+    const stat = await fs.stat(outputPath)
+    if (stat.isDirectory()) {
+      throw new CliValidationError('Output path must be a file, not a directory')
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return
+    }
+    throw error
+  }
+}
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+    const nextChar = line[i + 1]
+
+    if (char === '"' && inQuotes && nextChar === '"') {
+      current += '"'
+      i++
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = !inQuotes
+      continue
+    }
+
+    if (char === ',' && !inQuotes) {
+      fields.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  fields.push(current.trim())
+  return fields
+}
+
+function handleCliFailure(
+  command: string,
+  spinner: ReturnType<typeof ora> | undefined,
+  message: string,
+  error: unknown,
+  context: Record<string, unknown> = {}
+): void {
+  if (spinner) {
+    spinner.fail(chalk.red(message))
+  } else {
+    console.error(chalk.red(message))
+  }
+
+  const formatted = formatCliError(error)
+  console.error(chalk.red('Error:'), formatted)
+  cliLogger.error('CLI command failed', toError(error, formatted), {
+    command,
+    ...context
+  })
+  process.exitCode = 1
+}
+
+function formatCliError(error: unknown): string {
+  if (error instanceof CliValidationError) {
+    return error.details?.length ? `${error.message}: ${error.details.join('; ')}` : error.message
+  }
+  if (error instanceof ZodError) {
+    return error.issues.map((issue) => issue.message).join('; ')
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+function toError(error: unknown, fallbackMessage?: string): Error {
+  if (error instanceof Error) {
+    return error
+  }
+  return new Error(fallbackMessage || String(error))
+}
 
 // Helper function to convert data to CSV
 function convertToCSV(data: { filings?: UCCFiling[] }): string {
@@ -474,22 +1024,6 @@ function convertToCSV(data: { filings?: UCCFiling[] }): string {
   return csvContent
 }
 
-function parseLeadExportFormat(value: string): LeadExportFormat {
-  const format = value.toLowerCase()
-  if (format === 'json' || format === 'csv' || format === 'both') {
-    return format
-  }
-  throw new Error('format must be one of: json, csv, both')
-}
-
-function parseCliInteger(value: string, label: string): number {
-  const parsed = Number.parseInt(value, 10)
-  if (!Number.isFinite(parsed)) {
-    throw new Error(`${label} must be an integer`)
-  }
-  return parsed
-}
-
 function convertEnrichmentToCSV(data: Record<string, unknown>): string {
   const headers = ['Field', 'Value']
   const rows: string[][] = []
@@ -502,19 +1036,19 @@ function convertEnrichmentToCSV(data: Record<string, unknown>): string {
   if (data.enrichedData && typeof data.enrichedData === 'object') {
     const enriched = data.enrichedData as Record<string, Record<string, unknown>>
     if (enriched.sec) {
-      rows.push(['SEC CIK', enriched.sec.cik || ''])
-      rows.push(['SEC SIC Code', enriched.sec.sicCode || ''])
+      rows.push(['SEC CIK', String(enriched.sec.cik || '')])
+      rows.push(['SEC SIC Code', String(enriched.sec.sicCode || '')])
     }
     if (enriched.osha) {
-      rows.push(['OSHA Violations', enriched.osha.violations || '0'])
+      rows.push(['OSHA Violations', String(enriched.osha.violations || '0')])
       rows.push(['OSHA Penalties', `$${enriched.osha.totalPenalties || 0}`])
     }
     if (enriched.uspto) {
-      rows.push(['USPTO Trademarks', enriched.uspto.trademarkCount || '0'])
+      rows.push(['USPTO Trademarks', String(enriched.uspto.trademarkCount || '0')])
     }
     if (enriched.samGov) {
       rows.push(['SAM.gov Registered', enriched.samGov.isRegistered ? 'Yes' : 'No'])
-      rows.push(['SAM.gov Contracts', enriched.samGov.contractCount || '0'])
+      rows.push(['SAM.gov Contracts', String(enriched.samGov.contractCount || '0')])
     }
   }
 
@@ -529,5 +1063,14 @@ function escapeCSV(value: unknown): string {
   return str
 }
 
-// Parse and execute
-program.parse()
+export async function main(argv = process.argv): Promise<void> {
+  await program.parseAsync(argv)
+}
+
+const invokedDirectly = process.argv[1] === fileURLToPath(import.meta.url)
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    handleCliFailure('main', undefined, 'Fatal CLI error', error)
+  })
+}

--- a/server/__tests__/middleware/errorHandler.test.ts
+++ b/server/__tests__/middleware/errorHandler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Request, Response, NextFunction } from 'express'
 import {
   errorHandler,
@@ -21,6 +21,8 @@ describe('errorHandler middleware', () => {
   let mockReq: Partial<Request>
   let mockRes: Partial<Response>
   let mockNext: NextFunction
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     mockReq = {
@@ -33,7 +35,13 @@ describe('errorHandler middleware', () => {
       json: vi.fn().mockReturnThis()
     }
     mockNext = vi.fn()
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
   })
 
   it('handles generic errors with 500 status', () => {
@@ -141,15 +149,36 @@ describe('errorHandler middleware', () => {
 
     errorHandler(error, mockReq as Request, mockRes as Response, mockNext)
 
-    expect(console.error).toHaveBeenCalledWith(
-      '[ERROR]',
-      expect.objectContaining({
-        path: '/test',
-        method: 'GET',
-        message: 'Test error',
+    const serialized = String(consoleErrorSpy.mock.calls[0][0])
+    expect(serialized).toContain('Request failed with unexpected error')
+    expect(serialized).toContain('"path":"/test"')
+    expect(serialized).toContain('"method":"GET"')
+    expect(serialized).toContain('Test error')
+    expect(serialized).toContain('[test-correlation-id]')
+  })
+
+  it('handles malformed JSON body parser errors', () => {
+    const error = new SyntaxError('Unexpected token }') as SyntaxError & {
+      statusCode: number
+      type: string
+      body: string
+    }
+    error.statusCode = 400
+    error.type = 'entity.parse.failed'
+    error.body = '{"bad":}'
+
+    errorHandler(error, mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockRes.status).toHaveBeenCalledWith(400)
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Malformed JSON request body',
+        code: 'INVALID_JSON',
+        statusCode: 400,
         correlationId: 'test-correlation-id'
-      })
-    )
+      }
+    })
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('Invalid JSON request body')
   })
 })
 

--- a/server/__tests__/middleware/requestLogger.test.ts
+++ b/server/__tests__/middleware/requestLogger.test.ts
@@ -11,7 +11,7 @@ describe('requestLogger middleware', () => {
   let mockReq: Partial<Request>
   let mockRes: Partial<Response>
   let mockNext: NextFunction
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>
   let finishCallback: (() => void) | undefined
 
   beforeEach(() => {
@@ -27,6 +27,7 @@ describe('requestLogger middleware', () => {
     }
     mockRes = {
       statusCode: 200,
+      setHeader: vi.fn(),
       on: vi.fn((event: string, callback: () => void) => {
         if (event === 'finish') {
           finishCallback = callback
@@ -34,13 +35,23 @@ describe('requestLogger middleware', () => {
       })
     }
     mockNext = vi.fn()
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
   })
 
   afterEach(() => {
-    consoleSpy.mockRestore()
+    consoleInfoSpy.mockRestore()
     finishCallback = undefined
   })
+
+  function findLogContext(message: string): Record<string, unknown> {
+    const call = consoleInfoSpy.mock.calls.find((current) => String(current[0]).includes(message))
+    expect(call).toBeDefined()
+
+    const serialized = String(call![0])
+    const jsonStart = serialized.indexOf('{')
+    expect(jsonStart).toBeGreaterThanOrEqual(0)
+    return JSON.parse(serialized.slice(jsonStart))
+  }
 
   it('adds correlation ID to request', () => {
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
@@ -48,6 +59,38 @@ describe('requestLogger middleware', () => {
     expect((mockReq as Request & { correlationId: string }).correlationId).toBe(
       'mock-correlation-id'
     )
+    expect(mockRes.setHeader).toHaveBeenCalledWith('X-Correlation-ID', 'mock-correlation-id')
+  })
+
+  it('accepts valid caller-provided correlation ID', () => {
+    mockReq.headers = {
+      'x-correlation-id': 'external-request-123',
+      'user-agent': 'test-agent'
+    }
+
+    requestLogger(mockReq as Request, mockRes as Response, mockNext)
+
+    expect((mockReq as Request & { correlationId: string }).correlationId).toBe(
+      'external-request-123'
+    )
+    expect(mockRes.setHeader).toHaveBeenCalledWith('X-Correlation-ID', 'external-request-123')
+  })
+
+  it('rejects invalid caller-provided correlation ID', () => {
+    mockReq.headers = {
+      'x-correlation-id': 'bad id with spaces',
+      'user-agent': 'test-agent'
+    }
+
+    requestLogger(mockReq as Request, mockRes as Response, mockNext)
+
+    expect((mockReq as Request & { correlationId: string }).correlationId).toBe(
+      'mock-correlation-id'
+    )
+    expect(findLogContext('HTTP request received')).toMatchObject({
+      requestIdSource: 'generated',
+      rejectedRequestIdHeader: true
+    })
   })
 
   it('calls next', () => {
@@ -59,17 +102,13 @@ describe('requestLogger middleware', () => {
   it('logs incoming request with details', () => {
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    expect(consoleSpy).toHaveBeenCalledWith('[REQUEST]', expect.any(String))
-
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
-
-    expect(logData).toMatchObject({
-      correlationId: 'mock-correlation-id',
+    expect(findLogContext('HTTP request received')).toMatchObject({
+      event: 'http.request',
       method: 'GET',
       path: '/api/test',
       ip: '127.0.0.1',
-      userAgent: 'test-agent'
+      userAgent: 'test-agent',
+      requestIdSource: 'generated'
     })
   })
 
@@ -81,13 +120,9 @@ describe('requestLogger middleware', () => {
       finishCallback()
     }
 
-    // Find the RESPONSE log call
-    const responseCall = consoleSpy.mock.calls.find((call) => call[0] === '[RESPONSE]')
-    expect(responseCall).toBeDefined()
-
-    const logData = JSON.parse(responseCall![1] as string)
+    const logData = findLogContext('HTTP response completed')
     expect(logData).toMatchObject({
-      correlationId: 'mock-correlation-id',
+      event: 'http.response',
       method: 'GET',
       path: '/api/test',
       statusCode: 200
@@ -105,8 +140,7 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
+    const logData = findLogContext('HTTP request received')
 
     expect(logData.query).toEqual({
       page: '1',
@@ -129,8 +163,7 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
+    const logData = findLogContext('HTTP request received')
 
     expect(logData.query).toEqual({
       authorization: '[REDACTED]',
@@ -147,8 +180,7 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
+    const logData = findLogContext('HTTP request received')
 
     expect(logData.query).toEqual({})
   })
@@ -165,11 +197,8 @@ describe('requestLogger middleware', () => {
       finishCallback()
     }
 
-    const responseCall = consoleSpy.mock.calls.find((call) => call[0] === '[RESPONSE]')
-    expect(responseCall).toBeDefined()
-
-    const logData = JSON.parse(responseCall![1] as string)
-    expect(logData.duration).toMatch(/\d+ms/)
+    const logData = findLogContext('HTTP response completed')
+    expect(logData.durationMs).toBeGreaterThanOrEqual(0)
 
     vi.useRealTimers()
   })
@@ -184,9 +213,8 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
-    const body = JSON.parse(logData.body)
+    const logData = findLogContext('HTTP request received')
+    const body = JSON.parse(logData.body as string)
 
     expect(body).toEqual({
       username: 'testuser',
@@ -208,9 +236,8 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
-    const body = JSON.parse(logData.body)
+    const logData = findLogContext('HTTP request received')
+    const body = JSON.parse(logData.body as string)
 
     expect(body.user.credentials.password).toBe('[REDACTED]')
     expect(body.user.email).toBe('test@example.com')
@@ -221,10 +248,21 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
+    const logData = findLogContext('HTTP request received')
 
     expect(logData.body).toBeUndefined()
+  })
+
+  it('summarizes raw Buffer bodies without logging contents', () => {
+    mockReq.body = Buffer.from('{"secret":"payload"}')
+
+    requestLogger(mockReq as Request, mockRes as Response, mockNext)
+
+    const logData = findLogContext('HTTP request received')
+    expect(JSON.parse(logData.body as string)).toEqual({
+      type: 'Buffer',
+      length: 20
+    })
   })
 
   it('truncates large body payloads', () => {
@@ -234,9 +272,8 @@ describe('requestLogger middleware', () => {
 
     requestLogger(mockReq as Request, mockRes as Response, mockNext)
 
-    const logCall = consoleSpy.mock.calls[0]
-    const logData = JSON.parse(logCall[1] as string)
+    const logData = findLogContext('HTTP request received')
 
-    expect(logData.body.endsWith('...[TRUNCATED]')).toBe(true)
+    expect((logData.body as string).endsWith('...[TRUNCATED]')).toBe(true)
   })
 })

--- a/server/__tests__/middleware/validateRequest.test.ts
+++ b/server/__tests__/middleware/validateRequest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Request, Response, NextFunction } from 'express'
 import { z } from 'zod'
 import { validateRequest } from '../../middleware/validateRequest'
@@ -7,6 +7,7 @@ describe('validateRequest middleware', () => {
   let mockReq: Partial<Request>
   let mockRes: Partial<Response>
   let mockNext: NextFunction
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     mockReq = {
@@ -19,6 +20,11 @@ describe('validateRequest middleware', () => {
       json: vi.fn().mockReturnThis()
     }
     mockNext = vi.fn()
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
   })
 
   describe('body validation', () => {
@@ -94,6 +100,28 @@ describe('validateRequest middleware', () => {
 
       expect(details).toContainEqual(expect.objectContaining({ field: 'name' }))
       expect(details).toContainEqual(expect.objectContaining({ field: 'email' }))
+    })
+
+    it('includes correlation ID when validation fails with request context', () => {
+      mockReq = {
+        ...mockReq,
+        correlationId: 'correlation-1',
+        body: {
+          name: '',
+          email: 'invalid-email'
+        }
+      } as Partial<Request>
+
+      const middleware = validateRequest({ body: bodySchema })
+      middleware(mockReq as Request, mockRes as Response, mockNext)
+
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            correlationId: 'correlation-1'
+          })
+        })
+      )
     })
   })
 

--- a/server/__tests__/utils/logger.test.ts
+++ b/server/__tests__/utils/logger.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createServiceLogger } from '../../utils/logger'
+
+describe('logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('logs error details with sanitized context', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logger = createServiceLogger('LoggerTest')
+
+    logger.error('Operation failed', new Error('boom'), {
+      correlationId: 'correlation-1',
+      apiKey: 'secret-key',
+      nested: {
+        token: 'secret-token',
+        safe: 'value'
+      }
+    })
+
+    const serialized = String(consoleErrorSpy.mock.calls[0][0])
+    expect(serialized).toContain('[ERROR]')
+    expect(serialized).toContain('[correlation-1]')
+    expect(serialized).toContain('Operation failed')
+    expect(serialized).toContain('Error: boom')
+    expect(serialized).toContain('"apiKey":"[REDACTED]"')
+    expect(serialized).toContain('"token":"[REDACTED]"')
+    expect(serialized).toContain('"safe":"value"')
+  })
+})

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import { orgContextMiddleware } from './middleware/orgContext'
 import { httpsRedirect } from './middleware/httpsRedirect'
 import { dataTierRouter } from './middleware/dataTier'
 import { auditMiddleware } from './middleware/auditMiddleware'
+import { createServiceLogger } from './utils/logger'
 
 // Import routes
 import prospectsRouter from './routes/prospects'
@@ -48,6 +49,8 @@ import {
 } from './queue/queues'
 import { jobScheduler } from './queue/scheduler'
 import { redisConnection } from './queue/connection'
+
+const serverLogger = createServiceLogger('Server')
 
 export class Server {
   private app: Express
@@ -228,9 +231,9 @@ export class Server {
           res.type('text/yaml').sendFile(openApiPath)
         })
 
-        console.log('[Server] Swagger UI enabled at /api/docs')
+        serverLogger.info('Swagger UI enabled', { path: '/api/docs' })
       } else {
-        console.warn('[Server] OpenAPI spec not found at', openApiPath)
+        serverLogger.warn('OpenAPI spec not found', { openApiPath })
 
         // Serve placeholder when spec is missing
         this.app.get('/api/docs', (req, res) => {
@@ -241,7 +244,7 @@ export class Server {
         })
       }
     } catch (error) {
-      console.error('[Server] Failed to load OpenAPI spec:', error)
+      serverLogger.error('Failed to load OpenAPI spec', toError(error))
 
       // Serve error message when spec fails to load
       this.app.get('/api/docs', (req, res) => {
@@ -269,7 +272,7 @@ export class Server {
     try {
       validateConfig()
     } catch (error) {
-      console.error('Configuration error:', error instanceof Error ? error.message : error)
+      serverLogger.error('Configuration validation failed', toError(error))
       process.exit(1)
     }
 
@@ -277,26 +280,26 @@ export class Server {
     try {
       await database.connect()
     } catch (error) {
-      console.error('Failed to connect to database:', error)
+      serverLogger.error('Failed to connect to database', toError(error))
       process.exit(1)
     }
 
     // Initialize telemetry persistence and hydrate from database
     initTelemetryPersistence(database)
     if (config.telemetry.skipHydration) {
-      console.warn('[telemetry] Startup hydration skipped by config')
+      serverLogger.warn('Telemetry startup hydration skipped by config')
     } else {
       const hydratedCount = await hydrateTelemetryFromDatabase({
         historyLimitPerState: config.telemetry.hydrateHistoryLimit
       })
-      console.log(`[telemetry] Hydrated ${hydratedCount} states from database`)
+      serverLogger.info('Telemetry hydrated from database', { hydratedCount })
     }
 
     // Initialize job queues
     try {
       initializeQueues()
     } catch (error) {
-      console.error('Failed to initialize job queues:', error)
+      serverLogger.error('Failed to initialize job queues', toError(error))
       process.exit(1)
     }
 
@@ -304,41 +307,38 @@ export class Server {
     try {
       await jobScheduler.start()
     } catch (error) {
-      console.error('Failed to start job scheduler:', error)
+      serverLogger.error('Failed to start job scheduler', toError(error))
       process.exit(1)
     }
 
     // Start server (retain the HTTP server handle so we can drain it on shutdown)
     this.httpServer = this.app.listen(port, host, () => {
-      console.log('')
-      console.log('🚀 UCC-MCA Intelligence API Server')
-      console.log('─────────────────────────────────────')
-      console.log(`  Environment: ${config.server.env}`)
-      console.log(`  Server:      http://${host}:${port}`)
-      console.log(`  Health:      http://${host}:${port}/api/health`)
-      console.log(`  Jobs:        http://${host}:${port}/api/jobs`)
-      console.log(`  Database:    ${this.maskConnectionString(config.database.url)}`)
-      console.log(`  Redis:       ${config.redis.host}:${config.redis.port}`)
-      console.log(`  Docs:        http://${host}:${port}/api/docs`)
-      console.log('─────────────────────────────────────')
-      console.log('')
+      serverLogger.info('Server started', {
+        env: config.server.env,
+        host,
+        port,
+        healthUrl: `http://${host}:${port}/api/health`,
+        jobsUrl: `http://${host}:${port}/api/jobs`,
+        docsUrl: `http://${host}:${port}/api/docs`,
+        database: this.maskConnectionString(config.database.url),
+        redis: `${config.redis.host}:${config.redis.port}`
+      })
     })
   }
 
   async shutdown(signal?: string): Promise<void> {
     // Guard against repeated SIGTERM/SIGINT triggering concurrent shutdowns.
     if (this.shuttingDown) {
-      console.log('Shutdown already in progress, ignoring duplicate signal')
+      serverLogger.warn('Shutdown already in progress, ignoring duplicate signal', { signal })
       return
     }
     this.shuttingDown = true
 
-    console.log('')
-    console.log(`Shutting down server${signal ? ` (${signal})` : ''}...`)
+    serverLogger.info('Server shutdown started', { signal })
 
     // Force exit if graceful shutdown hangs (e.g. a connection won't drain).
     const forceExitTimer = setTimeout(() => {
-      console.error('✗ Graceful shutdown timed out after 30s — forcing exit')
+      serverLogger.error('Graceful shutdown timed out after 30s, forcing exit')
       process.exit(1)
     }, 30_000)
     forceExitTimer.unref()
@@ -366,11 +366,11 @@ export class Server {
       // Disconnect from database
       await database.disconnect()
 
-      console.log('✓ Server shutdown complete')
+      serverLogger.info('Server shutdown complete')
       clearTimeout(forceExitTimer)
       process.exit(0)
     } catch (error) {
-      console.error('✗ Error during shutdown:', error)
+      serverLogger.error('Error during shutdown', toError(error))
       clearTimeout(forceExitTimer)
       process.exit(1)
     }
@@ -401,7 +401,7 @@ const invokedDirectly = process.argv[1] === fileURLToPath(import.meta.url)
 if (invokedDirectly) {
   const server = new Server()
   server.start().catch((error) => {
-    console.error('Fatal error during server startup:', error)
+    serverLogger.error('Fatal error during server startup', toError(error))
     process.exit(1)
   })
 
@@ -417,13 +417,17 @@ if (invokedDirectly) {
   // Process-level safety nets: log loudly and shut down cleanly rather than
   // leaving the process in an undefined state.
   process.on('unhandledRejection', (reason) => {
-    console.error('[FATAL] Unhandled promise rejection:', reason)
+    serverLogger.error('Unhandled promise rejection', toError(reason))
     void server.shutdown('unhandledRejection')
   })
   process.on('uncaughtException', (error) => {
-    console.error('[FATAL] Uncaught exception:', error)
+    serverLogger.error('Uncaught exception', toError(error))
     void server.shutdown('uncaughtException')
   })
 }
 
 export default Server
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express'
 import { config } from '../config'
 import { ServiceError, isServiceError } from '../errors'
+import { createRequestLogger, logger } from '../utils/logger'
 
 // Extended request type with correlation ID
 interface RequestWithCorrelation extends Request {
@@ -9,8 +10,11 @@ interface RequestWithCorrelation extends Request {
 
 export interface AppError extends Error {
   statusCode?: number
+  status?: number
   code?: string
   details?: Record<string, unknown>
+  type?: string
+  body?: unknown
 }
 
 export class HttpError extends Error implements AppError {
@@ -33,19 +37,36 @@ export const errorHandler = (
   _next: NextFunction
 ) => {
   const correlationId = req.correlationId
+  const requestLogger = correlationId ? createRequestLogger(correlationId) : logger
+
+  if (isJsonParseError(err)) {
+    requestLogger.warn('Invalid JSON request body', {
+      event: 'http.validation_error',
+      path: req.path,
+      method: req.method,
+      statusCode: 400,
+      code: 'INVALID_JSON'
+    })
+
+    return res.status(400).json({
+      error: {
+        message: 'Malformed JSON request body',
+        code: 'INVALID_JSON',
+        statusCode: 400,
+        ...(correlationId && { correlationId })
+      }
+    })
+  }
 
   // Handle ServiceError instances with rich error info
   if (isServiceError(err)) {
-    console.error('[ERROR]', {
-      timestamp: new Date().toISOString(),
+    requestLogger.error('Request failed with service error', err, {
+      event: 'http.error',
       path: req.path,
       method: req.method,
       statusCode: err.statusCode,
       code: err.code,
-      message: err.message,
-      details: err.details,
-      stack: config.server.env === 'development' ? err.stack : undefined,
-      correlationId
+      details: err.details
     })
 
     return res.status(err.statusCode).json({
@@ -64,19 +85,17 @@ export const errorHandler = (
   // errors that may carry internal details in their message, so in production
   // we mask the message regardless of statusCode. Only ServiceError instances
   // (handled above) are considered "safe to surface" client errors.
-  const statusCode = err.statusCode || 500
+  const statusCode = err.statusCode || err.status || 500
   const rawMessage = err.message || 'Internal Server Error'
   const isProduction = config.server.env === 'production'
 
   // Log error - omit stack trace in production
-  console.error('[ERROR]', {
-    timestamp: new Date().toISOString(),
+  requestLogger.error('Request failed with unexpected error', err, {
+    event: 'http.error',
     path: req.path,
     method: req.method,
     statusCode,
-    message: rawMessage,
-    stack: config.server.env === 'development' ? err.stack : undefined,
-    correlationId
+    code: err.code || 'INTERNAL_ERROR'
   })
 
   // In production, never leak the raw message of an unknown error. For client
@@ -86,7 +105,9 @@ export const errorHandler = (
   let responseMessage: string
   if (isProduction) {
     responseMessage =
-      statusCode >= 400 && statusCode < 500 ? 'Request could not be processed' : 'Internal Server Error'
+      statusCode >= 400 && statusCode < 500
+        ? 'Request could not be processed'
+        : 'Internal Server Error'
   } else {
     responseMessage = rawMessage
   }
@@ -104,13 +125,28 @@ export const errorHandler = (
 }
 
 export const notFoundHandler = (req: Request, res: Response) => {
+  const correlationId = (req as RequestWithCorrelation).correlationId
+
   res.status(404).json({
     error: {
       message: `Route ${req.method} ${req.path} not found`,
       code: 'NOT_FOUND',
-      statusCode: 404
+      statusCode: 404,
+      ...(correlationId && { correlationId })
     }
   })
+}
+
+function isJsonParseError(err: AppError | ServiceError): boolean {
+  if (!(err instanceof SyntaxError)) {
+    return false
+  }
+
+  const candidate = err as AppError
+  return (
+    (candidate.statusCode === 400 || candidate.status === 400) &&
+    (candidate.type === 'entity.parse.failed' || 'body' in candidate)
+  )
 }
 
 // Async error wrapper

--- a/server/middleware/requestLogger.ts
+++ b/server/middleware/requestLogger.ts
@@ -1,5 +1,11 @@
 import { Request, Response, NextFunction } from 'express'
 import { v4 as uuidv4 } from 'uuid'
+import { createRequestLogger } from '../utils/logger'
+
+const CORRELATION_ID_HEADER = 'x-correlation-id'
+const REQUEST_ID_HEADER = 'x-request-id'
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/
+const MAX_LOGGED_BODY_LENGTH = 1000
 
 // Sensitive keys that should be redacted from logs (query params)
 const SENSITIVE_PARAM_KEYS = [
@@ -57,6 +63,34 @@ const SENSITIVE_BODY_KEYS = [
   'private_key'
 ]
 
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0]
+  }
+  return value
+}
+
+function resolveCorrelationId(req: Request): {
+  correlationId: string
+  source: 'header' | 'generated'
+  rejectedHeader: boolean
+} {
+  const headerValue =
+    getHeaderValue(req.headers[CORRELATION_ID_HEADER]) ??
+    getHeaderValue(req.headers[REQUEST_ID_HEADER])
+  const trimmed = headerValue?.trim()
+
+  if (trimmed && CORRELATION_ID_PATTERN.test(trimmed)) {
+    return { correlationId: trimmed, source: 'header', rejectedHeader: false }
+  }
+
+  return {
+    correlationId: uuidv4(),
+    source: 'generated',
+    rejectedHeader: Boolean(trimmed)
+  }
+}
+
 function redactSensitiveParams(query: Record<string, unknown>): Record<string, unknown> {
   const redacted: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(query)) {
@@ -67,13 +101,22 @@ function redactSensitiveParams(query: Record<string, unknown>): Record<string, u
   return redacted
 }
 
-function redactSensitiveBody(body: Record<string, unknown>, depth = 0): Record<string, unknown> {
+function redactSensitiveBody(body: unknown, depth = 0): unknown {
   // Prevent infinite recursion
   if (depth > 5) return { '[TRUNCATED]': 'Object too deep' }
+  if (Buffer.isBuffer(body)) {
+    return { type: 'Buffer', length: body.length }
+  }
+  if (Array.isArray(body)) {
+    return body.map((item) => redactSensitiveBody(item, depth + 1))
+  }
+  if (!body || typeof body !== 'object') {
+    return body
+  }
 
   const redacted: Record<string, unknown> = {}
 
-  for (const [key, value] of Object.entries(body)) {
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
     const keyLower = key.toLowerCase()
     const isSensitive = SENSITIVE_BODY_KEYS.some(
       (sensitive) =>
@@ -84,14 +127,10 @@ function redactSensitiveBody(body: Record<string, unknown>, depth = 0): Record<s
       redacted[key] = '[REDACTED]'
     } else if (value && typeof value === 'object' && !Array.isArray(value)) {
       // Recursively redact nested objects
-      redacted[key] = redactSensitiveBody(value as Record<string, unknown>, depth + 1)
+      redacted[key] = redactSensitiveBody(value, depth + 1)
     } else if (Array.isArray(value)) {
       // Redact arrays of objects
-      redacted[key] = value.map((item) =>
-        item && typeof item === 'object'
-          ? redactSensitiveBody(item as Record<string, unknown>, depth + 1)
-          : item
-      )
+      redacted[key] = value.map((item) => redactSensitiveBody(item, depth + 1))
     } else {
       redacted[key] = value
     }
@@ -100,7 +139,7 @@ function redactSensitiveBody(body: Record<string, unknown>, depth = 0): Record<s
   return redacted
 }
 
-function truncateBody(body: Record<string, unknown>, maxLength = 1000): string {
+function truncateBody(body: unknown, maxLength = MAX_LOGGED_BODY_LENGTH): string {
   const stringified = JSON.stringify(body)
   if (stringified.length > maxLength) {
     return stringified.slice(0, maxLength) + '...[TRUNCATED]'
@@ -109,48 +148,48 @@ function truncateBody(body: Record<string, unknown>, maxLength = 1000): string {
 }
 
 export const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
-  // Generate correlation ID
-  const correlationId = uuidv4()
+  const { correlationId, source, rejectedHeader } = resolveCorrelationId(req)
   ;(req as Request & { correlationId: string }).correlationId = correlationId
+  res.setHeader('X-Correlation-ID', correlationId)
+
+  const log = createRequestLogger(correlationId)
 
   const start = Date.now()
 
   // Prepare redacted body for logging
-  let redactedBody: Record<string, unknown> | undefined
-  if (req.body && typeof req.body === 'object' && Object.keys(req.body).length > 0) {
-    redactedBody = redactSensitiveBody(req.body as Record<string, unknown>)
+  let redactedBody: unknown
+  if (req.body !== undefined && req.body !== null) {
+    if (Buffer.isBuffer(req.body) || typeof req.body !== 'object') {
+      redactedBody = redactSensitiveBody(req.body)
+    } else if (Object.keys(req.body as Record<string, unknown>).length > 0) {
+      redactedBody = redactSensitiveBody(req.body)
+    }
   }
 
   // Log incoming request with sensitive data redacted
-  console.log(
-    '[REQUEST]',
-    JSON.stringify({
-      timestamp: new Date().toISOString(),
-      correlationId,
-      method: req.method,
-      path: req.path,
-      query: redactSensitiveParams(req.query as Record<string, unknown>),
-      body: redactedBody ? truncateBody(redactedBody) : undefined,
-      ip: req.ip,
-      userAgent: req.headers['user-agent']
-    })
-  )
+  log.info('HTTP request received', {
+    event: 'http.request',
+    method: req.method,
+    path: req.path,
+    query: redactSensitiveParams(req.query as Record<string, unknown>),
+    body: redactedBody ? truncateBody(redactedBody) : undefined,
+    ip: req.ip,
+    userAgent: req.headers['user-agent'],
+    requestIdSource: source,
+    rejectedRequestIdHeader: rejectedHeader
+  })
 
   // Log response
   res.on('finish', () => {
     const duration = Date.now() - start
 
-    console.log(
-      '[RESPONSE]',
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        correlationId,
-        method: req.method,
-        path: req.path,
-        statusCode: res.statusCode,
-        duration: `${duration}ms`
-      })
-    )
+    log.info('HTTP response completed', {
+      event: 'http.response',
+      method: req.method,
+      path: req.path,
+      statusCode: res.statusCode,
+      durationMs: duration
+    })
   })
 
   next()

--- a/server/middleware/validateRequest.ts
+++ b/server/middleware/validateRequest.ts
@@ -1,10 +1,15 @@
 import { Request, Response, NextFunction } from 'express'
 import { ZodSchema, ZodError, ZodIssue } from 'zod'
+import { createRequestLogger, logger } from '../utils/logger'
 
 interface ValidationSchemas {
   body?: ZodSchema
   query?: ZodSchema
   params?: ZodSchema
+}
+
+interface RequestWithCorrelation extends Request {
+  correlationId?: string
 }
 
 export const validateRequest = (schemas: ValidationSchemas) => {
@@ -32,6 +37,8 @@ export const validateRequest = (schemas: ValidationSchemas) => {
       next()
     } catch (error) {
       if (error instanceof ZodError) {
+        const correlationId = (req as RequestWithCorrelation).correlationId
+        const requestLogger = correlationId ? createRequestLogger(correlationId) : logger
         // Zod 4.x uses 'issues', Zod 3.x uses 'errors'
         const issues: ZodIssue[] = error.issues || []
         const errorMessages = issues.map((err) => ({
@@ -39,12 +46,22 @@ export const validateRequest = (schemas: ValidationSchemas) => {
           message: err.message
         }))
 
+        requestLogger.warn('Request validation failed', {
+          event: 'http.validation_error',
+          path: req.path,
+          method: req.method,
+          statusCode: 400,
+          code: 'VALIDATION_ERROR',
+          details: errorMessages
+        })
+
         return res.status(400).json({
           error: {
             message: 'Validation failed',
             code: 'VALIDATION_ERROR',
             statusCode: 400,
-            details: errorMessages
+            details: errorMessages,
+            ...(correlationId && { correlationId })
           }
         })
       }

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -26,6 +26,19 @@ interface LogEntry {
   correlationId?: string
 }
 
+// Sensitive keys are redacted from every structured log context. Keep this list
+// broad because log context can be built from request, CLI, and integration data.
+const SENSITIVE_KEYS = [
+  'password',
+  'token',
+  'secret',
+  'apiKey',
+  'api_key',
+  'authorization',
+  'creditCard',
+  'ssn'
+]
+
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   debug: 0,
   info: 1,
@@ -119,7 +132,7 @@ export interface Logger {
 function createLogger(defaultContext?: LogContext): Logger {
   const mergeContext = (context?: LogContext): LogContext | undefined => {
     if (!defaultContext && !context) return undefined
-    return { ...defaultContext, ...context }
+    return sanitizeContext({ ...defaultContext, ...context })
   }
 
   return {
@@ -143,7 +156,7 @@ function createLogger(defaultContext?: LogContext): Logger {
 
     error: (message: string, error?: Error, context?: LogContext) => {
       if (!shouldLog('error')) return
-      const entry = createLogEntry('error', message, error, mergeContext(context))
+      const entry = createLogEntry('error', message, mergeContext(context), error)
       console.error(formatLogEntry(entry))
     },
 
@@ -220,17 +233,6 @@ export async function withTiming<T>(
 /**
  * Sanitize sensitive data from log context
  */
-const SENSITIVE_KEYS = [
-  'password',
-  'token',
-  'secret',
-  'apiKey',
-  'api_key',
-  'authorization',
-  'creditCard',
-  'ssn'
-]
-
 export function sanitizeContext(context: LogContext): LogContext {
   const sanitized: LogContext = {}
 
@@ -244,6 +246,10 @@ export function sanitizeContext(context: LogContext): LogContext {
       sanitized[key] = '[REDACTED]'
     } else if (value && typeof value === 'object' && !Array.isArray(value)) {
       sanitized[key] = sanitizeContext(value as LogContext)
+    } else if (Array.isArray(value)) {
+      sanitized[key] = value.map((item) =>
+        item && typeof item === 'object' ? sanitizeContext(item as LogContext) : item
+      )
     } else {
       sanitized[key] = value
     }

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -10,23 +10,23 @@ import { createVelocityAnalysisWorker } from './queue/workers/velocityAnalysisWo
 import { createPortalProbeWorker } from './queue/workers/portalProbeWorker'
 import { redisConnection } from './queue/connection'
 import { config } from './config'
+import { createServiceLogger } from './utils/logger'
 
 type ClosableWorker = {
   close: () => Promise<unknown>
 }
+
+const workerLogger = createServiceLogger('WorkerProcess')
 
 class WorkerProcess {
   private workers: ClosableWorker[] = []
   private shuttingDown = false
 
   async start() {
-    console.log('')
-    console.log('🔧 Starting Worker Process')
-    console.log('─────────────────────────────────────')
-    console.log(`  Environment: ${config.server.env}`)
-    console.log(`  Redis:       ${config.redis.host}:${config.redis.port}`)
-    console.log('─────────────────────────────────────')
-    console.log('')
+    workerLogger.info('Worker process starting', {
+      env: config.server.env,
+      redis: `${config.redis.host}:${config.redis.port}`
+    })
 
     try {
       // Connect to database
@@ -38,7 +38,7 @@ class WorkerProcess {
       // Start workers — one consumer per queue the scheduler enqueues into.
       // Every worker registered here is also drained by the 30s graceful
       // shutdown handler below (via the shared this.workers list).
-      console.log('Starting workers...')
+      workerLogger.info('Starting queue workers')
       this.workers.push(createIngestionWorker())
       this.workers.push(createEnrichmentWorker())
       this.workers.push(createHealthWorker())
@@ -48,13 +48,9 @@ class WorkerProcess {
       this.workers.push(createVelocityAnalysisWorker())
       this.workers.push(createPortalProbeWorker())
 
-      console.log('')
-      console.log('✓ Worker process started successfully')
-      console.log('  Workers are now processing jobs from the queues')
-      console.log('  Press Ctrl+C to stop')
-      console.log('')
+      workerLogger.info('Worker process started successfully', { workerCount: this.workers.length })
     } catch (error) {
-      console.error('Failed to start worker process:', error)
+      workerLogger.error('Failed to start worker process', toError(error))
       process.exit(1)
     }
   }
@@ -62,24 +58,23 @@ class WorkerProcess {
   async shutdown(signal?: string) {
     // Guard against duplicate SIGTERM/SIGINT triggering concurrent shutdowns.
     if (this.shuttingDown) {
-      console.log('Shutdown already in progress, ignoring duplicate signal')
+      workerLogger.warn('Shutdown already in progress, ignoring duplicate signal', { signal })
       return
     }
     this.shuttingDown = true
 
-    console.log('')
-    console.log(`Shutting down worker process${signal ? ` (${signal})` : ''}...`)
+    workerLogger.info('Worker process shutdown started', { signal })
 
     // Force exit if graceful shutdown hangs (e.g. a job won't drain in time).
     const forceExitTimer = setTimeout(() => {
-      console.error('✗ Worker graceful shutdown timed out after 30s — forcing exit')
+      workerLogger.error('Worker graceful shutdown timed out after 30s, forcing exit')
       process.exit(1)
     }, 30_000)
     forceExitTimer.unref()
 
     try {
       // Close workers (drains in-flight jobs)
-      console.log('Closing workers...')
+      workerLogger.info('Closing workers', { workerCount: this.workers.length })
       await Promise.all(this.workers.map((worker) => worker.close()))
 
       // Close queues
@@ -91,11 +86,11 @@ class WorkerProcess {
       // Disconnect from database
       await database.disconnect()
 
-      console.log('✓ Worker process shutdown complete')
+      workerLogger.info('Worker process shutdown complete')
       clearTimeout(forceExitTimer)
       process.exit(0)
     } catch (error) {
-      console.error('✗ Error during worker shutdown:', error)
+      workerLogger.error('Error during worker shutdown', toError(error))
       clearTimeout(forceExitTimer)
       process.exit(1)
     }
@@ -105,7 +100,7 @@ class WorkerProcess {
 // Start worker process
 const worker = new WorkerProcess()
 worker.start().catch((error) => {
-  console.error('Fatal error during worker startup:', error)
+  workerLogger.error('Fatal error during worker startup', toError(error))
   process.exit(1)
 })
 
@@ -119,10 +114,14 @@ process.on('SIGINT', () => {
 
 // Process-level safety nets
 process.on('unhandledRejection', (reason) => {
-  console.error('[FATAL] Unhandled promise rejection:', reason)
+  workerLogger.error('Unhandled promise rejection', toError(reason))
   void worker.shutdown('unhandledRejection')
 })
 process.on('uncaughtException', (error) => {
-  console.error('[FATAL] Uncaught exception:', error)
+  workerLogger.error('Uncaught exception', toError(error))
   void worker.shutdown('uncaughtException')
 })
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}


### PR DESCRIPTION
Autonomous **limen** dispatch of task `BLD-public-record-data-scrapper-harden`.

Harden the main entry points: input validation, error handling, and structured logging on the primary request/CLI paths.

_Produced in an isolated worktree off origin — review before merge._