### PR TITLE
[limen BLD2-public-record-data-scrapper-auth] public-record-data-scrapper: auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,8 +186,17 @@ CORS_ORIGIN=http://localhost:5173,http://localhost:5000
 
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-change-in-production
+JWT_ISSUER=ucc-mca-api
+JWT_AUDIENCE=ucc-mca-customers
 JWT_ORG_CLAIM=org_id
 JWT_TIER_CLAIM=tier
+
+# API key issuance bootstrap secret.
+# Generate with: openssl rand -base64 32
+# Operators present this only to POST /api/auth/api-keys; issued keys are signed
+# with JWT_SECRET and used as Authorization: Bearer <key> or X-API-Key: <key>.
+API_KEY_ISSUER_SECRET=replace-with-api-key-issuer-secret
+API_KEY_EXPIRES_IN=30d
 
 # Production deploy gate acknowledgements for npm run deploy:verify.
 # Set these to true only after Auth0/access-token org_id issuance and product

--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5434/ucc_intelligence
 DATABASE_URL=postgresql://postgres:postgres@localhost:5434/ucc_intelligence_test
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=test-secret
+API_KEY_ISSUER_SECRET=test-issuer-secret

--- a/docs/DEMO_RUNBOOK.md
+++ b/docs/DEMO_RUNBOOK.md
@@ -402,10 +402,10 @@ fail-closed to live.
 
 Production-only guard: when `NODE_ENV=production`, `validateConfig` (`server/config/index.ts`) hard-fails
 startup unless `STRIPE_WEBHOOK_SECRET`, `TWILIO_AUTH_TOKEN`, `SENDGRID_WEBHOOK_VERIFICATION_KEY`,
-`PLAID_CLIENT_ID`, and `PLAID_SECRET` are present. The local demo runs as `development`, so these are
-optional — their absence simply keeps the corresponding sends/webhooks fail-closed. `PLAID_WEBHOOK_SECRET`
-is no longer used; Plaid webhooks are verified with ES256 signatures and JWKs fetched through the Plaid
-client credentials.
+`PLAID_CLIENT_ID`, `PLAID_SECRET`, and `API_KEY_ISSUER_SECRET` are present. The local demo runs as
+`development`, so these are optional — their absence simply keeps the corresponding sends/webhooks or API
+key issuance fail-closed. `PLAID_WEBHOOK_SECRET` is no longer used; Plaid webhooks are verified with ES256
+signatures and JWKs fetched through the Plaid client credentials.
 
 ---
 
@@ -417,7 +417,7 @@ platform refusing to fabricate. If you see one not on this list, stop and invest
 | Symptom / error                                                                                                     | Meaning                                                                                                                                    | Action                                                                                                                           |
 | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | Server exits at boot: `JWT_SECRET is required (set it in every environment)`                                        | `JWT_SECRET` is unset — there is no dev fallback by design.                                                                                | Export `JWT_SECRET` (§1.3) and restart. Use the **same** value you minted the token with.                                        |
-| `401 Unauthorized` / `No authorization header provided` on every `/api/*` call                                      | The `$AUTH` header is missing, or the token was signed with a different secret.                                                            | Re-run §1.6 with the current `JWT_SECRET`; confirm `echo "$AUTH"` shows a Bearer token.                                          |
+| `401 Unauthorized` / `No authorization header or X-API-Key provided` on every `/api/*` call                         | The `$AUTH` header or `X-API-Key` header is missing, or the token was signed with a different secret.                                      | Re-run §1.6 with the current `JWT_SECRET`; confirm `echo "$AUTH"` shows a Bearer token.                                          |
 | `401 Unauthorized` from the **dashboard** while `curl` works                                                        | Expected. The UI has no login and does not send the token in this phase (§2.4).                                                            | Drive the lifecycle over `curl`; use the UI for narration. Do not "fix" by enabling mock data.                                   |
 | `403 FORBIDDEN` / `No organization associated with this account` on discovery/compliance                            | The token has no `org_id` claim.                                                                                                           | Re-mint the token with `org_id` set to your `$ORG_ID` (§1.6).                                                                    |
 | `403` / `org_id does not match authenticated organization`                                                          | A request body/query `org_id` differs from the token's org.                                                                                | Drop the explicit `org_id` from the request — the org always comes from the token.                                               |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,6 +7,7 @@ Run it before promoting a production deploy.
 
 1. Provision production secrets in the deployment secret store:
    - `JWT_SECRET`
+   - `API_KEY_ISSUER_SECRET`
    - `DATABASE_URL`
    - `CORS_ORIGIN`
    - `STRIPE_WEBHOOK_SECRET`

--- a/docs/api/AUTHENTICATION.md
+++ b/docs/api/AUTHENTICATION.md
@@ -4,14 +4,17 @@ This document describes the authentication system used by the UCC-MCA Intelligen
 
 ## Overview
 
-The API uses JWT (JSON Web Token) based authentication. All protected endpoints require a valid JWT token in the Authorization header.
+The API uses signed JWT bearer tokens as customer API keys. All protected endpoints require a valid signed key issued by `POST /api/auth/api-keys`.
+
+Issued keys are verified by the shared auth middleware on the primary API endpoints.
 
 ## Authentication Flow
 
-1. Client obtains JWT token (via login or external auth provider)
-2. Client includes token in `Authorization` header
-3. Server validates token on each request
-4. Server extracts user claims from token
+1. Operator sets `JWT_SECRET` and `API_KEY_ISSUER_SECRET` in the server environment.
+2. Operator calls `POST /api/auth/api-keys` with `X-API-Key-Issuer-Secret`.
+3. Server returns a signed customer API key.
+4. Client sends that key to protected endpoints.
+5. Server verifies the key signature, issuer/audience when configured, expiration, and user/org claims.
 
 ## Token Format
 
@@ -19,20 +22,81 @@ The API uses JWT (JSON Web Token) based authentication. All protected endpoints 
 Authorization: Bearer <jwt-token>
 ```
 
+Customer integrations may also send the same issued key with:
+
+```
+X-API-Key: <jwt-token>
+```
+
+## Issuing API Keys
+
+`POST /api/auth/api-keys` is a bootstrap endpoint. It is not protected by a customer API key because it creates them; instead, it requires the operator-only `API_KEY_ISSUER_SECRET`.
+
+Required server configuration:
+
+| Variable                | Purpose                                             |
+| ----------------------- | --------------------------------------------------- |
+| `JWT_SECRET`            | Signs and verifies issued API keys                  |
+| `API_KEY_ISSUER_SECRET` | Authorizes calls to the issuance endpoint           |
+| `API_KEY_EXPIRES_IN`    | Optional default issued-key lifetime, default `30d` |
+| `JWT_ISSUER`            | Optional issuer claim enforced during verification  |
+| `JWT_AUDIENCE`          | Optional audience claim enforced during verification |
+| `JWT_ORG_CLAIM`         | Optional organization claim name, default `org_id`  |
+| `JWT_TIER_CLAIM`        | Optional tier claim name, default `tier`            |
+
+Generate secrets with a local secret generator and store them in `.env` for development or a secrets manager in production:
+
+```bash
+openssl rand -base64 32
+```
+
+Example issuance request:
+
+```bash
+curl -X POST "https://api.example.com/api/auth/api-keys" \
+  -H "X-API-Key-Issuer-Secret: $API_KEY_ISSUER_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": "user_123",
+    "orgId": "org_456",
+    "email": "user@example.com",
+    "role": "user",
+    "tier": "starter-tier",
+    "expiresIn": "30d"
+  }'
+```
+
+Response:
+
+```json
+{
+  "apiKey": "<signed-api-key>",
+  "keyId": "<key-id>",
+  "tokenType": "Bearer",
+  "expiresIn": "30d",
+  "expiresAt": "<iso-expiration>"
+}
+```
+
 ### JWT Claims
 
-| Claim   | Description                   | Required                |
-| ------- | ----------------------------- | ----------------------- |
-| `sub`   | User ID                       | Yes                     |
-| `email` | User email                    | Yes                     |
-| `role`  | User role (admin/user/viewer) | No (defaults to 'user') |
-| `iat`   | Issued at timestamp           | Yes                     |
-| `exp`   | Expiration timestamp          | Yes                     |
+| Claim       | Description                     | Required                |
+| ----------- | ------------------------------- | ----------------------- |
+| `sub`       | User ID                         | Yes                     |
+| `org_id`    | Organization/tenant ID          | Yes for issued API keys |
+| `email`     | User email                      | No                      |
+| `role`      | User role (admin/user/viewer)   | No (defaults to `user`) |
+| `tier`      | Subscription/data tier          | No                      |
+| `token_use` | `api_key` for issued API keys   | Yes for issued API keys |
+| `jti`       | Issued key id                   | Yes for issued API keys |
+| `iat`       | Issued at timestamp             | Yes                     |
+| `exp`       | Expiration timestamp            | Yes                     |
 
 ### Token Expiration
 
-- **Access tokens**: 1 hour
-- **Refresh tokens**: 7 days
+- **Issued API keys**: default `30d`, configurable with `API_KEY_EXPIRES_IN`
+- **External JWT access tokens**: 1 hour by default
+- **Refresh tokens**: 7 days, when an external identity provider is used
 
 ## Public Endpoints
 
@@ -44,10 +108,14 @@ The following endpoints do not require authentication:
 | `GET /api/health/live`     | Liveness probe         |
 | `GET /api/health/ready`    | Readiness probe        |
 | `GET /api/health/detailed` | Detailed health status |
+| `GET /api/docs`            | Swagger UI             |
+| `GET /status`              | Public status page     |
+
+`POST /api/auth/api-keys` is an operator bootstrap endpoint. It requires `X-API-Key-Issuer-Secret`, not a customer API key.
 
 ## Protected Endpoints
 
-All other endpoints require authentication:
+The primary application endpoints require issued API-key or bearer-token authentication:
 
 | Resource    | Endpoints            |
 | ----------- | -------------------- |
@@ -56,6 +124,14 @@ All other endpoints require authentication:
 | Portfolio   | `/api/portfolio/*`   |
 | Enrichment  | `/api/enrichment/*`  |
 | Jobs        | `/api/jobs/*`        |
+| Contacts    | `/api/contacts/*`    |
+| Deals       | `/api/deals/*`       |
+| Competitive | `/api/competitive/*` |
+| Outreach    | `/api/outreach/*`    |
+| Communications | `/api/communications/*` |
+| Compliance  | `/api/compliance/*`  |
+| Discovery   | `/api/discovery/*`   |
+| Agentic     | `/api/agentic/*`     |
 
 ## Role-Based Access Control
 
@@ -81,18 +157,15 @@ A role includes all permissions of lower roles.
 
 Returned when:
 
-- No Authorization header provided
+- No `Authorization` or `X-API-Key` header provided
 - Invalid token format
 - Token expired
 - Token signature invalid
 
 ```json
 {
-  "error": {
-    "message": "Invalid or expired token",
-    "code": "UNAUTHORIZED",
-    "statusCode": 401
-  }
+  "error": "Unauthorized",
+  "message": "Invalid token"
 }
 ```
 
@@ -119,11 +192,18 @@ Returned when:
 
 ```typescript
 // server/middleware/authMiddleware.ts
-const decoded = jwt.verify(token, config.jwt.secret) as JwtPayload
+const decoded = jwt.verify(token, config.jwt.secret, {
+  algorithms: ['HS256'],
+  issuer: config.jwt.issuer,
+  audience: config.jwt.audience
+}) as JwtPayload
+
 req.user = {
   id: decoded.sub,
   email: decoded.email,
-  role: decoded.role || 'user'
+  role: decoded.role,
+  orgId: decoded.org_id,
+  tier: decoded.tier
 }
 ```
 

--- a/docs/api/ENDPOINTS.md
+++ b/docs/api/ENDPOINTS.md
@@ -11,13 +11,54 @@ Production:  https://your-domain.com/api
 
 ## Authentication
 
-All endpoints (except health checks) require JWT authentication via Bearer token:
+All endpoints except health checks, docs, status, webhooks, and the auth bootstrap route require an issued API key. The key is a signed JWT bearer token:
 
 ```
 Authorization: Bearer <token>
 ```
 
-See [AUTHENTICATION.md](./AUTHENTICATION.md) for details on obtaining tokens.
+Customer clients may also use:
+
+```
+X-API-Key: <token>
+```
+
+Issue keys with `POST /api/auth/api-keys` using the operator-only `X-API-Key-Issuer-Secret` header. See [AUTHENTICATION.md](./AUTHENTICATION.md) for configuration and issuance details.
+
+---
+
+## Auth
+
+### Issue API Key
+
+```http
+POST /api/auth/api-keys
+```
+
+Requires `X-API-Key-Issuer-Secret: <API_KEY_ISSUER_SECRET>`.
+
+**Request Body:**
+
+| Field       | Type   | Required | Description                         |
+| ----------- | ------ | -------- | ----------------------------------- |
+| `userId`    | string | Yes      | User identifier for the `sub` claim |
+| `orgId`     | string | Yes      | Organization id for tenant binding  |
+| `email`     | string | No       | User email                          |
+| `role`      | string | No       | `admin`, `user`, or `viewer`        |
+| `tier`      | string | No       | Subscription/data tier              |
+| `expiresIn` | string | No       | Duration such as `1h`, `7d`, `30d`  |
+
+**Response:**
+
+```json
+{
+  "apiKey": "<signed-api-key>",
+  "keyId": "<key-id>",
+  "tokenType": "Bearer",
+  "expiresIn": "30d",
+  "expiresAt": "<iso-expiration>"
+}
+```
 
 ---
 

--- a/docs/configuration/ENV_VARIABLES.md
+++ b/docs/configuration/ENV_VARIABLES.md
@@ -8,12 +8,13 @@ This document describes all environment variables used by the UCC-MCA Intelligen
 
 These variables MUST be set in production environments:
 
-| Variable       | Description                                                   | Example                                             |
-| -------------- | ------------------------------------------------------------- | --------------------------------------------------- |
-| `JWT_SECRET`   | Secret key for JWT signing. Must be cryptographically secure. | `a-very-long-random-string-here`                    |
-| `DATABASE_URL` | PostgreSQL connection URL                                     | `postgresql://user:pass@host:5432/dbname`           |
-| `CORS_ORIGIN`  | Comma-separated list of allowed origins                       | `https://app.example.com,https://admin.example.com` |
-| `REDIS_URL`    | Redis connection URL                                          | `redis://:password@host:6379`                       |
+| Variable                | Description                                                   | Example                                             |
+| ----------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
+| `JWT_SECRET`            | Secret key for JWT signing. Must be cryptographically secure. | `a-very-long-random-string-here`                    |
+| `API_KEY_ISSUER_SECRET` | Operator secret for issuing customer API keys                 | `another-very-long-random-string-here`              |
+| `DATABASE_URL`          | PostgreSQL connection URL                                     | `postgresql://user:pass@host:5432/dbname`           |
+| `CORS_ORIGIN`           | Comma-separated list of allowed origins                       | `https://app.example.com,https://admin.example.com` |
+| `REDIS_URL`             | Redis connection URL                                          | `redis://:password@host:6379`                       |
 
 ## Server Configuration
 
@@ -58,13 +59,19 @@ rediss://[:password@]host[:port]  # TLS connection
 
 ## Authentication
 
-| Variable              | Description                   | Default | Required   |
-| --------------------- | ----------------------------- | ------- | ---------- |
-| `JWT_SECRET`          | Secret key for signing JWTs   | N/A     | Yes (prod) |
-| `AUTH0_DOMAIN`        | Auth0 domain (if using Auth0) | -       | No         |
-| `AUTH0_CLIENT_ID`     | Auth0 client ID               | -       | No         |
-| `AUTH0_CLIENT_SECRET` | Auth0 client secret           | -       | No         |
-| `AUTH0_AUDIENCE`      | Auth0 API audience            | -       | No         |
+| Variable                | Description                                      | Default | Required   |
+| ----------------------- | ------------------------------------------------ | ------- | ---------- |
+| `JWT_SECRET`            | Secret key for signing and verifying API keys    | N/A     | Yes (prod) |
+| `API_KEY_ISSUER_SECRET` | Operator secret for `POST /api/auth/api-keys`    | N/A     | Yes (prod) |
+| `API_KEY_EXPIRES_IN`    | Default issued API-key lifetime (`1h`, `7d`)     | `30d`   | No         |
+| `JWT_ISSUER`            | Optional issuer claim enforced during validation | -       | No         |
+| `JWT_AUDIENCE`          | Optional audience claim enforced during validation | -       | No         |
+| `JWT_ORG_CLAIM`         | Organization claim name                          | `org_id` | No        |
+| `JWT_TIER_CLAIM`        | Tier claim name                                  | `tier`  | No         |
+| `AUTH0_DOMAIN`          | Auth0 domain (if using Auth0)                    | -       | No         |
+| `AUTH0_CLIENT_ID`       | Auth0 client ID                                  | -       | No         |
+| `AUTH0_CLIENT_SECRET`   | Auth0 client secret                              | -       | No         |
+| `AUTH0_AUDIENCE`        | Auth0 API audience                               | -       | No         |
 
 ## CORS Configuration
 
@@ -127,6 +134,7 @@ PORT=3000
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ucc_dev
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=dev-secret-not-for-production
+API_KEY_ISSUER_SECRET=dev-issuer-secret-not-for-production
 ```
 
 ### Production (.env.production)
@@ -137,6 +145,7 @@ PORT=3000
 DATABASE_URL=postgresql://user:password@db.example.com:5432/ucc_prod?sslmode=require
 REDIS_URL=rediss://:password@redis.example.com:6379
 JWT_SECRET=<generated-secure-random-string>
+API_KEY_ISSUER_SECRET=<generated-secure-random-string>
 CORS_ORIGIN=https://app.example.com
 ```
 
@@ -147,6 +156,7 @@ NODE_ENV=test
 TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ucc_test
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=test-secret
+API_KEY_ISSUER_SECRET=test-issuer-secret
 ```
 
 ## Validation
@@ -157,5 +167,5 @@ To test configuration validation:
 
 ```bash
 NODE_ENV=production npm run dev
-# Will fail if JWT_SECRET, DATABASE_URL, or CORS_ORIGIN are not set
+# Will fail if JWT_SECRET, API_KEY_ISSUER_SECRET, DATABASE_URL, or CORS_ORIGIN are not set
 ```

--- a/docs/customer-api/AUTHENTICATION.md
+++ b/docs/customer-api/AUTHENTICATION.md
@@ -1,6 +1,6 @@
 # API Authentication
 
-The UCC-MCA Intelligence API uses JSON Web Tokens (JWT) to authenticate requests. All customer-facing endpoints require a valid token to be included in the `Authorization` header.
+The UCC-MCA Intelligence API uses signed API keys to authenticate requests. These keys are JWT bearer tokens issued during onboarding or by `POST /api/auth/api-keys`.
 
 ## Authentication Flow
 
@@ -10,14 +10,29 @@ To authenticate your requests, include the `Authorization` header with the `Bear
 Authorization: Bearer <your_jwt_token>
 ```
 
+You can also send the issued key with:
+
+```http
+X-API-Key: <your_api_key>
+```
+
 ## Obtaining a Token
 
-Depending on your subscription tier and setup, you may obtain tokens via your platform dashboard or an authentication endpoint provided during your onboarding.
+Depending on your subscription tier and setup, you may obtain keys via your platform dashboard, onboarding, or the operator issuance endpoint:
+
+```bash
+curl -X POST "https://api.your-domain.com/api/auth/api-keys" \
+  -H "X-API-Key-Issuer-Secret: $API_KEY_ISSUER_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"user_123","orgId":"org_456","role":"user","expiresIn":"30d"}'
+```
+
+`API_KEY_ISSUER_SECRET` is an operator-only secret and should never be embedded in customer applications.
 
 ## Token Expiration
 
-* **Access tokens:** Typically expire in 1 hour.
-* **Refresh tokens:** Last up to 7 days, allowing you to obtain new access tokens without requiring manual login.
+* **Issued API keys:** Default to 30 days unless the operator sets a shorter `expiresIn` or `API_KEY_EXPIRES_IN`.
+* **External access tokens:** Typically expire in 1 hour when an identity provider is used.
 
 Make sure your integration handles 401 Unauthorized responses to seamlessly refresh tokens or prompt for re-authentication.
 
@@ -26,7 +41,7 @@ Make sure your integration handles 401 Unauthorized responses to seamlessly refr
 **cURL**
 ```bash
 curl -X GET "https://api.your-domain.com/api/prospects" \
-     -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+     -H "Authorization: Bearer YOUR_API_KEY" \
      -H "Content-Type: application/json"
 ```
 

--- a/scripts/verify-deploy-prereqs.ts
+++ b/scripts/verify-deploy-prereqs.ts
@@ -8,6 +8,7 @@ loadDotenv()
 
 const REQUIRED_ENV = [
   'JWT_SECRET',
+  'API_KEY_ISSUER_SECRET',
   'DATABASE_URL',
   'CORS_ORIGIN',
   'STRIPE_WEBHOOK_SECRET',
@@ -74,6 +75,12 @@ function checkRequiredEnv(state: CheckState): void {
 
   if ((process.env.JWT_SECRET ?? '').trim().length > 0 && process.env.JWT_SECRET!.length < 32) {
     addError(state, 'JWT_SECRET must be at least 32 characters')
+  }
+  if (
+    (process.env.API_KEY_ISSUER_SECRET ?? '').trim().length > 0 &&
+    process.env.API_KEY_ISSUER_SECRET!.length < 32
+  ) {
+    addError(state, 'API_KEY_ISSUER_SECRET must be at least 32 characters')
   }
 
   const plaidEnv = process.env.PLAID_ENV || 'sandbox'

--- a/server/README.md
+++ b/server/README.md
@@ -53,6 +53,10 @@ server/
 - `GET /api/health/ready` - Kubernetes readiness probe
 - `GET /api/health/live` - Kubernetes liveness probe
 
+### Auth
+
+- `POST /api/auth/api-keys` - Issue signed customer API keys using `X-API-Key-Issuer-Secret`
+
 ### Prospects
 
 - `GET /api/prospects` - List prospects (paginated, filtered, sorted)
@@ -100,8 +104,15 @@ See `.env.example` in the project root for all available environment variables.
 Required variables:
 
 - `DATABASE_URL` - PostgreSQL connection string
+- `JWT_SECRET` - Signs and verifies JWT/API-key credentials
+- `API_KEY_ISSUER_SECRET` - Operator secret required to issue customer API keys
 - `PORT` - Server port (default: 3000)
 - `NODE_ENV` - Environment (development/production)
+
+Optional auth variables:
+
+- `API_KEY_EXPIRES_IN` - Default issued API-key lifetime (default: `30d`)
+- `JWT_ISSUER`, `JWT_AUDIENCE` - Optional claims enforced during credential verification
 
 Optional tiered integration variables (used when routing by `x-data-tier`):
 

--- a/server/__tests__/config/index.test.ts
+++ b/server/__tests__/config/index.test.ts
@@ -52,7 +52,8 @@ describe('server config', () => {
       SENDGRID_WEBHOOK_VERIFICATION_KEY: 'sendgrid-verification-key',
       PLAID_CLIENT_ID: 'plaid-client-id',
       PLAID_SECRET: 'plaid-secret',
-      PLAID_ENV: 'production'
+      PLAID_ENV: 'production',
+      API_KEY_ISSUER_SECRET: 'issuer-secret'
     }
 
     it('accepts the current Plaid ES256/JWK prerequisite without PLAID_WEBHOOK_SECRET', async () => {
@@ -79,6 +80,24 @@ describe('server config', () => {
       })
 
       expect(() => validateConfig()).toThrow(/PLAID_ENV must be one of/)
+    })
+
+    it('requires API key issuer secret in production', async () => {
+      const { validateConfig } = await loadConfig({
+        ...productionEnv,
+        API_KEY_ISSUER_SECRET: ''
+      })
+
+      expect(() => validateConfig()).toThrow(/API_KEY_ISSUER_SECRET is required/)
+    })
+
+    it('rejects invalid API key expiration durations', async () => {
+      const { validateConfig } = await loadConfig({
+        ...productionEnv,
+        API_KEY_EXPIRES_IN: 'forever'
+      })
+
+      expect(() => validateConfig()).toThrow(/API_KEY_EXPIRES_IN must use a duration/)
     })
   })
 })

--- a/server/__tests__/middleware/authMiddleware.test.ts
+++ b/server/__tests__/middleware/authMiddleware.test.ts
@@ -48,7 +48,7 @@ describe('authMiddleware', () => {
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: 'Unauthorized',
-          message: 'No authorization header provided'
+          message: 'No authorization header or X-API-Key provided'
         })
       )
       expect(mockNext).not.toHaveBeenCalled()
@@ -117,6 +117,27 @@ describe('authMiddleware', () => {
         id: 'user123',
         email: 'user@example.com',
         role: 'admin'
+      })
+    })
+
+    it('authenticates a valid API key from X-API-Key', () => {
+      const validToken = createToken({
+        sub: 'user123',
+        email: 'user@example.com',
+        role: 'user',
+        org_id: 'org-1',
+        token_use: 'api_key'
+      })
+      mockReq.headers = { 'x-api-key': validToken }
+
+      authMiddleware(mockReq as AuthenticatedRequest, mockRes as Response, mockNext)
+
+      expect(mockNext).toHaveBeenCalled()
+      expect(mockReq.user).toEqual({
+        id: 'user123',
+        email: 'user@example.com',
+        role: 'user',
+        orgId: 'org-1'
       })
     })
 
@@ -266,6 +287,20 @@ describe('optionalAuthMiddleware', () => {
   it('adds user when valid token provided', () => {
     const token = createToken({ sub: 'user789', email: 'test@test.com' })
     mockReq.headers = { authorization: `Bearer ${token}` }
+
+    optionalAuthMiddleware(mockReq as AuthenticatedRequest, mockRes as Response, mockNext)
+
+    expect(mockNext).toHaveBeenCalled()
+    expect(mockReq.user).toEqual({
+      id: 'user789',
+      email: 'test@test.com',
+      role: undefined
+    })
+  })
+
+  it('adds user when valid API key is provided via X-API-Key', () => {
+    const token = createToken({ sub: 'user789', email: 'test@test.com', token_use: 'api_key' })
+    mockReq.headers = { 'x-api-key': token }
 
     optionalAuthMiddleware(mockReq as AuthenticatedRequest, mockRes as Response, mockNext)
 

--- a/server/__tests__/routes/auth.test.ts
+++ b/server/__tests__/routes/auth.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import authRouter from '../../routes/auth'
+import { authMiddleware, type AuthenticatedRequest } from '../../middleware/authMiddleware'
+
+vi.mock('../../config', () => ({
+  config: {
+    jwt: {
+      secret: 'test-jwt-secret',
+      issuer: 'ucc-test',
+      audience: 'ucc-customers',
+      orgClaim: 'org_id',
+      tierClaim: 'tier',
+      apiKeyExpiresIn: '7d'
+    },
+    auth: {
+      apiKeyIssuerSecret: 'issuer-secret'
+    }
+  }
+}))
+
+describe('Auth API', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(express.json())
+    app.use('/api/auth', authRouter)
+    app.get('/api/protected', authMiddleware, (req: AuthenticatedRequest, res) => {
+      res.json({ user: req.user })
+    })
+  })
+
+  it('rejects API key issuance without the issuer secret', async () => {
+    const response = await request(app).post('/api/auth/api-keys').send({
+      userId: 'user-1',
+      orgId: 'org-1'
+    })
+
+    expect(response.status).toBe(401)
+    expect(response.body).toMatchObject({
+      error: 'Unauthorized',
+      message: 'Valid X-API-Key-Issuer-Secret header required'
+    })
+  })
+
+  it('validates API key issuance input after the issuer secret passes', async () => {
+    const response = await request(app)
+      .post('/api/auth/api-keys')
+      .set('X-API-Key-Issuer-Secret', 'issuer-secret')
+      .send({
+        userId: 'user-1'
+      })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('issues a signed API key with tenant and user claims', async () => {
+    const response = await request(app)
+      .post('/api/auth/api-keys')
+      .set('X-API-Key-Issuer-Secret', 'issuer-secret')
+      .send({
+        userId: 'user-1',
+        orgId: 'org-1',
+        email: 'user@example.com',
+        role: 'admin',
+        tier: 'starter-tier',
+        expiresIn: '1h'
+      })
+
+    expect(response.status).toBe(201)
+    expect(response.body).toMatchObject({
+      apiKey: expect.any(String),
+      keyId: expect.any(String),
+      tokenType: 'Bearer',
+      expiresIn: '1h',
+      expiresAt: expect.any(String),
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+        role: 'admin',
+        orgId: 'org-1',
+        tier: 'starter-tier'
+      }
+    })
+
+    const decoded = jwt.verify(response.body.apiKey, 'test-jwt-secret', {
+      algorithms: ['HS256'],
+      issuer: 'ucc-test',
+      audience: 'ucc-customers'
+    }) as jwt.JwtPayload
+
+    expect(decoded).toMatchObject({
+      sub: 'user-1',
+      email: 'user@example.com',
+      role: 'admin',
+      org_id: 'org-1',
+      tier: 'starter-tier',
+      token_use: 'api_key',
+      jti: response.body.keyId
+    })
+  })
+
+  it('verifies an issued API key on protected endpoints via X-API-Key', async () => {
+    const issued = await request(app)
+      .post('/api/auth/api-keys')
+      .set('X-API-Key-Issuer-Secret', 'issuer-secret')
+      .send({
+        userId: 'user-2',
+        orgId: 'org-2',
+        role: 'viewer'
+      })
+
+    const response = await request(app)
+      .get('/api/protected')
+      .set('X-API-Key', issued.body.apiKey)
+
+    expect(response.status).toBe(200)
+    expect(response.body.user).toMatchObject({
+      id: 'user-2',
+      role: 'viewer',
+      orgId: 'org-2'
+    })
+  })
+})

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -2,6 +2,10 @@ function parseBooleanFlag(value: string | undefined): boolean {
   return value === '1' || value?.toLowerCase() === 'true'
 }
 
+function isJwtDuration(value: string): boolean {
+  return /^\d+[smhd]$/.test(value)
+}
+
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
@@ -123,6 +127,7 @@ export const config = {
     issuer: process.env.JWT_ISSUER || undefined,
     audience: process.env.JWT_AUDIENCE || undefined,
     expiresIn: '1h',
+    apiKeyExpiresIn: process.env.API_KEY_EXPIRES_IN || '30d',
     refreshExpiresIn: '7d',
     // Name of the custom claim carrying the organization id. Auth0 namespaces
     // custom claims (e.g. https://<app>/org_id); the resolver also accepts any
@@ -132,6 +137,9 @@ export const config = {
     // Namespaced variants ending in /tier or /plan are also accepted. When
     // present it is authoritative and avoids a DB lookup. Default 'tier'.
     tierClaim: process.env.JWT_TIER_CLAIM || 'tier'
+  },
+  auth: {
+    apiKeyIssuerSecret: process.env.API_KEY_ISSUER_SECRET || ''
   },
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY,
@@ -192,6 +200,10 @@ export function validateConfig(): void {
       )
     }
   }
+  if (process.env.API_KEY_EXPIRES_IN && !isJwtDuration(process.env.API_KEY_EXPIRES_IN)) {
+    const value = process.env.API_KEY_EXPIRES_IN
+    errors.push(`API_KEY_EXPIRES_IN must use a duration like 1h, 7d, or 30d (got "${value}")`)
+  }
 
   if (isProduction) {
     if (!process.env.DATABASE_URL) {
@@ -221,6 +233,9 @@ export function validateConfig(): void {
     }
     if (!process.env.PLAID_SECRET) {
       errors.push('PLAID_SECRET is required in production for Plaid webhook verification')
+    }
+    if (!config.auth.apiKeyIssuerSecret) {
+      errors.push('API_KEY_ISSUER_SECRET is required in production for API key issuance')
     }
     if (!['sandbox', 'development', 'production'].includes(config.plaid.env)) {
       errors.push('PLAID_ENV must be one of: sandbox, development, production')

--- a/server/index.ts
+++ b/server/index.ts
@@ -38,6 +38,7 @@ import complianceRouter from './routes/compliance'
 import discoveryRouter from './routes/discovery'
 import metricsRouter from './routes/metrics'
 import agenticRouter from './routes/agentic'
+import authRouter from './routes/auth'
 
 // Import queue infrastructure
 import {
@@ -136,6 +137,9 @@ export class Server {
     // Public routes (no authentication required)
     this.app.use('/api/health', healthRouter)
 
+    // Auth bootstrap routes. API key issuance is guarded by API_KEY_ISSUER_SECRET.
+    this.app.use('/api/auth', authRouter)
+
     // Webhook routes (signature verification, no JWT auth)
     this.app.use('/api/webhooks', webhooksRouter)
 
@@ -187,6 +191,7 @@ export class Server {
           compliance: '/api/compliance',
           discovery: '/api/discovery',
           metrics: '/api/metrics',
+          auth: '/api/auth',
           webhooks: '/api/webhooks'
         }
       })

--- a/server/middleware/authMiddleware.ts
+++ b/server/middleware/authMiddleware.ts
@@ -24,6 +24,32 @@ interface JwtPayload {
   [claim: string]: unknown
 }
 
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function extractBearerToken(authHeader: string | undefined): { token?: string; error?: string } {
+  if (!authHeader) return {}
+
+  const parts = authHeader.split(' ')
+  if (parts.length !== 2 || parts[0] !== 'Bearer' || !parts[1]) {
+    return { error: 'Invalid authorization header format. Expected: Bearer <token>' }
+  }
+
+  return { token: parts[1] }
+}
+
+function extractAuthToken(req: Request): { token?: string; error?: string } {
+  const authHeader = firstHeaderValue(req.headers.authorization)
+  const bearer = extractBearerToken(authHeader)
+  if (bearer.token || bearer.error) return bearer
+
+  const apiKey = firstHeaderValue(req.headers['x-api-key'])?.trim()
+  if (apiKey) return { token: apiKey }
+
+  return {}
+}
+
 /**
  * Coerce an arbitrary claim value to a non-empty string, or undefined.
  * Guards against object/array/number claim shapes that some IdPs emit.
@@ -120,27 +146,24 @@ function getVerifyOptions(): jwt.VerifyOptions {
  * Adds user info to request object if valid.
  */
 export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-  const authHeader = req.headers.authorization
+  const auth = extractAuthToken(req)
 
-  if (!authHeader) {
+  if (auth.error) {
     return res.status(401).json({
       error: 'Unauthorized',
-      message: 'No authorization header provided'
+      message: auth.error
     })
   }
 
-  const parts = authHeader.split(' ')
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+  if (!auth.token) {
     return res.status(401).json({
       error: 'Unauthorized',
-      message: 'Invalid authorization header format. Expected: Bearer <token>'
+      message: 'No authorization header or X-API-Key provided'
     })
   }
-
-  const token = parts[1]
 
   try {
-    const decoded = jwt.verify(token, config.jwt.secret, getVerifyOptions()) as JwtPayload
+    const decoded = jwt.verify(auth.token, config.jwt.secret, getVerifyOptions()) as JwtPayload
 
     req.user = buildUser(decoded)
 
@@ -176,21 +199,13 @@ export const optionalAuthMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
-  const authHeader = req.headers.authorization
-
-  if (!authHeader) {
+  const auth = extractAuthToken(req)
+  if (!auth.token || auth.error) {
     return next()
   }
-
-  const parts = authHeader.split(' ')
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
-    return next()
-  }
-
-  const token = parts[1]
 
   try {
-    const decoded = jwt.verify(token, config.jwt.secret, getVerifyOptions()) as JwtPayload
+    const decoded = jwt.verify(auth.token, config.jwt.secret, getVerifyOptions()) as JwtPayload
 
     req.user = buildUser(decoded)
   } catch {

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -22,6 +22,8 @@ servers:
 tags:
   - name: Health
     description: Health check endpoints for monitoring
+  - name: Auth
+    description: API key issuance and authentication bootstrap
   - name: Prospects
     description: UCC prospect management
   - name: Competitors
@@ -41,8 +43,40 @@ tags:
 
 security:
   - bearerAuth: []
+  - apiKeyAuth: []
 
 paths:
+  # ===========================================
+  # Auth Endpoints
+  # ===========================================
+  /api/auth/api-keys:
+    post:
+      tags:
+        - Auth
+      summary: Issue API key
+      description: Issues a signed customer API key. Requires the operator-only API key issuer secret.
+      security:
+        - apiKeyIssuerSecret: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiKeyIssueRequest'
+      responses:
+        '201':
+          description: API key issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyIssueResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          description: API key issuance is not configured
+
   # ===========================================
   # Health Endpoints
   # ===========================================
@@ -1737,7 +1771,19 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: JWT token for API authentication
+      description: Issued API key as a JWT bearer token
+
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: Issued API key header alternative to bearer auth
+
+    apiKeyIssuerSecret:
+      type: apiKey
+      in: header
+      name: X-API-Key-Issuer-Secret
+      description: Operator-only secret used to issue customer API keys
 
     twilioSignature:
       type: apiKey
@@ -1826,6 +1872,83 @@ components:
               type: string
             statusCode:
               type: integer
+
+    ApiKeyIssueRequest:
+      type: object
+      required:
+        - userId
+        - orgId
+      properties:
+        userId:
+          type: string
+          minLength: 1
+          maxLength: 128
+          example: user_123
+        orgId:
+          type: string
+          minLength: 1
+          maxLength: 128
+          example: org_456
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        role:
+          type: string
+          enum: [admin, user, viewer]
+          default: user
+        tier:
+          type: string
+          example: starter-tier
+        expiresIn:
+          type: string
+          pattern: '^\d+[smhd]$'
+          default: 30d
+          example: 30d
+
+    ApiKeyIssueResponse:
+      type: object
+      required:
+        - apiKey
+        - keyId
+        - tokenType
+        - expiresIn
+        - user
+      properties:
+        apiKey:
+          type: string
+          description: Signed API key. Store securely and present as bearer auth or X-API-Key.
+        keyId:
+          type: string
+          format: uuid
+        tokenType:
+          type: string
+          enum: [Bearer]
+        expiresIn:
+          type: string
+          example: 30d
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        user:
+          type: object
+          required:
+            - id
+            - role
+            - orgId
+          properties:
+            id:
+              type: string
+            email:
+              type: string
+              format: email
+            role:
+              type: string
+            orgId:
+              type: string
+            tier:
+              type: string
 
     Pagination:
       type: object

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,0 +1,119 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto'
+import { Router, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import { z } from 'zod'
+import { config } from '../config'
+import { validateRequest } from '../middleware/validateRequest'
+import type { AuthenticatedRequest } from '../middleware/authMiddleware'
+
+const router = Router()
+
+const issueApiKeySchema = z.object({
+  userId: z.string().min(1).max(128),
+  orgId: z.string().min(1).max(128),
+  email: z.string().email().optional(),
+  role: z.enum(['admin', 'user', 'viewer']).default('user'),
+  tier: z.string().min(1).max(64).optional(),
+  expiresIn: z
+    .string()
+    .regex(/^\d+[smhd]$/, 'expiresIn must use a duration such as 1h, 7d, or 30d')
+    .optional()
+})
+
+type IssueApiKeyBody = z.infer<typeof issueApiKeySchema>
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function constantTimeEqualString(a: string, b: string): boolean {
+  const aDigest = createHash('sha256').update(a).digest()
+  const bDigest = createHash('sha256').update(b).digest()
+  return timingSafeEqual(aDigest, bDigest)
+}
+
+function getIssuerSecret(req: AuthenticatedRequest): string | undefined {
+  return firstHeaderValue(req.headers['x-api-key-issuer-secret'])?.trim()
+}
+
+export function requireApiKeyIssuerSecret(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  if (!config.jwt.secret || !config.auth.apiKeyIssuerSecret) {
+    return res.status(503).json({
+      error: 'ServiceUnavailable',
+      message: 'API key issuance is not configured'
+    })
+  }
+
+  const presentedSecret = getIssuerSecret(req)
+  const secretMatches =
+    presentedSecret &&
+    constantTimeEqualString(presentedSecret, config.auth.apiKeyIssuerSecret)
+
+  if (!secretMatches) {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Valid X-API-Key-Issuer-Secret header required'
+    })
+  }
+
+  next()
+}
+
+router.post(
+  '/api-keys',
+  requireApiKeyIssuerSecret,
+  validateRequest({ body: issueApiKeySchema }),
+  (req, res) => {
+    const body = req.body as IssueApiKeyBody
+    const expiresIn = body.expiresIn || config.jwt.apiKeyExpiresIn
+    const keyId = randomUUID()
+    const payload: Record<string, unknown> = {
+      email: body.email,
+      role: body.role,
+      org_id: body.orgId,
+      token_use: 'api_key'
+    }
+
+    if (body.tier) {
+      payload.tier = body.tier
+    }
+
+    const signOptions: jwt.SignOptions = {
+      algorithm: 'HS256',
+      expiresIn: expiresIn as jwt.SignOptions['expiresIn'],
+      jwtid: keyId,
+      subject: body.userId
+    }
+
+    if (config.jwt.issuer) {
+      signOptions.issuer = config.jwt.issuer
+    }
+    if (config.jwt.audience) {
+      signOptions.audience = config.jwt.audience
+    }
+
+    const apiKey = jwt.sign(payload, config.jwt.secret, signOptions)
+    const decoded = jwt.decode(apiKey) as { exp?: number } | null
+
+    res.status(201).json({
+      apiKey,
+      keyId,
+      tokenType: 'Bearer',
+      expiresIn,
+      expiresAt: decoded?.exp ? new Date(decoded.exp * 1000).toISOString() : null,
+      user: {
+        id: body.userId,
+        email: body.email,
+        role: body.role,
+        orgId: body.orgId,
+        tier: body.tier
+      }
+    })
+  }
+)
+
+export default router

--- a/vitest.config.server.ts
+++ b/vitest.config.server.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     // works under vitest without depending on a loaded .env file.
     env: {
       JWT_SECRET: process.env.JWT_SECRET || 'test-secret',
+      API_KEY_ISSUER_SECRET: process.env.API_KEY_ISSUER_SECRET || 'test-issuer-secret',
       NODE_ENV: process.env.NODE_ENV || 'test'
     },
     setupFiles: ['./server/__tests__/setup.ts'],


### PR DESCRIPTION
Autonomous **limen** dispatch of task `BLD2-public-record-data-scrapper-auth`.

Add user auth / API-key issuance + verification on the primary endpoints (or CLI), with a documented secret/config path.

_Produced in an isolated worktree off origin — review before merge._