### PR TITLE
fix: heal six audit defects (tests, deps, states, ML, enrichment, serverless backend) + Express 5 query coercion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ TX_UCC_PASSWORD=your_texas_sos_password
 # CA_UCC_USERNAME=your_california_username
 # CA_UCC_PASSWORD=your_california_password
 
+# New York DOS UCC portal scraper (Optional - activates the NY collector).
+# The NY public portal supports per-debtor search only (no bulk/date query), so
+# the collector enumerates a configured list of debtor names. Set a comma-
+# separated list to enable NY collection; leave unset and NY fails closed
+# (isReady()=false) and is withheld by the StateCollectorFactory.
+# NY_UCC_DEBTOR_SEEDS=Acme Corp,Example LLC,Another Business Inc
+
 # =============================================================================
 # ML & ENRICHMENT SERVICES
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Tests: 3,321](https://img.shields.io/badge/tests-3%2C321%20passing-brightgreen)](https://github.com/organvm-iii-ergon/public-record-data-scrapper)
+[![Tests: 3,399](https://img.shields.io/badge/tests-3%2C399%20passing-brightgreen)](https://github.com/organvm-iii-ergon/public-record-data-scrapper)
 [![Deploy: Vercel](https://img.shields.io/badge/deploy-Vercel-black?logo=vercel)](https://public-record-data-scrapper.vercel.app)
 
 ---
@@ -150,17 +150,17 @@ public-record-data-scrapper/
 
 The Express server exposes a RESTful API documented at `/api/docs` when running.
 
-| Method  | Endpoint                   | Description                                  |
-| ------- | -------------------------- | -------------------------------------------- |
-| `GET`   | `/api/prospects`           | List prospects with filtering and pagination |
-| `GET`   | `/api/prospects/export/leads` | Export scored MCA leads as JSON or CSV |
-| `GET`   | `/api/prospects/:id`       | Prospect detail with enrichment data         |
-| `POST`  | `/api/prospects/:id/claim` | Claim a prospect for outreach                |
-| `POST`  | `/api/prospects/:id/score` | Trigger re-scoring                           |
-| `GET`   | `/api/deals`               | List deals with pipeline stage filter        |
-| `PATCH` | `/api/deals/:id/stage`     | Move deal to next pipeline stage             |
-| `POST`  | `/api/communications/send` | Send email or SMS                            |
-| `GET`   | `/api/compliance/report`   | Generate compliance report                   |
+| Method  | Endpoint                      | Description                                  |
+| ------- | ----------------------------- | -------------------------------------------- |
+| `GET`   | `/api/prospects`              | List prospects with filtering and pagination |
+| `GET`   | `/api/prospects/export/leads` | Export scored MCA leads as JSON or CSV       |
+| `GET`   | `/api/prospects/:id`          | Prospect detail with enrichment data         |
+| `POST`  | `/api/prospects/:id/claim`    | Claim a prospect for outreach                |
+| `POST`  | `/api/prospects/:id/score`    | Trigger re-scoring                           |
+| `GET`   | `/api/deals`                  | List deals with pipeline stage filter        |
+| `PATCH` | `/api/deals/:id/stage`        | Move deal to next pipeline stage             |
+| `POST`  | `/api/communications/send`    | Send email or SMS                            |
+| `GET`   | `/api/compliance/report`      | Generate compliance report                   |
 
 Full endpoint list: [server/openapi.yaml](server/openapi.yaml)
 
@@ -185,22 +185,23 @@ Full endpoint list: [server/openapi.yaml](server/openapi.yaml)
 
 ## Testing
 
-3,321 tests across 156 files, zero failures (verified). The suite is split across two runners:
+3,399 passing tests across 168 files (plus 6 skipped server tests), zero failures on a clean run (verified, branch rebased onto `main`). `npm test` runs two Vitest projects; the server suite is a third:
 
 ```bash
-npm test                       # Web suite (jsdom):   2,005 tests / 83 files
-npm run test:server            # Server suite (node):  1,316 tests / 73 files (+6 skipped)
+npm test                       # Client suites:  2,029 tests / 88 files (apps/web jsdom + root)
+npm run test:server            # Server (node):   1,370 tests / 80 files (+6 skipped)
 npm run test:coverage          # V8 coverage report (web)
 npm run test:e2e               # Playwright end-to-end (3 specs, run separately)
 ```
 
-| Suite                  | Runner         | Tests     | Files   |
-| ---------------------- | -------------- | --------- | ------- |
-| Web (`npm test`)       | Vitest + jsdom | 2,005     | 83      |
-| Server (`test:server`) | Vitest + node  | 1,316     | 73      |
-| **Total**              |                | **3,321** | **156** |
+| Suite                           | Runner         | Tests     | Files   |
+| ------------------------------- | -------------- | --------- | ------- |
+| Web — `apps/web` (`npm test`)   | Vitest + jsdom | 2,005     | 83      |
+| Web — root project (`npm test`) | Vitest         | 24        | 5       |
+| Server (`test:server`)          | Vitest + node  | 1,370     | 80      |
+| **Total**                       |                | **3,399** | **168** |
 
-Counts are reproducible from the test runners above; the previous "2,055 tests / 91 files" badge was inaccurate (and the web run had been failing on a config-glob bug + a jsdom localStorage regression, both now fixed).
+Counts are reproducible from the test runners above. The server suite carries one pre-existing, order-dependent flaky test (`outreach` briefing "cache warm") that passes in isolation and on re-run; it is unrelated to this branch. The web run's earlier config-glob bug + jsdom localStorage regression were fixed here.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Public Record Data Scraper
 
-**Extract, enrich, and score UCC filings from all 50 US state Secretary of State portals.** Turns raw public records into prioritized, outreach-ready leads for the Merchant Cash Advance industry.
+**Extract, enrich, and score UCC filings from US state Secretary of State portals.** Turns raw public records into prioritized, outreach-ready leads for the Merchant Cash Advance industry. Four state collectors are implemented today (CA, TX, FL, NY); the remaining states are on the roadmap.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Tests: 2,055](https://img.shields.io/badge/tests-2%2C055%20passing-brightgreen)](https://github.com/organvm-iii-ergon/public-record-data-scrapper)
+[![Tests: 3,321](https://img.shields.io/badge/tests-3%2C321%20passing-brightgreen)](https://github.com/organvm-iii-ergon/public-record-data-scrapper)
 [![Deploy: Vercel](https://img.shields.io/badge/deploy-Vercel-black?logo=vercel)](https://public-record-data-scrapper.vercel.app)
 
 ---
 
 ## What It Does
 
-1. **Collects** UCC-1 filing data from 50 state portals via 60+ autonomous agents (handles CAPTCHAs, rate limits, session management, and fallback strategies per state)
-2. **Enriches** each filing with data from SEC EDGAR, OSHA, USPTO, Census Bureau, SAM.gov, and optional commercial sources (D&B, Clearbit, ZoomInfo)
+1. **Collects** UCC-1 filing data from state Secretary of State portals — 4 collectors implemented (CA API, TX bulk, FL vendor, NY portal scraper) with per-state strategies (API, bulk download, vendor feed, scrape) and fallback. FL and NY are credential-gated and fail closed when unconfigured.
+2. **Enriches** each filing with free public data (SEC EDGAR, OSHA, USPTO, Census Bureau) plus optional, key-gated sources (SAM.gov, D&B, Clearbit, ZoomInfo) that fail closed — returning a named error, never fabricated data — when no API key is configured
 3. **Scores** every prospect 0--100 on financing likelihood, assigns a health grade (A--F), and flags growth signals (hiring, permits, equipment purchases, expansion)
 4. **Delivers** results through a React web dashboard, REST API, or CLI tool
 
@@ -77,7 +77,7 @@ npm run scrape -- batch -i companies.csv -o ./results
 # Export scored MCA leads as JSON + CSV batches (requires database)
 npm run scrape -- lead-export --min-score 70 --limit 100 --output-dir ./lead-export
 
-# List all 50 state agents
+# List state collectors (4 implemented: CA, TX, FL, NY)
 npm run scrape -- list-states
 ```
 
@@ -107,14 +107,15 @@ A non-zero exit from the first command means the API is not up.
         │              │
 ┌───────▼──────┐ ┌─────▼───────┐ ┌────────────────────┐
 │ PostgreSQL   │ │   Redis 7   │ │ Agent Orchestrator  │
-│ 9 migrations │ │ cache/queue │ │ 60+ collectors      │
+│ 9 migrations │ │ cache/queue │ │ 4 state collectors  │
 │ multitenancy │ │             │ │ circuit breakers     │
 └──────────────┘ └─────────────┘ └─────┬──────────────┘
                                        │
                     ┌──────────────────▼────────────────┐
-                    │  50 State SOS Agents               │
-                    │  CA · TX · NY · FL · IL · ...      │
-                    │  + SEC · OSHA · USPTO · Census     │
+                    │  State SOS Collectors (4 live)      │
+                    │  CA · TX · FL · NY                  │
+                    │  + SEC · OSHA · USPTO · Census      │
+                    │  + SAM.gov · D&B · Clearbit · Zoom  │
                     └────────────────────────────────────┘
 ```
 
@@ -165,17 +166,17 @@ Full endpoint list: [server/openapi.yaml](server/openapi.yaml)
 
 ### Data Tiers
 
-| Tier           | Sources                                                     | Cost         |
-| -------------- | ----------------------------------------------------------- | ------------ |
-| **Free / OSS** | SEC EDGAR, OSHA, USPTO, Census, SAM.gov                     | $0           |
-| **Paid**       | + D&B, Clearbit, Experian, ZoomInfo, Google Places, NewsAPI | Subscription |
+| Tier                    | Sources                                                           | Cost               |
+| ----------------------- | ----------------------------------------------------------------- | ------------------ |
+| **Free / OSS (no key)** | SEC EDGAR, OSHA, USPTO, Census                                    | $0                 |
+| **Optional, key-gated** | SAM.gov, D&B, Clearbit, ZoomInfo (fail closed without an API key) | Provider-dependent |
 
 ---
 
 ## Key Features
 
-- **50-state UCC collection** -- autonomous agents for every Secretary of State portal, with per-state fallback strategies (API, bulk download, vendor feed, scrape)
-- **ML-based lead scoring** -- priority score (0--100), health grade, growth signal detection, revenue estimation, competitive position analysis
+- **Multi-state UCC collection** -- 4 implemented collectors (CA API, TX bulk, FL vendor, NY portal scraper) with per-state fallback strategies (API, bulk download, vendor feed, scrape); FL and NY are credential-gated and fail closed when unconfigured. 47 states remain on the roadmap.
+- **Transparent rules-based lead scoring** -- priority score (0--100) from a weighted, inspectable formula, health grade, growth signal detection, revenue estimation. An **optional, experimental ML model** (logistic regression) can be attached per request; it is opt-in, low-confidence, and trained on synthetic seed data pending validation against real outcomes — the rules-based score stays authoritative.
 - **Compliance built in** -- CA SB 1235 and NY CFDL disclosure calculators, TCPA consent tracking, suppression list management, immutable audit trail
 - **Full broker workflow** -- prospect dashboard, deal pipeline (Kanban), contact CRM, unified communications inbox (email/SMS/voice), bank statement underwriting (Plaid)
 - **Production infrastructure** -- Terraform-provisioned AWS (VPC, RDS, ElastiCache, S3), Vercel frontend deployment, Docker Compose for local dev, Kubernetes manifests for container orchestration
@@ -184,25 +185,22 @@ Full endpoint list: [server/openapi.yaml](server/openapi.yaml)
 
 ## Testing
 
-2,055 tests across 91 files. Zero failures.
+3,321 tests across 156 files, zero failures (verified). The suite is split across two runners:
 
 ```bash
-npm test                       # Full suite
-npm run test:coverage          # V8 coverage report
-npm run test:server            # Server-side only
-npm run test:e2e               # Playwright end-to-end
+npm test                       # Web suite (jsdom):   2,005 tests / 83 files
+npm run test:server            # Server suite (node):  1,316 tests / 73 files (+6 skipped)
+npm run test:coverage          # V8 coverage report (web)
+npm run test:e2e               # Playwright end-to-end (3 specs, run separately)
 ```
 
-| Category            | Tests | Scope                                              |
-| ------------------- | ----- | -------------------------------------------------- |
-| Frontend components | ~500  | React dashboard, pipeline, inbox, forms            |
-| Server services     | ~400  | All 27 domain services                             |
-| State agents        | ~250  | 50 state-specific collectors + fallback strategies |
-| Agentic system      | ~200  | Agent engine, orchestration, council               |
-| Data pipeline       | ~150  | Quality checks, enrichment, stale data detection   |
-| Server routes       | ~150  | API endpoints, webhook verification                |
-| Integration + E2E   | ~100  | Cross-service workflows                            |
-| Security            | ~55   | XSS prevention, input sanitization                 |
+| Suite                  | Runner         | Tests     | Files   |
+| ---------------------- | -------------- | --------- | ------- |
+| Web (`npm test`)       | Vitest + jsdom | 2,005     | 83      |
+| Server (`test:server`) | Vitest + node  | 1,316     | 73      |
+| **Total**              |                | **3,321** | **156** |
+
+Counts are reproducible from the test runners above; the previous "2,055 tests / 91 files" badge was inaccurate (and the web run had been failing on a config-glob bug + a jsdom localStorage regression, both now fixed).
 
 ---
 
@@ -258,7 +256,7 @@ Provisions: VPC with multi-AZ subnets, RDS PostgreSQL (encrypted, Multi-AZ), Ela
 1. Fork and create a feature branch: `git checkout -b feature/your-feature`
 2. Install: `npm install --legacy-peer-deps`
 3. Develop: `npm run dev:full`
-4. Test: `npm test` (all 2,055 tests must pass)
+4. Test: `npm test` and `npm run test:server` (all tests must pass — 3,321 across both suites)
 5. Lint: `npm run lint`
 6. Commit: `git commit -m "feat: description"` ([Conventional Commits](https://www.conventionalcommits.org/))
 7. Open a Pull Request

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Vercel serverless entrypoint for the Express API.
+ *
+ * `vercel.json` rewrites every `/api/*` request to this function. We import the
+ * already-built Express app (no port binding, no background workers — see
+ * `getServerlessApp`) and hand the raw Node request/response to it.
+ *
+ * Path normalization: depending on Vercel's rewrite handling the incoming
+ * `req.url` may arrive with or without the `/api` prefix. The Express app mounts
+ * its routers under `/api/*`, so we ensure the prefix is present exactly once.
+ *
+ * Typed with Node's `http` types (what Vercel passes) to avoid a hard dependency
+ * on `@vercel/node`; the Express application is callable with these directly.
+ */
+import type { IncomingMessage, ServerResponse } from 'http'
+import { getServerlessApp } from '../server/index'
+
+export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const app = await getServerlessApp()
+
+  if (req.url && !req.url.startsWith('/api/') && req.url !== '/api') {
+    req.url = '/api' + (req.url.startsWith('/') ? req.url : `/${req.url}`)
+  }
+
+  // The Express application instance is itself a (req, res) request listener.
+  ;(app as unknown as (req: IncomingMessage, res: ServerResponse) => void)(req, res)
+}

--- a/api/spark-fallback.ts
+++ b/api/spark-fallback.ts
@@ -1,0 +1,27 @@
+/**
+ * Graceful fallback for `@github/spark` runtime endpoints (`/_spark/*`).
+ *
+ * Spark's KV / LLM / user endpoints are served by the Spark dev plugin during
+ * local development only; they do not exist in a production deployment. The SPA
+ * already degrades gracefully (its `use-safe-kv` hook falls back to
+ * localStorage), but unhandled `/_spark/*` requests would otherwise return 404s
+ * and add console noise. This stub returns benign, empty 200 responses so the
+ * client's optional Spark calls resolve quietly.
+ *
+ * HONEST NOTE: this is a stub, not a Spark implementation. Real KV persistence
+ * and LLM features are NOT provided by the production backend — they are a
+ * development convenience. The product's actual data lives behind `/api/*`.
+ */
+import type { IncomingMessage, ServerResponse } from 'http'
+
+export default function handler(req: IncomingMessage, res: ServerResponse): void {
+  const url = req.url ?? ''
+  res.setHeader('Content-Type', 'application/json')
+  res.setHeader('X-Spark-Fallback', 'stub')
+
+  // `/_spark/user` is read as a value; everything else is treated as an empty
+  // key-value namespace. Always 200 so the SPA's optional calls don't error.
+  const body = url.includes('/_spark/user') ? 'null' : '{}'
+  res.statusCode = 200
+  res.end(body)
+}

--- a/apps/web/public/access.html
+++ b/apps/web/public/access.html
@@ -202,8 +202,8 @@
                 
                 <div class="access-card">
                     <div class="icon">🚀</div>
-                    <h2>Live Demo</h2>
-                    <p>Try the interactive platform sandbox with real data, AI agents, and all features fully functional.</p>
+                    <h2>Interactive Demo</h2>
+                    <p>Explore the platform UI with synthetic sample data. Live data collection, enrichment, and scoring require a configured backend and API credentials.</p>
                     <a href="/" class="btn btn-secondary">
                         🔗 Launch Demo
                     </a>
@@ -222,20 +222,20 @@
             
             <div class="stats">
                 <div class="stat">
-                    <span class="stat-value">526</span>
+                    <span class="stat-value">3,321</span>
                     <span class="stat-label">Automated Tests</span>
                 </div>
                 <div class="stat">
-                    <span class="stat-value">60+</span>
-                    <span class="stat-label">AI Agents</span>
+                    <span class="stat-value">4</span>
+                    <span class="stat-label">State Collectors (CA, TX, FL, NY)</span>
                 </div>
                 <div class="stat">
-                    <span class="stat-value">50</span>
-                    <span class="stat-label">States Covered</span>
+                    <span class="stat-value">8</span>
+                    <span class="stat-label">Enrichment Sources</span>
                 </div>
                 <div class="stat">
-                    <span class="stat-value">100%</span>
-                    <span class="stat-label">Test Coverage</span>
+                    <span class="stat-value">0</span>
+                    <span class="stat-label">Critical/High CVEs</span>
                 </div>
             </div>
         </div>

--- a/apps/web/src/lib/collectors/StateCollectorFactory.test.ts
+++ b/apps/web/src/lib/collectors/StateCollectorFactory.test.ts
@@ -48,8 +48,10 @@ describe('StateCollectorFactory', () => {
       expect(collector).toBeUndefined()
     })
 
-    it('should return undefined for states with no access methods', () => {
-      // NY has empty accessMethods array
+    it('should fail closed for credential-gated NY without seeds configured', () => {
+      // NY uses the portal scraper but is gated on NY_UCC_DEBTOR_SEEDS, which is
+      // not set in the test env, so the collector reports isReady()=false and the
+      // factory withholds it (mirrors the FL active-contract gate).
       const collector = factory.getCollector('NY')
       expect(collector).toBeUndefined()
     })
@@ -111,12 +113,12 @@ describe('StateCollectorFactory', () => {
     it('should list all implemented states including those needing config', () => {
       const implemented = factory.getImplementedStates()
 
-      // NY is intentionally excluded: it has empty accessMethods and no
-      // collector implementation, so getCollector('NY') returns undefined.
-      // Keeping it out of the implemented list keeps hasCollector()/
-      // getImplementedStates()/getCollector() consistent (no null-deref).
-      expect(implemented.length).toBe(3) // CA, TX, FL
-      expect(implemented).not.toContain('NY')
+      // CA, TX, FL, NY all have collector implementations. FL and NY are
+      // credential-gated (active contract / NY_UCC_DEBTOR_SEEDS) and fail closed
+      // when unconfigured, but they are still "implemented" — the collection
+      // code exists and is tested.
+      expect(implemented.length).toBe(4) // CA, TX, FL, NY
+      expect(implemented).toContain('NY')
       expect(implemented).toContain('CA')
       expect(implemented).toContain('TX')
       expect(implemented).toContain('FL')
@@ -217,18 +219,18 @@ describe('StateCollectorFactory', () => {
     it('should track implemented states', () => {
       const stats = factory.getStats()
 
-      expect(stats.implemented).toBe(3) // CA, TX, FL (NY has no collector)
+      expect(stats.implemented).toBe(4) // CA, TX, FL, NY
       expect(stats.implementedStates).toContain('CA')
       expect(stats.implementedStates).toContain('TX')
       expect(stats.implementedStates).toContain('FL')
-      expect(stats.implementedStates).not.toContain('NY')
+      expect(stats.implementedStates).toContain('NY')
     })
 
     it('should track pending states', () => {
       const stats = factory.getStats()
 
-      expect(stats.pending).toBe(48) // 51 - 3
-      expect(stats.pendingStates.length).toBe(48)
+      expect(stats.pending).toBe(47) // 51 - 4
+      expect(stats.pendingStates.length).toBe(47)
     })
   })
 
@@ -245,10 +247,10 @@ describe('StateCollectorFactory', () => {
       expect(config).toBeUndefined()
     })
 
-    it('should report NY has no access methods', () => {
+    it('should report NY uses the scrape access method', () => {
       const nyConfig = factory.getStateConfig('NY')
       expect(nyConfig).toBeDefined()
-      expect(nyConfig?.accessMethods).toHaveLength(0)
+      expect(nyConfig?.accessMethods).toContain('scrape')
     })
 
     it('should report FL requires vendor agreement', () => {

--- a/apps/web/src/lib/collectors/StateCollectorFactory.ts
+++ b/apps/web/src/lib/collectors/StateCollectorFactory.ts
@@ -15,6 +15,7 @@ import type { StateCollector } from './types'
 import { createCAApiCollector } from './state-collectors/CAApiCollector'
 import { createTXBulkCollector } from './state-collectors/TXBulkCollector'
 import { FLVendorCollector, createFLVendorCollector } from './state-collectors/FLVendorCollector'
+import { NYScraperCollector, createNYScraperCollector } from './state-collectors/NYScraperCollector'
 
 /**
  * Access method types for state data
@@ -140,7 +141,8 @@ const STATE_CONFIGS: Record<string, StateConfig> = {
   NY: {
     code: 'NY',
     name: 'New York',
-    accessMethods: [],
+    accessMethods: ['scrape'],
+    activeMethod: 'scrape',
     hasApi: false,
     hasBulk: false,
     requiresVendor: false,
@@ -150,7 +152,12 @@ const STATE_CONFIGS: Record<string, StateConfig> = {
       vendor: null,
       scrape: 0
     },
-    notes: 'NY portal ingestion is not wired to a production collector yet'
+    notes:
+      'NY DOS UCC public portal scraper. Credential-gated like FL: set ' +
+      'NY_UCC_DEBTOR_SEEDS (comma-separated debtor names) to activate; otherwise ' +
+      'the collector reports isReady()=false and is withheld (fail-closed). The ' +
+      'portal has no bulk/date-windowed query, so collection is seed-enumeration ' +
+      'based. Live-portal extraction is implemented but pending production verification.'
   }
 }
 
@@ -320,11 +327,26 @@ export class StateCollectorFactory {
   }
 
   /**
-   * Create scraper-based collector
+   * Create scraper-based collector.
+   *
+   * Mirrors the FL vendor gate: the collector is only returned when it reports
+   * isReady() (i.e. its required configuration is present), so an unconfigured
+   * state fails closed via getCollector() returning undefined rather than
+   * running an empty/fabricated collection.
    */
   private createScraperCollector(stateCode: string): StateCollector | undefined {
-    void stateCode
-    return undefined
+    switch (stateCode) {
+      case 'NY': {
+        const collector = createNYScraperCollector()
+        // Only expose NY once debtor seeds are configured (NY_UCC_DEBTOR_SEEDS).
+        if (collector && (collector as NYScraperCollector).isReady()) {
+          return collector
+        }
+        return undefined
+      }
+      default:
+        return undefined
+    }
   }
 
   /**
@@ -513,12 +535,12 @@ export class StateCollectorFactory {
   /**
    * Check if a state has an implemented collector.
    *
-   * This is kept consistent with getImplementedStates(): a state is only
-   * reported as having a collector if a concrete collector implementation
-   * exists for it. NY is intentionally excluded — it has empty accessMethods
-   * and no collector factory case, so getCollector('NY') returns undefined.
-   * Previously hasCollector('NY') returned true while getCollector('NY')
-   * returned undefined, which could lead callers into a null dereference.
+   * This reports whether a concrete collector implementation exists for a state
+   * (CA, TX, FL, NY). Like FL, a credential-gated state can be "implemented" yet
+   * still have getCollector() return undefined when its configuration is absent
+   * (FL: contract inactive; NY: NY_UCC_DEBTOR_SEEDS unset). Callers that
+   * materialise collectors go through getCollectors(), which skips undefined
+   * results, so the gated-but-implemented state never causes a null dereference.
    */
   hasCollector(stateCode: string): boolean {
     const normalizedCode = stateCode.toUpperCase()
@@ -528,16 +550,18 @@ export class StateCollectorFactory {
   /**
    * Get list of states with implemented collectors.
    *
-   * Only includes states that have an actual collector implementation wired up
-   * via createCollectorForMethod(). NY is excluded until its portal collector
-   * is implemented (its STATE_CONFIG has empty accessMethods), so that
-   * hasCollector()/getImplementedStates()/getCollector() all agree.
+   * Includes every state that has an actual collector implementation wired up
+   * via createCollectorForMethod(). Some entries are credential-gated and will
+   * only yield a live collector once configured: FL needs an active vendor
+   * contract, NY needs NY_UCC_DEBTOR_SEEDS. They are still "implemented" — the
+   * collection code exists and is tested — but fail closed when unconfigured.
    */
   getImplementedStates(): string[] {
     return [
-      'CA', // California - API
-      'TX', // Texas - Bulk
-      'FL' // Florida - Vendor (requires contract)
+      'CA', // California - API (CA_SOS_API_KEY)
+      'TX', // Texas - Bulk (TX_SOSDIRECT_API_KEY + account)
+      'FL', // Florida - Vendor (requires active contract)
+      'NY' // New York - Portal scraper (requires NY_UCC_DEBTOR_SEEDS)
     ]
   }
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -7,6 +7,55 @@ import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
+// jsdom 27 + vitest 4 no longer expose window.localStorage / sessionStorage
+// when the document runs under an opaque origin (the default). Code under test
+// (e.g. the agentic-engine hook) relies on the Web Storage API, so provide a
+// spec-compliant in-memory implementation when the real one is unavailable.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value))
+  }
+}
+
+for (const area of ['localStorage', 'sessionStorage'] as const) {
+  const existing = (() => {
+    try {
+      return window[area]
+    } catch {
+      return undefined
+    }
+  })()
+  if (!existing || typeof existing.clear !== 'function') {
+    Object.defineProperty(window, area, {
+      configurable: true,
+      writable: true,
+      value: new MemoryStorage()
+    })
+  }
+}
+
 // Mock window.matchMedia for useIsMobile hook
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,9 +11,16 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Pin discovery to this app's own root and source tree. Without this, a
+    // root-level `vitest` invocation lets the default `**/*.{test,spec}` glob
+    // escape into sibling workspaces (notably the node-environment server
+    // suite), producing spurious failures. Keep the web run hermetic.
+    root: __dirname,
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     setupFiles: [resolve(__dirname, 'src/test/setup.ts')],
     exclude: [
       'node_modules/**',
+      'dist/**',
       '**/tests/e2e/**' // Playwright E2E tests are run separately
     ],
     coverage: {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,9 +1,100 @@
-# Deployment Gate
+# Deployment — Real Backend on Vercel (serverless)
+
+This guide stands up a **real** backend for the hosted app. Previously the Vercel
+deployment served only the static SPA, so every `/api/*` and `/_spark/*` request
+returned 404. The repo now ships Vercel serverless functions that run the actual
+Express API.
+
+## What's wired
+
+| File                    | Role                                                                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `api/index.ts`          | Vercel function that forwards every `/api/*` request to the Express app (`getServerlessApp()` in `server/index.ts`). No port binding, no background workers. |
+| `api/spark-fallback.ts` | Benign 200 stub for `@github/spark` `/_spark/*` calls (dev-only endpoints).                                                                                  |
+| `vercel.json`           | Builds the SPA to `dist/`, routes `/api/*` → the API function, `/_spark/*` → the fallback, and everything else → the SPA (`index.html`).                     |
+
+`getServerlessApp()` makes a single best-effort database connection per warm
+container when `DATABASE_URL` is set; it does **not** start the BullMQ workers or
+the cron scheduler (those run in a separate long-lived process — see below).
+
+## Honest constraints (read before deploying)
+
+- **The API code runs, but DB-backed routes need a database.** Without
+  `DATABASE_URL`, routes like `/api/prospects` fail closed (controlled error),
+  not silently. Stateless routes (`/api/health/live`, docs) work with no env.
+- **Background work is not serverless.** UCC ingestion, enrichment, and digests
+  run on BullMQ workers (`server/worker.ts`) that need Redis and a persistent
+  host. A Vercel function cannot run them. Deploy the worker separately
+  (Render/Fly/a small VM) pointed at the same Postgres + Redis.
+- **This was verified locally, not deployed.** `server/__tests__/serverlessApp.test.ts`
+  proves the function serves `/api/health/live` (200), guards `/api/prospects`
+  (401, not 404), returns the API's own 404 for unknown paths, forwards through
+  `api/index.ts`, and that the Spark fallback returns 200. A live deployment
+  additionally requires your Vercel project + the secrets below.
+
+## Required environment variables (set in the Vercel dashboard)
+
+Minimum for an authenticated, data-backed API:
+
+```
+JWT_SECRET=<32+ char secret>          # required in every environment
+DATABASE_URL=postgresql://user:pass@host:5432/db
+NODE_ENV=production
+```
+
+Optional (enable when you have them — all fail closed if unset):
+
+```
+# Background worker host (NOT the Vercel function):
+REDIS_URL=redis://host:6379
+
+# Commercial enrichment (key-gated, fail-closed):
+SAM_GOV_API_KEY=...                   # free api.data.gov key
+DNB_API_KEY=...
+CLEARBIT_API_KEY=...
+ZOOMINFO_API_KEY=...
+
+# State collection (fail-closed if unset):
+CA_SOS_API_KEY=...                    # California
+TX_SOSDIRECT_API_KEY=...              # Texas (+ account id)
+NY_UCC_DEBTOR_SEEDS=Acme Corp,Example LLC   # New York portal scraper
+```
+
+See `.env.example` for the full list.
+
+## Deploy steps
+
+1. `vercel link` (or import the repo in the Vercel dashboard).
+2. Add the environment variables above (Project → Settings → Environment Variables).
+3. Provision Postgres (e.g. Neon/Supabase/RDS) and run the migrations in
+   `server/database/migrations` against it. See the **Production deployment gate**
+   below for the migration/RLS sequence the security hardening requires.
+4. Deploy. `vercel.json`'s `buildCommand` builds the SPA; Vercel builds the
+   `api/*` functions automatically.
+5. Deploy the **worker** separately (`npm run build:server && node dist/worker.cjs`
+   or `tsx server/worker.ts`) on a host with Redis access, using the same
+   `DATABASE_URL` / `REDIS_URL`.
+
+## Local verification
+
+```bash
+# Unit-level proof the serverless app is wired (no DB needed):
+npm run test:server -- serverlessApp
+
+# Full local stack (API + workers + DB + Redis) for a true end-to-end demo:
+#   1. start Postgres + Redis
+#   2. set DATABASE_URL / REDIS_URL / JWT_SECRET
+#   3. npm run dev   (or build:all then run dist/server.cjs + dist/worker.cjs)
+```
+
+---
+
+## Production deployment gate (security prerequisites)
 
 This checklist covers the security-hardening prerequisites from PR #234 / issue #235.
 Run it before promoting a production deploy.
 
-## Required Sequence
+### Required sequence
 
 1. Provision production secrets in the deployment secret store:
    - `JWT_SECRET`
@@ -42,7 +133,7 @@ Run it before promoting a production deploy.
    `DEPLOY_PREREQ_ACCESS_TOKEN` containing a representative access token; the
    verifier decodes it and checks for an `org_id`/`orgId` claim shape.
 
-## Notes
+### Notes
 
 - `PLAID_WEBHOOK_SECRET` is intentionally not required. Plaid webhooks are
   verified with ES256 JWT signatures by fetching JWKs through `PLAID_CLIENT_ID`

--- a/docs/DEPLOYMENT_READY.md
+++ b/docs/DEPLOYMENT_READY.md
@@ -68,7 +68,7 @@ Direct prominent links at the top of README.md:
 - Embedded HTML5 video player
 - Direct download button
 - Live demo launch button
-- Platform statistics display (526 tests, 60+ AI agents, 50 states, 100% coverage)
+- Platform statistics display (3,321 tests, 4 state collectors, 8 enrichment sources, 0 critical/high CVEs)
 - Professional gradient design
 - Fully responsive layout
 
@@ -90,22 +90,22 @@ README.md                          # Updated with prominent links
 
 ### 4. Access Points Summary
 
-| Location      | Type            | Link/Path                                          |
-| ------------- | --------------- | -------------------------------------------------- |
-| README Header | Direct Link     | `./public/videos/EXECUTIVE_VIDEO_SCRIPT.mp4`       |
-| README Header | Live Demo       | `https://public-record-data-scrapper.vercel.app`   |
-| In-App Banner | Download Button | `/public/videos/EXECUTIVE_VIDEO_SCRIPT.mp4`        |
-| In-App Banner | Access Page     | `/access.html`                                     |
-| Access Page   | Video Player    | Embedded with `/videos/EXECUTIVE_VIDEO_SCRIPT.mp4` |
-| Access Page   | Demo Button     | `/` (main app)                                     |
+| Location      | Type            | Link/Path                                                                                                                                  |
+| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| README Header | Direct Link     | `./public/videos/EXECUTIVE_VIDEO_SCRIPT.mp4`                                                                                               |
+| README Header | SPA Demo        | `https://public-record-data-scrapper.vercel.app` (UI + synthetic data; real `/api` backend requires deployment — see `docs/DEPLOYMENT.md`) |
+| In-App Banner | Download Button | `/public/videos/EXECUTIVE_VIDEO_SCRIPT.mp4`                                                                                                |
+| In-App Banner | Access Page     | `/access.html`                                                                                                                             |
+| Access Page   | Video Player    | Embedded with `/videos/EXECUTIVE_VIDEO_SCRIPT.mp4`                                                                                         |
+| Access Page   | Demo Button     | `/` (main app)                                                                                                                             |
 
 ### 5. Deployment Status
 
 - ✅ Video file committed (4.1 MB)
 - ✅ All UI components created
 - ✅ README updated
-- ✅ Build successful (9.2s)
-- ✅ Zero vulnerabilities
+- ✅ Build successful (web + server bundle)
+- ✅ 0 critical / 0 high dependency vulnerabilities (17 moderate remain, confined to the Expo/React-Native mobile toolchain — see evidence ledger)
 - ✅ No lint errors
 - ✅ Type-safe components
 - ✅ Ready for auto-deployment via Vercel

--- a/docs/REMEDIATION.md
+++ b/docs/REMEDIATION.md
@@ -1,0 +1,128 @@
+# Remediation Report — Full Heal of Audit Findings
+
+This documents the code-level remediation of the six defects surfaced by the
+α→ω inspection. Every claim below is reproducible with the listed command. No
+data sources, customers, or compliance posture were invented; where a real fix
+required credentials we don't have, the implementation is **key-gated and
+fail-closed** and labeled as such.
+
+Verification baseline (run from repo root):
+
+```bash
+npm test                                         # web   → 2,005 passing / 83 files
+npm run test:server                              # server → 1,316 passing / 73 files (+6 skipped)
+npm run build && npm run build:server            # web SPA + server bundle
+npm audit                                        # 0 critical / 0 high (17 moderate, mobile-only)
+```
+
+Totals: **3,321 tests across 156 files, zero failures; 0 critical / 0 high CVEs.**
+
+---
+
+## 1. Test suite — config-glob bug + jsdom regression → green & truthfully counted
+
+**Was:** the standard web run exited 1 (231 failures): `apps/web/vitest.config.ts`
+had no `include`/`root`, so a root-level run swept the node-environment server
+suite into jsdom; and 21 `use-agentic-engine` tests threw in `beforeEach`
+because jsdom 27 + vitest 4 no longer expose `window.localStorage`. The
+"2,055 tests / 91 files" badge was inaccurate.
+
+**Fix:**
+
+- `apps/web/vitest.config.ts` — added `root: __dirname` + `include: ['src/**/*.{test,spec}.{ts,tsx}']`.
+- `apps/web/src/test/setup.ts` — added a spec-compliant `MemoryStorage` polyfill installed for `localStorage`/`sessionStorage` when absent.
+- README badge + testing section corrected to the real, reproducible counts.
+
+**Evidence:** `npm test` → 2,005 passing / 0 failing; `npm run test:server` → 1,316 passing.
+
+## 2. Dependencies — 5 critical + 8 high → 0 critical / 0 high
+
+**Fix:**
+
+- `npm audit fix` (non-breaking) for the simple advisories (axios, ws, form-data, minimatch, vitest, tsx, vite, …).
+- `concurrently` bumped `^9 → ^10.0.3` (dev tool) to clear the `shell-quote` critical.
+- `overrides.esbuild = "0.28.1"` to force vite's transitive esbuild off the vulnerable `<0.28.1` range.
+
+**Evidence:** `npm audit` → `critical=0 high=0`. The remaining **17 moderate** are
+confined to the `apps/mobile` Expo/React-Native toolchain and require major
+framework upgrades (expo 56 / react-native 0.86) — a separate migration, called
+out here rather than forced.
+
+## 3. State coverage — NY re-enabled; "50 states" corrected to the real 4
+
+**Was:** NY was disabled in `apps/web/src/lib/collectors/StateCollectorFactory.ts`
+(empty `accessMethods`, stub `createScraperCollector`, excluded from
+`getImplementedStates()`) even though a real NY portal scraper + collector +
+worker case + strategy profile already existed.
+
+**Fix:** wired NY in the factory (registers `createNYScraperCollector`, FL-style
+`isReady()` gate on `NY_UCC_DEBTOR_SEEDS`, added to `getImplementedStates()`),
+updated the factory tests, and corrected every "50 states / 60+ agents" overclaim
+in `README.md`, `DEPLOYMENT_READY.md`, and `apps/web/public/access.html` to the
+real **4 implemented collectors (CA, TX, FL, NY)** with FL/NY credential-gated.
+
+**Evidence:** `StateCollectorFactory.test.ts` (43 tests) asserts NY is implemented
+and fail-closed without seeds.
+
+## 4. Scoring — added a real, trainable ML model (honestly labeled); rules stay default
+
+**Was:** "ML-based scoring" was a rules engine with zero ML.
+
+**Fix:** added a genuine, dependency-free logistic-regression model
+(`server/services/MLScoringModel.ts`) trained by gradient descent on binary
+cross-entropy, a domain strategy (`server/services/MLScoringStrategy.ts`) with a
+reproducible synthetic dataset, a training script (`npm run train:ml-model`), and
+a committed weights artifact (`server/models/ml-scoring-weights.json`). It is
+wired into `ScoringService.scoreProspect` as an **opt-in** supplement
+(`includeMl`), computed from the same fetched signals.
+
+**Honesty:** the model is trained on **synthetic seed data**, returns low
+confidence (0.3) and an explicit warning, and the **transparent rules-based
+composite remains the authoritative score**. README relabeled accordingly.
+
+**Evidence:** `MLScoringModel.test.ts` (7 tests) proves it learns a separable
+pattern (~95% train accuracy), round-trips weights, and ranks a strong prospect
+above a weak one.
+
+## 5. Enrichment — SAM.gov + D&B/Clearbit/ZoomInfo wired, fail-closed & key-gated
+
+**Was:** these were env stubs, not wired into the enrichment pipeline.
+
+**Fix:** updated `SAMGovSource` to use `SAM_GOV_API_KEY`; added real adapters
+`DnBSource` / `ClearbitSource` / `ZoomInfoSource`
+(`packages/core/src/enrichment/commercial-tier.ts`) following the existing
+`BaseDataSource` contract; registered them in
+`server/services/EnrichmentService.ts` so a source is queried **only when its key
+is configured** (unconfigured sources are skipped, never dragging confidence
+down). Each makes a real HTTP request when keyed and returns a **named error,
+never fabricated data**, when unkeyed or on failure.
+
+**Honesty:** the commercial adapters follow each vendor's published REST shape
+but cannot be end-to-end verified without paid accounts; this is stated in-code
+and they fail closed by default.
+
+**Evidence:** `commercialSources.test.ts` (8 tests) — fail-closed when unkeyed,
+correct mapping when keyed; `EnrichmentService.test.ts` (15 tests) — a configured
+keyed source is queried and contributes; unconfigured sources don't affect
+confidence.
+
+## 6. Live backend — real serverless `/api` + Spark fallback (was: every path 404)
+
+**Was:** the Vercel deployment served only the static SPA; every `/api/*` and
+`/_spark/*` returned 404.
+
+**Fix:**
+
+- `server/index.ts` exports `getServerlessApp()` (builds the Express app, best-effort DB connect, no port/worker/cron).
+- `api/index.ts` — Vercel function forwarding `/api/*` to the app (path-normalized).
+- `api/spark-fallback.ts` — benign 200 stub for `/_spark/*`.
+- `vercel.json` — routes `/api/*` → the function, `/_spark/*` → the fallback, everything else → the SPA; `outputDirectory: apps/web/dist` (the real build output).
+- `docs/DEPLOYMENT.md` — honest deploy guide (DB/Redis/secrets required; workers run separately).
+
+**Honesty:** verified **locally**, not deployed — a live deployment additionally
+needs the owner's Vercel project + Postgres/Redis + secrets. DB-backed routes
+fail closed without `DATABASE_URL`.
+
+**Evidence:** `server/__tests__/serverlessApp.test.ts` (5 tests) — `/api/health/live`
+→ 200, `/api/prospects` → 401 (guarded, not 404), unknown `/api/*` → Express 404
+JSON, the `api/index` entrypoint forwards, and the Spark fallback returns 200.

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "@vitest/ui": "^4.0.8",
         "axios": "^1.16.0",
         "cheerio": "^1.1.2",
-        "concurrently": "^9.2.1",
+        "concurrently": "^10.0.3",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
-      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.2.tgz",
+      "integrity": "sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -385,12 +385,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -399,29 +399,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -438,13 +438,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -454,25 +454,25 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -482,17 +482,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -503,12 +503,12 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
-      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
         "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-      "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -545,40 +545,40 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -588,35 +588,35 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-wrap-function": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -626,14 +626,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -643,13 +643,13 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -674,36 +674,36 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
-      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -796,12 +796,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -811,14 +811,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
-      "integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-syntax-decorators": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -828,12 +828,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.27.1.tgz",
-      "integrity": "sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.29.7.tgz",
+      "integrity": "sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -843,12 +843,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
-      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -870,12 +870,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.28.6.tgz",
-      "integrity": "sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.29.7.tgz",
+      "integrity": "sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -885,12 +885,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
-      "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -900,12 +900,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -939,12 +939,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -954,12 +954,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -969,14 +969,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
-      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -985,91 +985,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/generator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
-      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1079,12 +1003,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
-      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1094,13 +1018,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
-      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1110,13 +1034,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
-      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1126,17 +1050,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
-      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1146,13 +1070,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
-      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/template": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/template": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1162,13 +1086,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1178,12 +1102,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1193,13 +1117,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
-      "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+      "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-flow": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-flow": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1209,13 +1133,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1225,14 +1149,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1242,12 +1166,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1257,12 +1181,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
-      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1272,13 +1196,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1288,13 +1212,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
-      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1304,12 +1228,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
-      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1319,12 +1243,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
-      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1334,16 +1258,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
-      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1353,12 +1277,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
-      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1368,13 +1292,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
-      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1384,12 +1308,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1399,13 +1323,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
-      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1415,14 +1339,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
-      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1432,12 +1356,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
-      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1447,16 +1371,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
-      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-syntax-jsx": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1466,12 +1390,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
-      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.27.1"
+        "@babel/plugin-transform-react-jsx": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1511,13 +1435,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
-      "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1527,12 +1451,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
-      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1542,13 +1466,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
-      "integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
+      "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
         "babel-plugin-polyfill-corejs2": "^0.4.14",
         "babel-plugin-polyfill-corejs3": "^0.13.0",
         "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -1562,12 +1486,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1577,13 +1501,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
-      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1593,12 +1517,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1608,16 +1532,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
-      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1627,13 +1551,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1643,17 +1567,17 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
-      "integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-transform-react-display-name": "^7.28.0",
-        "@babel/plugin-transform-react-jsx": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
-        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-react-display-name": "^7.29.7",
+        "@babel/plugin-transform-react-jsx": "^7.29.7",
+        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1663,16 +1587,16 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
-      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-typescript": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1691,31 +1615,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1800,13 +1724,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1981,9 +1905,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1997,9 +1921,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -2013,9 +1937,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -2029,9 +1953,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -2045,9 +1969,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -2061,9 +1985,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -2077,9 +2001,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -2093,9 +2017,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -2109,9 +2033,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -2125,9 +2049,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -2141,9 +2065,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -2157,9 +2081,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -2173,9 +2097,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2189,9 +2113,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2205,9 +2129,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2221,9 +2145,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -2237,9 +2161,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -2253,9 +2177,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -2269,9 +2193,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -2285,9 +2209,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2301,9 +2225,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -2317,9 +2241,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -2333,9 +2257,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -2349,9 +2273,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -2365,9 +2289,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -2381,9 +2305,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2623,6 +2547,25 @@
         "xml2js": "0.6.0"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2664,9 +2607,9 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2700,9 +2643,9 @@
       }
     },
     "node_modules/@expo/config/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2783,9 +2726,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
-      "integrity": "sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.11.tgz",
+      "integrity": "sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -2839,9 +2782,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-      "integrity": "sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+      "integrity": "sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -2851,7 +2794,7 @@
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^10.2.2",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
@@ -2875,13 +2818,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@expo/fingerprint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/chalk": {
@@ -2901,15 +2856,15 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2925,9 +2880,9 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2937,21 +2892,18 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.8.tgz",
-      "integrity": "sha512-HHHaG4J4nKjTtVa1GG9PCh763xlETScfEyNxxOvfTRr8IKPJckjTyqSLEtdJoFNJ1vqiABEjW7tqGhqGibZLeA==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.14.tgz",
+      "integrity": "sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0",
-        "semver": "^7.6.0",
-        "temp-dir": "~2.0.0",
-        "unique-string": "~2.0.0"
+        "semver": "^7.6.0"
       }
     },
     "node_modules/@expo/image-utils/node_modules/ansi-styles": {
@@ -2985,19 +2937,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@expo/image-utils/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@expo/image-utils/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3007,22 +2950,13 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
-      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
+        "@babel/code-frame": "^7.20.0",
         "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/metro": {
@@ -3048,9 +2982,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-      "integrity": "sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==",
+      "version": "54.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3058,7 +2992,7 @@
         "@babel/generator": "^7.20.5",
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.8",
+        "@expo/json-file": "~10.0.16",
         "@expo/metro": "~54.2.0",
         "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
@@ -3071,7 +3005,7 @@
         "hermes-parser": "^0.29.1",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "^1.30.1",
-        "minimatch": "^9.0.0",
+        "picomatch": "^4.0.3",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
       },
@@ -3082,6 +3016,25 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/metro-config/node_modules/ansi-styles": {
@@ -3097,15 +3050,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@expo/metro-config/node_modules/chalk": {
@@ -3151,19 +3095,16 @@
         "hermes-estree": "0.29.1"
       }
     },
-    "node_modules/@expo/metro-config/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/metro-config/node_modules/postcss": {
@@ -3204,26 +3145,25 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.8.tgz",
-      "integrity": "sha512-/TuOZvSG7Nn0I8c+FcEaoHeBO07yu6vwDgk7rZVvAXoeAK5rkA09jRyjYsZo+0tMEFaToBeywA6pj50Mb3ny9w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
+      "integrity": "sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "exec-async": "^2.2.0"
+        "@expo/spawn-async": "^1.8.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.9.10.tgz",
-      "integrity": "sha512-axJm+NOj3jVxep49va/+L3KkF3YW/dkV+RwzqUJedZrv4LeTqOG4rhrCaCPXHTvLqCTDKu6j0Xyd28N7mnxsGA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.12.1.tgz",
+      "integrity": "sha512-fQLiFAcFRWF53mtuLK32SUJQ1ahhrTcBZPZPedYTiUT5ha5FF+UO6bPtCc0Y/hgj0/m3HCGBAuSHjbg2kI9oPQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.0.8",
-        "@expo/spawn-async": "^1.7.2",
+        "@expo/json-file": "^10.2.0",
+        "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
@@ -3473,9 +3413,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -3514,15 +3454,34 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@expo/require-utils": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.5.tgz",
+      "integrity": "sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@expo/schema-utils": {
@@ -3538,12 +3497,12 @@
       "license": "MIT"
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.3"
+        "cross-spawn": "^7.0.6"
       },
       "engines": {
         "node": ">=12"
@@ -3573,9 +3532,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.0.tgz",
-      "integrity": "sha512-o2qDlTqJ606h4xR36H2zWTywmZ3v3842K6TU8Ik2n1mfW0S580VHlt3eItVYdLYz+klaPp7CXqanja8eASZjRw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3744,31 +3703,10 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
-      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -3907,9 +3845,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -3920,9 +3858,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -3933,9 +3871,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -3946,9 +3884,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -3959,9 +3897,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -3972,9 +3910,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -7221,9 +7159,9 @@
       }
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -7326,6 +7264,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7339,6 +7278,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7352,6 +7292,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7365,6 +7306,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7378,6 +7320,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7391,6 +7334,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7404,6 +7348,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7417,6 +7362,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7430,6 +7376,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7443,6 +7390,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7456,6 +7404,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7469,6 +7418,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7482,6 +7432,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7495,6 +7446,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7508,6 +7460,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7521,6 +7474,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7534,6 +7488,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7547,6 +7502,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7560,6 +7516,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7573,6 +7530,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7586,6 +7544,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7599,6 +7558,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7612,6 +7572,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7625,6 +7586,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7638,6 +7600,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8786,6 +8749,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -8924,7 +8888,7 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8934,7 +8898,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9246,13 +9210,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9391,29 +9355,29 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -9422,31 +9386,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -9455,7 +9419,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -9467,26 +9431,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -9494,13 +9458,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -9509,9 +9474,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9519,36 +9484,37 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
-      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.9.tgz",
+      "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "pathe": "^2.0.3",
         "sirv": "^3.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.0.18"
+        "vitest": "4.1.9"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -9757,21 +9723,21 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9803,7 +9769,35 @@
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
@@ -9831,13 +9825,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-      "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -9858,12 +9852,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-      "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.6"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -9918,9 +9912,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-      "integrity": "sha512-wTt7POavLFypLcPW/uC5v8y+mtQKDJiyGLzYCjqr9tx0Qc3vCXcDKk1iCFIj/++Iy5CWhhTflEa7VvVPNWeCfw==",
+      "version": "54.0.11",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
+      "integrity": "sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -10087,12 +10081,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
-      "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -10254,9 +10251,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10273,11 +10270,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -10341,43 +10338,40 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.67.1",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.67.1.tgz",
-      "integrity": "sha512-ELJEAzwzesgFxk29emvnAakqrwdBEhEyfZREPQ8pbG4ALVz/mk/AhfuChzxkFpJ7SfL2qclPHbiUGBZzaqcLvg==",
+      "version": "5.78.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.78.1.tgz",
+      "integrity": "sha512-zD5IT+qMqbMgPFPdL9FwnZka1bz6nckM+5lXj4N0vsXqdzoVO6wizmXpwsg/4GnHmXJsL7XOKeWA64tYUdPrOA==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
-        "ioredis": "5.9.2",
-        "msgpackr": "1.11.5",
+        "ioredis": "5.10.1",
+        "msgpackr": "2.0.2",
         "node-abort-controller": "3.1.1",
-        "semver": "7.7.3",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0"
+        "semver": "7.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/bullmq/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/bullmq/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/bytes": {
@@ -10440,9 +10434,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001766",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10966,190 +10960,109 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/concurrently/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/concurrently/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
-    "node_modules/concurrently/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/concurrently/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/concurrently/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/concurrently/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/concurrently/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/connect": {
@@ -11284,9 +11197,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1"
@@ -11363,15 +11276,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/css-select": {
@@ -11455,7 +11359,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -12252,9 +12156,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.279",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
-      "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
+      "version": "1.5.373",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -12436,9 +12340,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12481,9 +12385,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12493,32 +12397,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -12856,12 +12760,6 @@
         "bare-events": "^2.7.0"
       }
     },
-    "node_modules/exec-async": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
-      "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -12873,29 +12771,29 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.33",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
-      "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "version": "54.0.35",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
+      "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.23",
+        "@expo/cli": "54.0.25",
         "@expo/config": "~12.0.13",
         "@expo/config-plugins": "~54.0.4",
         "@expo/devtools": "0.1.8",
-        "@expo/fingerprint": "0.15.4",
+        "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.14",
+        "@expo/metro-config": "54.0.16",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.10",
-        "expo-asset": "~12.0.12",
+        "babel-preset-expo": "~54.0.11",
+        "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
-        "expo-file-system": "~19.0.21",
-        "expo-font": "~14.0.11",
+        "expo-file-system": "~19.0.23",
+        "expo-font": "~14.0.12",
         "expo-keep-awake": "~15.0.8",
-        "expo-modules-autolinking": "3.0.24",
-        "expo-modules-core": "3.0.29",
+        "expo-modules-autolinking": "3.0.26",
+        "expo-modules-core": "3.0.30",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -12925,13 +12823,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
+        "expo-constants": "~18.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -12954,9 +12852,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "19.0.23",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
+      "integrity": "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -12964,9 +12862,9 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
+      "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
@@ -12988,9 +12886,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-      "integrity": "sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==",
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
+      "integrity": "sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -13053,9 +12951,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.29",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-      "integrity": "sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+      "integrity": "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -13066,9 +12964,9 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-      "integrity": "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
+      "integrity": "sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
@@ -13088,9 +12986,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.23",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
-      "integrity": "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==",
+      "version": "54.0.25",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
+      "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -13100,12 +12998,12 @@
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.0.8",
         "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.16",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.14",
+        "@expo/metro-config": "~54.0.16",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
-        "@expo/plist": "^0.4.8",
+        "@expo/plist": "^0.4.9",
         "@expo/prebuild-config": "^54.0.8",
         "@expo/schema-utils": "^0.1.8",
         "@expo/spawn-async": "^1.7.2",
@@ -13125,16 +13023,16 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.5",
+        "expo-server": "^1.0.7",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "lan-network": "^0.1.6",
+        "lan-network": "^0.2.1",
         "minimatch": "^9.0.0",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
+        "picomatch": "^4.0.3",
         "pretty-bytes": "^5.6.0",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
@@ -13197,9 +13095,9 @@
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13398,12 +13296,12 @@
       }
     },
     "node_modules/expo/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -13498,12 +13396,12 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -13561,9 +13459,9 @@
       }
     },
     "node_modules/expo/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14386,18 +14284,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/get-uri": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -14422,17 +14308,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -14451,31 +14337,40 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/globals": {
@@ -14877,12 +14772,12 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
-      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.0",
+        "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",
@@ -14931,12 +14826,12 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15594,9 +15489,9 @@
       "license": "MIT"
     },
     "node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -16214,14 +16109,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -16821,9 +16716,9 @@
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -16951,9 +16846,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -16972,10 +16867,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -17064,18 +16959,18 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
-      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+      "integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17086,12 +16981,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/mz": {
@@ -17119,9 +17014,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -17214,10 +17109,13 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
@@ -17235,9 +17133,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17680,25 +17578,25 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -17889,17 +17787,26 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/pngjs": {
@@ -17912,9 +17819,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17931,7 +17839,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18440,9 +18348,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -18993,6 +18901,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19219,9 +19128,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -19277,11 +19186,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -19303,27 +19213,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve-workspace-root": {
@@ -19411,6 +19300,7 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -19519,9 +19409,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -19673,9 +19563,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19847,9 +19737,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -19996,9 +19886,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -20363,15 +20253,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -20556,9 +20437,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20702,13 +20583,12 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -20809,7 +20689,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -20897,18 +20777,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/universal-github-app-jwt": {
@@ -21118,6 +20986,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -21192,6 +21061,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -21209,6 +21079,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -21223,6 +21094,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -21232,31 +21104,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -21272,12 +21144,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -21298,6 +21173,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -21306,6 +21187,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -21524,9 +21408,9 @@
       }
     },
     "node_modules/wonka": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
-      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
     },
     "node_modules/word-wrap": {
@@ -21602,9 +21486,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -21639,6 +21523,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
       "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:scrapers:ny": "tsx scripts/scrapers/test-scrapers.ts NY",
     "test:scrapers:headed": "tsx scripts/scrapers/test-scrapers.ts --headed",
     "postinstall": "node ./scripts/ensure-main-branch.mjs",
+    "train:ml-model": "tsx scripts/trainMLModel.ts",
     "scrape": "tsx scripts/cli-scraper.ts",
     "scrape:scheduled": "tsx scripts/scheduled-run.ts",
     "migrate": "npm run db:migrate",
@@ -166,7 +167,7 @@
     "@vitest/ui": "^4.0.8",
     "axios": "^1.16.0",
     "cheerio": "^1.1.2",
-    "concurrently": "^9.2.1",
+    "concurrently": "^10.0.3",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -202,6 +203,7 @@
   "overrides": {
     "localtunnel": {
       "axios": "^1.7.4"
-    }
+    },
+    "esbuild": "0.28.1"
   }
 }

--- a/packages/core/src/enrichment/commercial-tier.ts
+++ b/packages/core/src/enrichment/commercial-tier.ts
@@ -1,0 +1,244 @@
+/**
+ * Commercial Tier Data Sources (shared)
+ *
+ * Key-gated adapters for paid commercial enrichment providers:
+ * - D&B (Dun & Bradstreet) — business credit / firmographics
+ * - Clearbit — company firmographics / tech stack
+ * - ZoomInfo — company intelligence (revenue / headcount)
+ *
+ * Each adapter is FAIL-CLOSED: with no credential configured it returns a named
+ * "not configured" error (never fabricated data) and `isConfigured()` is false,
+ * so the EnrichmentService skips it entirely. With a credential present it issues
+ * a real HTTP request to the provider and returns a named error on any non-2xx.
+ *
+ * HONESTY NOTE: the request/response shapes below follow each vendor's published
+ * REST API but cannot be end-to-end verified here without a paid account. They
+ * are wired and fail-closed; the exact field mapping should be confirmed against
+ * the customer's specific contract/product tier before relying on the values.
+ * No field is invented — anything the provider omits is returned as null.
+ *
+ * Framework-free (plain `fetch`); runs in apps/web and the Express server.
+ */
+
+import { BaseDataSource, DataSourceResponse } from './base-source'
+import { readEnv, notConfiguredResponse } from './credentials'
+
+/**
+ * D&B (Dun & Bradstreet) Direct+ API — business credit & firmographics.
+ *
+ * Auth: OAuth bearer token (`DNB_API_KEY`). Real deployments exchange a
+ * client_id/secret for a short-lived token; we accept a pre-issued token here so
+ * the adapter stays stateless and fail-closed.
+ */
+export class DnBSource extends BaseDataSource {
+  private readonly apiKey: string
+
+  constructor(apiKey?: string) {
+    super({
+      name: 'dnb',
+      tier: 'starter',
+      cost: 0.5,
+      timeout: 15000,
+      retryAttempts: 2,
+      retryDelay: 2000
+    })
+    this.apiKey = (apiKey ?? readEnv('DNB_API_KEY')).trim()
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey.length > 0
+  }
+
+  async fetchData(query: Record<string, unknown>): Promise<DataSourceResponse> {
+    if (!this.isConfigured()) {
+      return notConfiguredResponse(this.config.name, 'D&B API key not configured (set DNB_API_KEY)')
+    }
+
+    return this.executeFetch(async () => {
+      const companyName = typeof query.companyName === 'string' ? query.companyName : ''
+      const state = typeof query.state === 'string' ? query.state : ''
+
+      const searchUrl =
+        `https://plus.dnb.com/v1/match/cleanseMatch` +
+        `?name=${encodeURIComponent(companyName)}` +
+        (state ? `&countryISOAlpha2Code=US&addressRegion=${encodeURIComponent(state)}` : '')
+
+      const response = await fetch(searchUrl, {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          Accept: 'application/json'
+        }
+      })
+
+      if (!response.ok) {
+        throw new Error(`D&B API error: ${response.statusText}`)
+      }
+
+      const data = await response.json()
+      const match = data?.matchCandidates?.[0]?.organization ?? null
+
+      return {
+        dunsNumber: match?.duns ?? null,
+        businessName: match?.primaryName ?? null,
+        creditRating: match?.dnbAssessment?.standardRating?.rating ?? null,
+        employeeCount: match?.numberOfEmployees?.[0]?.value ?? null,
+        annualRevenue: match?.financials?.[0]?.yearlyRevenue?.[0]?.value ?? null,
+        companyName,
+        state
+      }
+    }, query)
+  }
+
+  protected validateQuery(query: Record<string, unknown>): boolean {
+    return typeof query.companyName === 'string' && query.companyName.length > 0
+  }
+}
+
+/**
+ * Clearbit Company API — firmographics, industry, headcount, revenue estimate.
+ *
+ * Auth: bearer secret key (`CLEARBIT_API_KEY`). Name lookups use the
+ * autocomplete/find endpoint; domain lookups (when a domain is supplied) are
+ * more accurate.
+ */
+export class ClearbitSource extends BaseDataSource {
+  private readonly apiKey: string
+
+  constructor(apiKey?: string) {
+    super({
+      name: 'clearbit',
+      tier: 'starter',
+      cost: 1.0,
+      timeout: 10000,
+      retryAttempts: 2,
+      retryDelay: 2000
+    })
+    this.apiKey = (apiKey ?? readEnv('CLEARBIT_API_KEY')).trim()
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey.length > 0
+  }
+
+  async fetchData(query: Record<string, unknown>): Promise<DataSourceResponse> {
+    if (!this.isConfigured()) {
+      return notConfiguredResponse(
+        this.config.name,
+        'Clearbit API key not configured (set CLEARBIT_API_KEY)'
+      )
+    }
+
+    return this.executeFetch(async () => {
+      const companyName = typeof query.companyName === 'string' ? query.companyName : ''
+      const domain = typeof query.domain === 'string' ? query.domain : ''
+
+      const searchUrl = domain
+        ? `https://company.clearbit.com/v2/companies/find?domain=${encodeURIComponent(domain)}`
+        : `https://company.clearbit.com/v1/domains/find?name=${encodeURIComponent(companyName)}`
+
+      const response = await fetch(searchUrl, {
+        headers: { Authorization: `Bearer ${this.apiKey}` }
+      })
+
+      if (!response.ok) {
+        throw new Error(`Clearbit API error: ${response.statusText}`)
+      }
+
+      const data = await response.json()
+
+      return {
+        name: data?.name ?? null,
+        domain: data?.domain ?? null,
+        industry: data?.category?.industry ?? null,
+        sector: data?.category?.sector ?? null,
+        employeeCount: data?.metrics?.employees ?? null,
+        estimatedRevenue: data?.metrics?.estimatedAnnualRevenue ?? null,
+        foundedYear: data?.foundedYear ?? null,
+        companyName
+      }
+    }, query)
+  }
+
+  protected validateQuery(query: Record<string, unknown>): boolean {
+    return (
+      (typeof query.companyName === 'string' && query.companyName.length > 0) ||
+      (typeof query.domain === 'string' && query.domain.length > 0)
+    )
+  }
+}
+
+/**
+ * ZoomInfo Enrich API — company intelligence (revenue, headcount, industry).
+ *
+ * Auth: bearer JWT issued from a username/clientId/privateKey pair. We accept a
+ * pre-issued token via `ZOOMINFO_API_KEY` so the adapter is stateless and
+ * fail-closed; production may add the token-exchange step upstream.
+ */
+export class ZoomInfoSource extends BaseDataSource {
+  private readonly apiToken: string
+
+  constructor(apiToken?: string) {
+    super({
+      name: 'zoominfo',
+      tier: 'starter',
+      cost: 2.5,
+      timeout: 12000,
+      retryAttempts: 2,
+      retryDelay: 2000
+    })
+    this.apiToken = (apiToken ?? readEnv('ZOOMINFO_API_KEY')).trim()
+  }
+
+  isConfigured(): boolean {
+    return this.apiToken.length > 0
+  }
+
+  async fetchData(query: Record<string, unknown>): Promise<DataSourceResponse> {
+    if (!this.isConfigured()) {
+      return notConfiguredResponse(
+        this.config.name,
+        'ZoomInfo API key not configured (set ZOOMINFO_API_KEY)'
+      )
+    }
+
+    return this.executeFetch(async () => {
+      const companyName = typeof query.companyName === 'string' ? query.companyName : ''
+      const state = typeof query.state === 'string' ? query.state : ''
+
+      const response = await fetch('https://api.zoominfo.com/enrich/company', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiToken}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify({
+          matchCompanyInput: [{ companyName, state }],
+          outputFields: ['id', 'name', 'revenue', 'employeeCount', 'industry', 'website']
+        })
+      })
+
+      if (!response.ok) {
+        throw new Error(`ZoomInfo API error: ${response.statusText}`)
+      }
+
+      const data = await response.json()
+      const company = data?.data?.result?.[0]?.data?.[0] ?? null
+
+      return {
+        companyId: company?.id ?? null,
+        name: company?.name ?? null,
+        revenue: company?.revenue ?? null,
+        employeeCount: company?.employeeCount ?? null,
+        industry: company?.industry ?? null,
+        website: company?.website ?? null,
+        companyName,
+        state
+      }
+    }, query)
+  }
+
+  protected validateQuery(query: Record<string, unknown>): boolean {
+    return typeof query.companyName === 'string' && query.companyName.length > 0
+  }
+}

--- a/packages/core/src/enrichment/credentials.ts
+++ b/packages/core/src/enrichment/credentials.ts
@@ -1,0 +1,47 @@
+/**
+ * Credential helpers for enrichment data sources (shared).
+ *
+ * Commercial enrichment sources (D&B, Clearbit, ZoomInfo) and the rate-limited
+ * SAM.gov entity API are key-gated. These helpers let a source read its key from
+ * the environment in a way that is safe in BOTH the Node server and the browser
+ * bundle (where `process` may be undefined), and produce a consistent
+ * fail-closed `DataSourceResponse` when a source is not configured.
+ *
+ * Framework-free on purpose — no Node-only imports — so the same source classes
+ * run in apps/web and the Express server.
+ */
+
+import type { DataSourceResponse } from './base-source'
+
+/**
+ * Read an environment variable without assuming `process` exists.
+ *
+ * In the browser, `process` is typically undefined unless the bundler injects
+ * it; we guard defensively and return an empty string so callers treat the
+ * source as "not configured" rather than throwing at module-construction time.
+ */
+export function readEnv(name: string): string {
+  try {
+    if (typeof process !== 'undefined' && process.env && typeof process.env[name] === 'string') {
+      return process.env[name] as string
+    }
+  } catch {
+    // `process` not defined in this runtime — treat as unset.
+  }
+  return ''
+}
+
+/**
+ * Build the standard fail-closed response a source returns when its required
+ * credential is absent. Mirrors the `DataSourceResponse` error contract so the
+ * EnrichmentService records a *named* reason and never fabricates data.
+ */
+export function notConfiguredResponse(source: string, reason: string): DataSourceResponse {
+  return {
+    success: false,
+    error: reason,
+    source,
+    timestamp: new Date().toISOString(),
+    responseTime: 0
+  }
+}

--- a/packages/core/src/enrichment/free-tier.ts
+++ b/packages/core/src/enrichment/free-tier.ts
@@ -13,6 +13,7 @@
  */
 
 import { BaseDataSource, DataSourceResponse } from './base-source'
+import { readEnv, notConfiguredResponse } from './credentials'
 
 /**
  * SEC EDGAR API - Company filings and financial data
@@ -208,10 +209,18 @@ export class CensusSource extends BaseDataSource {
 }
 
 /**
- * SAM.gov Federal Contracts API - Government contract awards
+ * SAM.gov Entity Management API — federal contractor registration.
+ *
+ * SAM.gov's public Entity Management API requires a free api.data.gov key
+ * (`SAM_GOV_API_KEY`); unauthenticated requests are rejected (HTTP 403/429). The
+ * key is passed via the optional constructor arg or the env var. When no key is
+ * configured the source reports `isConfigured() === false` so callers can skip
+ * it rather than issue a request that is guaranteed to fail.
  */
 export class SAMGovSource extends BaseDataSource {
-  constructor() {
+  private readonly apiKey: string
+
+  constructor(apiKey?: string) {
     super({
       name: 'sam-gov',
       tier: 'free',
@@ -220,14 +229,30 @@ export class SAMGovSource extends BaseDataSource {
       retryAttempts: 3,
       retryDelay: 1000
     })
+    this.apiKey = (apiKey ?? readEnv('SAM_GOV_API_KEY')).trim()
+  }
+
+  /** Whether a usable API key is present. */
+  isConfigured(): boolean {
+    return this.apiKey.length > 0
   }
 
   async fetchData(query: Record<string, unknown>): Promise<DataSourceResponse> {
+    if (!this.isConfigured()) {
+      return notConfiguredResponse(
+        this.config.name,
+        'SAM.gov API key not configured (set SAM_GOV_API_KEY — a free api.data.gov key)'
+      )
+    }
+
     return this.executeFetch(async () => {
       const companyName = typeof query.companyName === 'string' ? query.companyName : ''
 
-      // SAM.gov entity information API
-      const searchUrl = `https://api.sam.gov/entity-information/v3/entities?legalBusinessName=${encodeURIComponent(companyName)}`
+      // SAM.gov entity information API (api.data.gov key required).
+      const searchUrl =
+        `https://api.sam.gov/entity-information/v3/entities` +
+        `?api_key=${encodeURIComponent(this.apiKey)}` +
+        `&legalBusinessName=${encodeURIComponent(companyName)}`
 
       const response = await fetch(searchUrl)
 

--- a/packages/core/src/enrichment/index.ts
+++ b/packages/core/src/enrichment/index.ts
@@ -1,11 +1,16 @@
 /**
  * Shared enrichment data-source layer.
  *
- * Free, key-less public-data sources (SEC EDGAR, OSHA, USPTO, Census, SAM.gov)
- * plus the rate limiter and base-source abstractions. Consumed by both the web
- * app (apps/web re-exports these) and the Express server (EnrichmentService).
+ * Free public-data sources (SEC EDGAR, OSHA, USPTO, Census) and the key-gated
+ * SAM.gov entity source, plus key-gated commercial adapters (D&B, Clearbit,
+ * ZoomInfo). All commercial/keyed sources are fail-closed: with no credential
+ * they return a named "not configured" error and the service skips them.
+ * Consumed by both the web app (apps/web re-exports these) and the Express
+ * server (EnrichmentService).
  */
 
 export * from './rate-limiter'
 export * from './base-source'
+export * from './credentials'
 export * from './free-tier'
+export * from './commercial-tier'

--- a/packages/core/src/enrichment/rate-limiter.ts
+++ b/packages/core/src/enrichment/rate-limiter.ts
@@ -107,9 +107,11 @@ export class RateLimiterManager {
       osha: { maxTokens: 5, refillRate: 1, refillInterval: 1000 }, // 1 req/sec
       uspto: { maxTokens: 5, refillRate: 1, refillInterval: 1000 }, // 1 req/sec
       census: { maxTokens: 5, refillRate: 1, refillInterval: 1000 }, // 1 req/sec
+      'sam-gov': { maxTokens: 5, refillRate: 1, refillInterval: 1000 }, // 1 req/sec (keyed)
       dnb: { maxTokens: 10, refillRate: 2, refillInterval: 1000 }, // 2 req/sec
       'google-places': { maxTokens: 50, refillRate: 10, refillInterval: 1000 }, // 10 req/sec
       clearbit: { maxTokens: 10, refillRate: 1, refillInterval: 1000 }, // 1 req/sec
+      zoominfo: { maxTokens: 10, refillRate: 1, refillInterval: 1000 }, // 1 req/sec
       'scraper-ca': { maxTokens: 5, refillRate: 5, refillInterval: 60000 }, // 5 req/min
       'scraper-tx': { maxTokens: 5, refillRate: 5, refillInterval: 60000 }, // 5 req/min
       'scraper-fl': { maxTokens: 5, refillRate: 5, refillInterval: 60000 } // 5 req/min

--- a/scripts/trainMLModel.ts
+++ b/scripts/trainMLModel.ts
@@ -1,0 +1,52 @@
+/**
+ * Train and persist the ML scoring model.
+ *
+ *   npm run train:ml-model
+ *
+ * IMPORTANT / HONEST DISCLOSURE:
+ * This trains on CLEARLY-SYNTHETIC seed data (a deterministic, generated dataset
+ * — see MLScoringStrategy.generateSyntheticTrainingData). The resulting weights
+ * are inspectable and reproducible, but the model is NOT validated against real
+ * repayment/closed-deal outcomes. Do not use the ML score for underwriting
+ * decisions until it has been retrained and evaluated on labeled history.
+ *
+ * The committed artifact (server/models/ml-scoring-weights.json) is what the
+ * server loads at runtime; if it is absent the strategy retrains the same
+ * deterministic dataset in-memory, so behavior is identical either way.
+ */
+import fs from 'fs'
+import path from 'path'
+import { MLScoringModel } from '../server/services/MLScoringModel'
+import { MLScoringStrategy, WEIGHTS_PATH } from '../server/services/MLScoringStrategy'
+
+function main(): void {
+  const strategy = new MLScoringStrategy()
+  const model = new MLScoringModel()
+
+  const data = strategy.generateSyntheticTrainingData()
+  console.log(
+    `[train:ml] generated ${data.length} synthetic training examples (deterministic seed)`
+  )
+
+  const metrics = model.train(data, { epochs: 400, learningRate: 0.05 })
+  console.log(
+    `[train:ml] trained: loss=${metrics.finalLoss.toFixed(4)} ` +
+      `trainAccuracy=${(metrics.trainAccuracy * 100).toFixed(1)}% ` +
+      `epochs=${metrics.epochs} samples=${metrics.samples}`
+  )
+
+  if (metrics.trainAccuracy < 0.6) {
+    console.warn('[train:ml] WARNING: low training accuracy — check hyperparameters/data')
+  }
+
+  const weights = model.exportWeights()
+  const dir = path.dirname(WEIGHTS_PATH)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(WEIGHTS_PATH, JSON.stringify(weights, null, 2) + '\n')
+  console.log(`[train:ml] wrote weights → ${WEIGHTS_PATH}`)
+  console.log(
+    '[train:ml] NOTE: synthetic training data — validate against real outcomes before relying on ML scores.'
+  )
+}
+
+main()

--- a/server/__tests__/config/index.test.ts
+++ b/server/__tests__/config/index.test.ts
@@ -44,7 +44,7 @@ describe('server config', () => {
   describe('validateConfig', () => {
     const productionEnv = {
       NODE_ENV: 'production',
-      JWT_SECRET: 'test-jwt-secret-that-is-long-enough',
+      JWT_SECRET: 'example-test-jwt-secret-do-not-use',
       DATABASE_URL: 'postgresql://app_user:secret@db.example.com:5432/app',
       CORS_ORIGIN: 'https://app.example.com',
       STRIPE_WEBHOOK_SECRET: 'whsec_test',

--- a/server/__tests__/serverlessApp.test.ts
+++ b/server/__tests__/serverlessApp.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Verifies the Vercel serverless wiring: the exported `getServerlessApp()`
+ * returns a real Express app that serves `/api/*` (the live deployment defect
+ * was that every `/api/*` path 404'd), protected routes stay guarded, and the
+ * `/_spark/*` fallback degrades gracefully. Also exercises the actual Vercel
+ * entrypoint (`api/index.ts`) end-to-end, including its path normalization.
+ *
+ * No database is required: these routes are either DB-free (liveness) or fail at
+ * the auth boundary before touching the database.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import type { IncomingMessage, ServerResponse } from 'http'
+import { getServerlessApp } from '../index'
+import apiHandler from '../../api/index'
+import sparkFallback from '../../api/spark-fallback'
+
+describe('serverless app wiring', () => {
+  it('serves the DB-free liveness route under /api (not a 404)', async () => {
+    const app = await getServerlessApp()
+    const res = await request(app).get('/api/health/live')
+    expect(res.status).toBe(200)
+    expect(res.body.alive).toBe(true)
+  })
+
+  it('keeps protected routes guarded (401, not 404) when unauthenticated', async () => {
+    const app = await getServerlessApp()
+    const res = await request(app).get('/api/prospects')
+    // The router is mounted and the auth middleware rejects — proving the
+    // backend is live and protected, not missing.
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the API 404 handler for unknown /api paths', async () => {
+    const app = await getServerlessApp()
+    const res = await request(app).get('/api/this-route-does-not-exist')
+    expect(res.status).toBe(404)
+    // Express notFoundHandler responds with JSON, proving our app handled it.
+    expect(res.headers['content-type']).toMatch(/json/)
+  })
+
+  it('forwards through the Vercel api/index entrypoint to the live app', async () => {
+    const listener = (req: IncomingMessage, res: ServerResponse) => {
+      void apiHandler(req, res)
+    }
+    const res = await request(listener).get('/api/health/live')
+    expect(res.status).toBe(200)
+    expect(res.body.alive).toBe(true)
+  })
+
+  it('spark fallback returns a benign 200 instead of a 404', async () => {
+    const captured: { status?: number; body?: string; headers: Record<string, string> } = {
+      headers: {}
+    }
+    const fakeReq = { url: '/_spark/kv/some-key' } as IncomingMessage
+    const fakeRes = {
+      statusCode: 0,
+      setHeader(name: string, value: string) {
+        captured.headers[name] = value
+      },
+      end(body?: string) {
+        captured.status = this.statusCode
+        captured.body = body
+      }
+    } as unknown as ServerResponse
+
+    sparkFallback(fakeReq, fakeRes)
+
+    expect(captured.status).toBe(200)
+    expect(captured.body).toBe('{}')
+    expect(captured.headers['X-Spark-Fallback']).toBe('stub')
+  })
+})

--- a/server/__tests__/services/EnrichmentService.test.ts
+++ b/server/__tests__/services/EnrichmentService.test.ts
@@ -17,20 +17,40 @@ const sourceMocks = vi.hoisted(() => ({
   census: vi.fn()
 }))
 
-vi.mock('@public-records/core/enrichment', () => ({
-  SECEdgarSource: class {
-    fetchData = sourceMocks.sec
-  },
-  OSHASource: class {
-    fetchData = sourceMocks.osha
-  },
-  USPTOSource: class {
-    fetchData = sourceMocks.uspto
-  },
-  CensusSource: class {
-    fetchData = sourceMocks.census
+vi.mock('@public-records/core/enrichment', () => {
+  // Keyed/commercial sources default to NOT configured in the test env (no API
+  // keys), so EnrichmentService filters them out and behaves exactly as the
+  // free-source-only pipeline. The configured path is covered separately by
+  // injecting a fake keyed source via the constructor.
+  const makeKeyed = (name: string) =>
+    class {
+      getConfig() {
+        return { name }
+      }
+      isConfigured() {
+        return false
+      }
+      fetchData = vi.fn()
+    }
+  return {
+    SECEdgarSource: class {
+      fetchData = sourceMocks.sec
+    },
+    OSHASource: class {
+      fetchData = sourceMocks.osha
+    },
+    USPTOSource: class {
+      fetchData = sourceMocks.uspto
+    },
+    CensusSource: class {
+      fetchData = sourceMocks.census
+    },
+    SAMGovSource: makeKeyed('sam-gov'),
+    DnBSource: makeKeyed('dnb'),
+    ClearbitSource: makeKeyed('clearbit'),
+    ZoomInfoSource: makeKeyed('zoominfo')
   }
-}))
+})
 
 // Mock the queue accessor used by getQueueStatus.
 const queueMocks = vi.hoisted(() => ({
@@ -200,6 +220,80 @@ describe('EnrichmentService', () => {
         /INSERT INTO enrichment_logs/.test(String(c[0]))
       )
       expect(logCall?.[1]?.[1]).toBe('failed')
+    })
+
+    it('queries a configured keyed source and uses its firmographic revenue', async () => {
+      withProspect()
+      // Free sources succeed but Census returns no payroll (so revenue would be 0
+      // without a keyed source).
+      sourceMocks.sec.mockResolvedValue(ok('sec-edgar', { cik: '123', filings: [] }))
+      sourceMocks.osha.mockResolvedValue(
+        ok('osha', { violations: 0, totalPenalties: 0, recentViolations: [] })
+      )
+      sourceMocks.uspto.mockResolvedValue(ok('uspto', { trademarkCount: 0, trademarks: [] }))
+      sourceMocks.census.mockResolvedValue(
+        ok('census', { businessCount: 10, totalEmployees: 100, totalPayroll: 0 })
+      )
+
+      // Inject a configured keyed source (e.g. D&B) returning real firmographics.
+      const keyedFetch = vi
+        .fn()
+        .mockResolvedValue(
+          ok('dnb', { annualRevenue: 4200000, industry: 'Construction', creditRating: '2A2' })
+        )
+      const keyedSource = {
+        getConfig: () => ({ name: 'dnb' }),
+        isConfigured: () => true,
+        fetchData: keyedFetch
+      }
+      const keyedService = new EnrichmentService({ keyedSources: [keyedSource] })
+
+      const result = await keyedService.enrichProspect('prospect-1')
+
+      // The keyed source was queried and counts toward coverage/confidence.
+      expect(keyedFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ companyName: 'Test Corp', state: 'CA' })
+      )
+      expect(result.data_sources_used).toContain('dnb')
+      expect(result.confidence).toBeCloseTo(1, 5) // 5 of 5 sources succeeded
+      // Commercial revenue is preferred over the (zero) Census proxy.
+      expect(result.estimated_revenue).toBe(4200000)
+      expect(result.industry_classification).toBe('Construction')
+
+      // estimated_revenue persisted to the prospect from the keyed figure.
+      const updateCall = mockQuery.mock.calls.find((c) =>
+        /UPDATE prospects[\s\S]*estimated_revenue/.test(String(c[0]))
+      )
+      expect(updateCall?.[1]?.[2]).toBe(4200000)
+    })
+
+    it('skips keyed sources that are not configured (no effect on confidence)', async () => {
+      withProspect()
+      sourceMocks.sec.mockResolvedValue(ok('sec-edgar', { cik: '123', filings: [] }))
+      sourceMocks.osha.mockResolvedValue(
+        ok('osha', { violations: 0, totalPenalties: 0, recentViolations: [] })
+      )
+      sourceMocks.uspto.mockResolvedValue(ok('uspto', { trademarkCount: 0, trademarks: [] }))
+      sourceMocks.census.mockResolvedValue(
+        ok('census', { businessCount: 10, totalEmployees: 100, totalPayroll: 99 })
+      )
+
+      const keyedFetch = vi.fn()
+      const unconfigured = {
+        getConfig: () => ({ name: 'clearbit' }),
+        isConfigured: () => false,
+        fetchData: keyedFetch
+      }
+      // Default constructor filters by isConfigured(); emulate that filter here.
+      const keyedService = new EnrichmentService({
+        keyedSources: [unconfigured].filter((s) => s.isConfigured())
+      })
+
+      const result = await keyedService.enrichProspect('prospect-1')
+
+      expect(keyedFetch).not.toHaveBeenCalled()
+      expect(result.data_sources_used).not.toContain('clearbit')
+      expect(result.confidence).toBeCloseTo(1, 5) // still just the 4 free sources
     })
 
     it('throws and queries no sources for a non-existent prospect', async () => {

--- a/server/__tests__/services/MLScoringModel.test.ts
+++ b/server/__tests__/services/MLScoringModel.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the trainable logistic-regression scoring model and its domain
+ * strategy. These prove the model genuinely LEARNS (fits separable data),
+ * persists/loads deterministically, and that the strategy is honestly labeled.
+ */
+import { describe, it, expect } from 'vitest'
+import { MLScoringModel, type TrainingExample } from '../../services/MLScoringModel'
+import {
+  MLScoringStrategy,
+  ML_WARNING,
+  type MlProspectInput
+} from '../../services/MLScoringStrategy'
+
+describe('MLScoringModel', () => {
+  it('sigmoid is bounded in [0, 1] and monotonic', () => {
+    expect(MLScoringModel.sigmoid(0)).toBeCloseTo(0.5, 5)
+    expect(MLScoringModel.sigmoid(-50)).toBeGreaterThanOrEqual(0)
+    expect(MLScoringModel.sigmoid(-50)).toBeLessThan(0.01)
+    expect(MLScoringModel.sigmoid(50)).toBeLessThanOrEqual(1)
+    expect(MLScoringModel.sigmoid(50)).toBeGreaterThan(0.99)
+    expect(MLScoringModel.sigmoid(2)).toBeGreaterThan(MLScoringModel.sigmoid(1))
+  })
+
+  it('throws when predicting before training', () => {
+    const model = new MLScoringModel()
+    expect(model.isReady()).toBe(false)
+    expect(() => model.predict({ a: 1 })).toThrow(/no weights/i)
+  })
+
+  it('learns a linearly separable pattern (high train accuracy)', () => {
+    // Label depends on whether x1 > x2; build a clean separable set.
+    const examples: TrainingExample[] = []
+    for (let i = 0; i < 80; i++) {
+      const x1 = (i % 8) / 8
+      const x2 = ((i * 3) % 8) / 8
+      examples.push({ features: { x1, x2 }, label: x1 > x2 ? 1 : 0 })
+    }
+    const model = new MLScoringModel()
+    const metrics = model.train(examples, { epochs: 600, learningRate: 0.2 })
+
+    expect(metrics.samples).toBe(80)
+    expect(metrics.finalLoss).toBeLessThan(0.6)
+    expect(metrics.trainAccuracy).toBeGreaterThan(0.75)
+  })
+
+  it('round-trips weights via export/load with identical predictions', () => {
+    const examples: TrainingExample[] = [
+      { features: { a: 0, b: 1 }, label: 0 },
+      { features: { a: 1, b: 0 }, label: 1 },
+      { features: { a: 0.2, b: 0.8 }, label: 0 },
+      { features: { a: 0.9, b: 0.1 }, label: 1 }
+    ]
+    const model = new MLScoringModel()
+    model.train(examples, { epochs: 200 })
+    const probe = { a: 0.7, b: 0.3 }
+    const before = model.predict(probe)
+
+    const weights = model.exportWeights()
+    const reloaded = new MLScoringModel()
+    reloaded.loadWeights(weights)
+
+    expect(reloaded.predict(probe)).toBeCloseTo(before, 10)
+    expect(weights.modelVersion).toBe('1.0.0')
+    expect(weights.featureOrder).toEqual(['a', 'b'])
+  })
+})
+
+describe('MLScoringStrategy', () => {
+  const strongProspect: MlProspectInput = {
+    daysSinceLastFiling: 25,
+    totalFilings: 2,
+    activeFilings: 0,
+    lapsedFilings: 0,
+    terminatedFilings: 2,
+    timeSinceDefault: 600,
+    reviewCount: 40,
+    avgSentiment: 0.85,
+    violationCount: 0,
+    healthScore: 88
+  }
+  const weakProspect: MlProspectInput = {
+    daysSinceLastFiling: 1100,
+    totalFilings: 7,
+    activeFilings: 6,
+    lapsedFilings: 1,
+    terminatedFilings: 0,
+    timeSinceDefault: 60,
+    reviewCount: 2,
+    avgSentiment: 0.2,
+    violationCount: 4,
+    healthScore: 25
+  }
+
+  it('extracts engineered features in [0,1]-ish ranges', () => {
+    const strategy = new MLScoringStrategy()
+    const f = strategy.extractFeatures(strongProspect)
+    expect(f.recency).toBeGreaterThan(0.8)
+    expect(f.terminatedRatio).toBe(1)
+    expect(f.filingBurden).toBe(0)
+    expect(f.violations).toBe(0)
+    expect(f.sentiment).toBeCloseTo(0.85, 5)
+  })
+
+  it('generates a reproducible, reasonably-balanced synthetic dataset', () => {
+    const a = new MLScoringStrategy().generateSyntheticTrainingData(120)
+    const b = new MLScoringStrategy().generateSyntheticTrainingData(120)
+    expect(a.length).toBe(120)
+    // Deterministic seed → identical datasets across instances.
+    expect(a[0]).toEqual(b[0])
+    expect(a[119]).toEqual(b[119])
+    const positives = a.filter((e) => e.label === 1).length
+    // Not degenerate (both classes represented).
+    expect(positives).toBeGreaterThan(20)
+    expect(positives).toBeLessThan(100)
+  })
+
+  it('scores a strong prospect higher than a weak one, with honest metadata', () => {
+    const strategy = new MLScoringStrategy()
+    const strong = strategy.score(strongProspect)
+    const weak = strategy.score(weakProspect)
+
+    expect(strong.score).toBeGreaterThan(weak.score)
+    expect(strong.probability).toBeGreaterThanOrEqual(0)
+    expect(strong.probability).toBeLessThanOrEqual(1)
+    expect(strong.score).toBeGreaterThanOrEqual(0)
+    expect(strong.score).toBeLessThanOrEqual(100)
+
+    // Honest labeling: low confidence + explicit warning, every time.
+    expect(strong.confidence).toBe(0.3)
+    expect(strong.warning).toBe(ML_WARNING)
+    expect(strong.warning).toMatch(/synthetic seed data/i)
+  })
+})

--- a/server/__tests__/services/commercialSources.test.ts
+++ b/server/__tests__/services/commercialSources.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the key-gated enrichment sources (SAM.gov + commercial
+ * adapters). These exercise the REAL source classes (no module mock) with a
+ * stubbed global fetch, proving two things:
+ *   1. Fail-closed: with no credential they return a named "not configured"
+ *      error and never issue a request.
+ *   2. When configured they issue a real request and map only the fields the
+ *      provider returned (no fabrication).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  SAMGovSource,
+  DnBSource,
+  ClearbitSource,
+  ZoomInfoSource
+} from '@public-records/core/enrichment'
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function okJson(body: unknown) {
+  return { ok: true, statusText: 'OK', json: async () => body }
+}
+
+describe('SAMGovSource', () => {
+  it('fails closed (no request) when no API key is configured', async () => {
+    const source = new SAMGovSource('')
+    expect(source.isConfigured()).toBe(false)
+
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('queries with the api_key and maps registration data when configured', async () => {
+    const source = new SAMGovSource('free-key')
+    fetchMock.mockResolvedValue(
+      okJson({
+        totalRecords: 1,
+        entityData: [
+          { entityRegistration: { ueiSAM: 'UEI123', cageCode: 'CAGE9' }, contractCount: 4 }
+        ]
+      })
+    )
+
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+
+    expect(res.success).toBe(true)
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('api_key=free-key')
+    expect(url).toContain('legalBusinessName=Acme%20Co')
+    expect(res.data).toMatchObject({ isRegistered: true, uei: 'UEI123', cageCode: 'CAGE9' })
+  })
+})
+
+describe('DnBSource', () => {
+  it('fails closed when DNB_API_KEY is absent', async () => {
+    const source = new DnBSource('')
+    expect(source.isConfigured()).toBe(false)
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends a bearer token and maps firmographics when configured', async () => {
+    const source = new DnBSource('dnb-token')
+    fetchMock.mockResolvedValue(
+      okJson({
+        matchCandidates: [
+          {
+            organization: {
+              duns: '999',
+              primaryName: 'Acme Co',
+              dnbAssessment: { standardRating: { rating: '5A1' } },
+              numberOfEmployees: [{ value: 120 }],
+              financials: [{ yearlyRevenue: [{ value: 8000000 }] }]
+            }
+          }
+        ]
+      })
+    )
+
+    const res = await source.fetchData({ companyName: 'Acme Co', state: 'NY' })
+
+    expect(res.success).toBe(true)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer dnb-token')
+    expect(res.data).toMatchObject({
+      dunsNumber: '999',
+      creditRating: '5A1',
+      employeeCount: 120,
+      annualRevenue: 8000000
+    })
+  })
+})
+
+describe('ClearbitSource', () => {
+  it('fails closed when CLEARBIT_API_KEY is absent', async () => {
+    const source = new ClearbitSource('')
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps industry/revenue when configured', async () => {
+    const source = new ClearbitSource('cb-key')
+    fetchMock.mockResolvedValue(
+      okJson({
+        name: 'Acme Co',
+        domain: 'acme.co',
+        category: { industry: 'Software', sector: 'Information Technology' },
+        metrics: { employees: 50, estimatedAnnualRevenue: '$1M-$10M' },
+        foundedYear: 2011
+      })
+    )
+
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+
+    expect(res.success).toBe(true)
+    expect(res.data).toMatchObject({ industry: 'Software', employeeCount: 50, foundedYear: 2011 })
+  })
+})
+
+describe('ZoomInfoSource', () => {
+  it('fails closed when ZOOMINFO_API_TOKEN is absent', async () => {
+    const source = new ZoomInfoSource('')
+    const res = await source.fetchData({ companyName: 'Acme Co' })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('POSTs an enrich request and maps company intelligence when configured', async () => {
+    const source = new ZoomInfoSource('zi-token')
+    fetchMock.mockResolvedValue(
+      okJson({
+        data: {
+          result: [
+            {
+              data: [
+                {
+                  id: 7,
+                  name: 'Acme Co',
+                  revenue: 12000000,
+                  employeeCount: 80,
+                  industry: 'Retail',
+                  website: 'acme.co'
+                }
+              ]
+            }
+          ]
+        }
+      })
+    )
+
+    const res = await source.fetchData({ companyName: 'Acme Co', state: 'CA' })
+
+    expect(res.success).toBe(true)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect(res.data).toMatchObject({ revenue: 12000000, employeeCount: 80, industry: 'Retail' })
+  })
+})

--- a/server/index.ts
+++ b/server/index.ts
@@ -390,6 +390,43 @@ export class Server {
   }
 }
 
+/**
+ * Build the Express app for a SERVERLESS host (e.g. a Vercel Node function).
+ *
+ * Unlike `Server.start()`, this does NOT bind a port, start the BullMQ workers,
+ * or the cron scheduler — a serverless function is request-scoped and the
+ * background workers run elsewhere. It makes a single best-effort database
+ * connection (memoized across warm invocations) so DB-backed routes work when
+ * `DATABASE_URL` is configured; if the connection is absent or fails, those
+ * routes fail closed through the normal error handler rather than hanging.
+ *
+ * The promise is cached so a warm Lambda/Vercel container reuses one app + pool.
+ */
+let serverlessAppPromise: Promise<Express> | null = null
+export function getServerlessApp(): Promise<Express> {
+  if (!serverlessAppPromise) {
+    serverlessAppPromise = (async () => {
+      const server = new Server()
+      if (process.env.DATABASE_URL) {
+        try {
+          await database.connect()
+        } catch (error) {
+          console.error(
+            '[serverless] database connect failed; DB-backed routes will return errors:',
+            error
+          )
+        }
+      } else {
+        console.warn(
+          '[serverless] DATABASE_URL not set; only stateless routes (health, docs) will work.'
+        )
+      }
+      return server.getApp()
+    })()
+  }
+  return serverlessAppPromise
+}
+
 // Start the server only when this module is executed directly — never on
 // import (e.g. by tests or tooling). The esbuild bundle (scripts/build-server.mjs)
 // shims `import.meta.url` to `pathToFileURL(__filename)`, so this guard holds in

--- a/server/middleware/validateRequest.ts
+++ b/server/middleware/validateRequest.ts
@@ -15,11 +15,19 @@ export const validateRequest = (schemas: ValidationSchemas) => {
         req.body = schemas.body.parse(req.body)
       }
 
-      // Validate query - use Object.assign to avoid getter-only property issue
+      // Validate query. In Express 5 `req.query` is a getter with no setter that
+      // re-derives the parsed querystring on each access, so mutating it in place
+      // (delete + Object.assign) does not persist — downstream handlers would read
+      // the raw, un-coerced values. Redefine it as an own data property holding the
+      // parsed/coerced result so the schema's transforms actually take effect.
       if (schemas.query) {
         const parsedQuery = schemas.query.parse(req.query)
-        Object.keys(req.query).forEach((key) => delete req.query[key])
-        Object.assign(req.query, parsedQuery)
+        Object.defineProperty(req, 'query', {
+          value: parsedQuery,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        })
       }
 
       // Validate params - use Object.assign to avoid getter-only property issue

--- a/server/models/ml-scoring-weights.json
+++ b/server/models/ml-scoring-weights.json
@@ -1,0 +1,71 @@
+{
+  "intercept": -0.1402703238531812,
+  "weights": {
+    "filingBurden": -1.3636308600294818,
+    "healthNorm": 0.3798677952356483,
+    "lapsedRatio": 0.2440984361852853,
+    "logFilings": -0.1865000574545853,
+    "logReviews": 0.8473478926566451,
+    "recency": 1.0466981002728077,
+    "recoveryWindow": 1.0749545674250982,
+    "sentiment": 0.6446202170698112,
+    "terminatedRatio": 0.8940231261076289,
+    "violations": -0.41407905998906525
+  },
+  "normalizers": {
+    "filingBurden": {
+      "mean": 0.41597222222222235,
+      "std": 0.39647604413706783
+    },
+    "healthNorm": {
+      "mean": 0.4905833333333334,
+      "std": 0.285897113875293
+    },
+    "lapsedRatio": {
+      "mean": 0.23088293650793662,
+      "std": 0.3197965917077133
+    },
+    "logFilings": {
+      "mean": 1.3564675568114841,
+      "std": 0.6242101084534227
+    },
+    "logReviews": {
+      "mean": 3.156445428327161,
+      "std": 0.8626085106973153
+    },
+    "recency": {
+      "mean": 0.10817351598173519,
+      "std": 0.22783090723391355
+    },
+    "recoveryWindow": {
+      "mean": 0.5509121061359868,
+      "std": 0.34738235707398274
+    },
+    "sentiment": {
+      "mean": 0.49713119747951473,
+      "std": 0.2905616244814482
+    },
+    "terminatedRatio": {
+      "mean": 0.2531448412698414,
+      "std": 0.332851916239356
+    },
+    "violations": {
+      "mean": 0.23749999999999988,
+      "std": 0.17007963820908517
+    }
+  },
+  "featureOrder": [
+    "filingBurden",
+    "healthNorm",
+    "lapsedRatio",
+    "logFilings",
+    "logReviews",
+    "recency",
+    "recoveryWindow",
+    "sentiment",
+    "terminatedRatio",
+    "violations"
+  ],
+  "trainedAt": "2026-06-16T11:19:51.459Z",
+  "modelVersion": "1.0.0"
+}

--- a/server/routes/prospects.ts
+++ b/server/routes/prospects.ts
@@ -133,7 +133,10 @@ const batchDeleteBodySchema = z.object({
 const scoreBodySchema = z
   .object({
     industry: z.string().optional(),
-    state: z.string().length(2).optional()
+    state: z.string().length(2).optional(),
+    // Opt-in: also compute the experimental, supplementary ML score. The
+    // rules-based composite remains the persisted, authoritative priority_score.
+    includeMl: z.boolean().optional()
   })
   .optional()
 
@@ -422,11 +425,16 @@ router.post(
       })
     }
 
-    const body = (req.body ?? {}) as { industry?: string; state?: string }
+    const body = (req.body ?? {}) as {
+      industry?: string
+      state?: string
+      includeMl?: boolean
+    }
     const scoringService = new ScoringService()
     const result = await scoringService.scoreProspect(req.params.id, {
       industry: body.industry,
-      state: body.state
+      state: body.state,
+      includeMl: body.includeMl === true
     })
 
     // Persist the live-computed composite as the canonical priority_score plus

--- a/server/services/EnrichmentService.ts
+++ b/server/services/EnrichmentService.ts
@@ -6,6 +6,10 @@
  * data sources (SEC EDGAR, OSHA enforcement, USPTO, Census Business Patterns)
  * via the shared `@public-records/core/enrichment` data-source layer.
  *
+ * Optional credential-gated sources (SAM.gov, D&B, Clearbit, ZoomInfo) are
+ * queried only when their API-key env vars are configured; unconfigured ones are
+ * skipped entirely and never count against the confidence denominator.
+ *
  * Fail-closed discipline: a source that errors contributes a *named* error, not
  * invented data. If ALL queried sources fail, enrichment fails with the
  * aggregated reasons rather than persisting fabricated values.
@@ -18,6 +22,10 @@ import {
   OSHASource,
   USPTOSource,
   CensusSource,
+  SAMGovSource,
+  DnBSource,
+  ClearbitSource,
+  ZoomInfoSource,
   type DataSourceResponse
 } from '@public-records/core/enrichment'
 import { database } from '../database/connection'
@@ -41,6 +49,19 @@ interface SourceOutcome {
   source: string
   success: boolean
   error?: string
+}
+
+/**
+ * A credential-gated enrichment source (SAM.gov, D&B, Clearbit, ZoomInfo).
+ *
+ * These are only queried when `isConfigured()` is true, so an unconfigured
+ * provider is skipped entirely (it never drags down the confidence denominator).
+ * Kept as a structural interface so tests can inject a fake without a real key.
+ */
+export interface KeyedEnrichmentSource {
+  getConfig(): { name: string }
+  isConfigured(): boolean
+  fetchData(query: Record<string, unknown>): Promise<DataSourceResponse>
 }
 
 /**
@@ -188,12 +209,24 @@ export class EnrichmentService {
   private readonly oshaSource: OSHASource
   private readonly usptoSource: USPTOSource
   private readonly censusSource: CensusSource
+  /**
+   * Credential-gated sources that are only queried when configured. By default
+   * this is the subset of {SAM.gov, D&B, Clearbit, ZoomInfo} whose API key env
+   * vars are present; with none configured the array is empty and enrichment
+   * behaves exactly as the free-source-only pipeline.
+   */
+  private readonly keyedSources: KeyedEnrichmentSource[]
 
-  constructor() {
+  constructor(options?: { keyedSources?: KeyedEnrichmentSource[] }) {
     this.secSource = new SECEdgarSource()
     this.oshaSource = new OSHASource()
     this.usptoSource = new USPTOSource()
     this.censusSource = new CensusSource()
+    this.keyedSources =
+      options?.keyedSources ??
+      [new SAMGovSource(), new DnBSource(), new ClearbitSource(), new ZoomInfoSource()].filter(
+        (source) => source.isConfigured()
+      )
   }
 
   /**
@@ -302,6 +335,51 @@ export class EnrichmentService {
       outcomes.push({ source: 'census', success: false, error: `unknown state '${state}'` })
     }
 
+    // --- Keyed/commercial sources (SAM.gov, D&B, Clearbit, ZoomInfo) ---------
+    // Only sources with a configured credential are present in `keyedSources`;
+    // each is fail-closed and contributes a *named* outcome. Their firmographic
+    // output (revenue, industry, headcount, credit rating, federal registration)
+    // refines the result when present but is never fabricated.
+    const firmographics: {
+      estimatedRevenue?: number
+      industry?: string
+      employeeCount?: number
+      creditRating?: string
+      samRegistered?: boolean
+    } = {}
+
+    for (const source of this.keyedSources) {
+      const sourceName = source.getConfig().name
+      if (!companyName) {
+        outcomes.push({ source: sourceName, success: false, error: 'missing company name' })
+        continue
+      }
+      const keyed = await source.fetchData({ companyName, state })
+      this.recordOutcome(outcomes, keyed)
+      if (keyed.success) {
+        const data = asRecord(keyed.data)
+        const revenue = asNumber(data.estimatedRevenue ?? data.revenue ?? data.annualRevenue)
+        if (revenue > 0 && firmographics.estimatedRevenue === undefined) {
+          firmographics.estimatedRevenue = revenue
+        }
+        const ind = typeof data.industry === 'string' ? data.industry.trim() : ''
+        if (ind && firmographics.industry === undefined) {
+          firmographics.industry = ind
+        }
+        const employees = asNumber(data.employeeCount)
+        if (employees > 0 && firmographics.employeeCount === undefined) {
+          firmographics.employeeCount = employees
+        }
+        const rating = typeof data.creditRating === 'string' ? data.creditRating.trim() : ''
+        if (rating && firmographics.creditRating === undefined) {
+          firmographics.creditRating = rating
+        }
+        if (typeof data.isRegistered === 'boolean' && firmographics.samRegistered === undefined) {
+          firmographics.samRegistered = data.isRegistered
+        }
+      }
+    }
+
     const successfulSources = outcomes.filter((o) => o.success)
     const failedSources = outcomes.filter((o) => !o.success)
     const sourceErrors = failedSources.map((o) => `${o.source}: ${o.error ?? 'unknown error'}`)
@@ -342,6 +420,10 @@ export class EnrichmentService {
 
     const dataSourcesUsed = successfulSources.map((o) => o.source)
 
+    // Prefer a commercial firmographic revenue figure (D&B/ZoomInfo/Clearbit)
+    // over the Census payroll proxy when a keyed source supplied one.
+    const resolvedRevenue = firmographics.estimatedRevenue ?? censusPayroll
+
     const result: EnrichmentResult = {
       growth_signals: growthSignals,
       health_score: {
@@ -350,8 +432,8 @@ export class EnrichmentService {
         trend,
         violations: oshaViolations
       },
-      estimated_revenue: censusPayroll,
-      industry_classification: industry || 'unknown',
+      estimated_revenue: resolvedRevenue,
+      industry_classification: firmographics.industry || industry || 'unknown',
       data_sources_used: dataSourcesUsed,
       confidence,
       source_errors: sourceErrors
@@ -433,10 +515,9 @@ export class EnrichmentService {
       enrichedFields.push('health_score')
     }
 
-    // Update prospect enrichment metadata (and estimated revenue when Census
-    // produced a payroll figure we can use as a proxy).
-    const censusSucceeded = successfulSources.some((o) => o.source === 'census')
-    if (censusSucceeded && censusPayroll > 0) {
+    // Update prospect enrichment metadata (and estimated revenue when either a
+    // keyed firmographic source or Census produced a usable figure).
+    if (resolvedRevenue > 0) {
       await database.query(
         `UPDATE prospects
             SET last_enriched_at = NOW(),
@@ -444,7 +525,7 @@ export class EnrichmentService {
                 estimated_revenue = $3,
                 updated_at = NOW()
           WHERE id = $1`,
-        [prospectId, confidence, censusPayroll]
+        [prospectId, confidence, resolvedRevenue]
       )
       enrichedFields.push('estimated_revenue')
     } else {
@@ -470,7 +551,9 @@ export class EnrichmentService {
         company_name: companyName,
         industry,
         state,
-        data_sources_used: dataSourcesUsed
+        data_sources_used: dataSourcesUsed,
+        // Only present when a configured keyed source actually returned values.
+        ...(Object.keys(firmographics).length > 0 ? { firmographics } : {})
       }
     })
 

--- a/server/services/MLScoringModel.ts
+++ b/server/services/MLScoringModel.ts
@@ -1,0 +1,224 @@
+/**
+ * MLScoringModel — a small, dependency-free, genuinely-trainable logistic
+ * regression model.
+ *
+ * This is a real machine-learning model: it fits weights to labeled examples via
+ * batch gradient descent on the binary cross-entropy loss, normalizes features
+ * with stored mean/std statistics, and serializes the learned parameters to JSON
+ * for inference. It is intentionally interpretable (one weight per feature) and
+ * has no heavy dependencies so it runs anywhere the server runs.
+ *
+ * It does NOT, by itself, make the product's scoring "ML-validated": the value of
+ * any model is in its training data. See {@link MLScoringStrategy}, which trains
+ * this model on clearly-SYNTHETIC seed data and labels the output accordingly.
+ *
+ * @module server/services/MLScoringModel
+ */
+
+export interface FeatureStats {
+  mean: number
+  std: number
+}
+
+export interface ModelWeights {
+  /** Bias term. */
+  intercept: number
+  /** Learned weight per feature name. */
+  weights: Record<string, number>
+  /** Per-feature normalization statistics captured at training time. */
+  normalizers: Record<string, FeatureStats>
+  /** Stable feature ordering (documentation / reproducibility). */
+  featureOrder: string[]
+  /** ISO timestamp the model was trained. */
+  trainedAt: string
+  /** Semantic version of the weights artifact. */
+  modelVersion: string
+}
+
+export interface TrainingExample {
+  features: Record<string, number>
+  /** Target label in [0, 1]; for classification use 0 or 1. */
+  label: number
+  /** Optional per-sample weight for class imbalance. */
+  sampleWeight?: number
+}
+
+export interface TrainingOptions {
+  learningRate?: number
+  epochs?: number
+  /** L2 regularization strength (ridge). */
+  l2?: number
+}
+
+export interface TrainingMetrics {
+  finalLoss: number
+  epochs: number
+  learningRate: number
+  samples: number
+  /** Training-set accuracy at a 0.5 threshold (overfitting smoke-check). */
+  trainAccuracy: number
+}
+
+const MIN_STD = 1e-6
+
+export class MLScoringModel {
+  private weights: ModelWeights | null = null
+
+  /** Numerically-stable logistic sigmoid. */
+  static sigmoid(z: number): number {
+    if (z >= 0) {
+      const e = Math.exp(-z)
+      return 1 / (1 + e)
+    }
+    const e = Math.exp(z)
+    return e / (1 + e)
+  }
+
+  /** Whether the model has trained or loaded weights. */
+  isReady(): boolean {
+    return this.weights !== null
+  }
+
+  private computeNormalizers(rows: Record<string, number>[]): {
+    normalizers: Record<string, FeatureStats>
+    featureOrder: string[]
+  } {
+    const featureOrder = Array.from(
+      rows.reduce<Set<string>>((set, row) => {
+        Object.keys(row).forEach((k) => set.add(k))
+        return set
+      }, new Set<string>())
+    ).sort()
+
+    const normalizers: Record<string, FeatureStats> = {}
+    for (const key of featureOrder) {
+      const values = rows.map((r) => r[key] ?? 0)
+      const mean = values.reduce((a, b) => a + b, 0) / values.length
+      const variance =
+        values.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) / Math.max(values.length, 1)
+      normalizers[key] = { mean, std: Math.max(Math.sqrt(variance), MIN_STD) }
+    }
+    return { normalizers, featureOrder }
+  }
+
+  private normalize(
+    features: Record<string, number>,
+    normalizers: Record<string, FeatureStats>
+  ): Record<string, number> {
+    const out: Record<string, number> = {}
+    for (const [key, norm] of Object.entries(normalizers)) {
+      const raw = features[key] ?? 0
+      out[key] = (raw - norm.mean) / norm.std
+    }
+    return out
+  }
+
+  /**
+   * Fit the model to labeled examples via batch gradient descent.
+   */
+  train(examples: TrainingExample[], options: TrainingOptions = {}): TrainingMetrics {
+    if (examples.length === 0) {
+      throw new Error('MLScoringModel.train: no training examples provided')
+    }
+    const learningRate = options.learningRate ?? 0.05
+    const epochs = options.epochs ?? 400
+    const l2 = options.l2 ?? 0.001
+
+    const { normalizers, featureOrder } = this.computeNormalizers(examples.map((e) => e.features))
+    const weights: Record<string, number> = {}
+    for (const key of featureOrder) weights[key] = 0
+    let intercept = 0
+
+    const normalizedRows = examples.map((e) => ({
+      x: this.normalize(e.features, normalizers),
+      y: e.label,
+      w: e.sampleWeight ?? 1
+    }))
+
+    let finalLoss = 0
+    for (let epoch = 0; epoch < epochs; epoch++) {
+      const gradW: Record<string, number> = {}
+      for (const key of featureOrder) gradW[key] = 0
+      let gradB = 0
+      let loss = 0
+      let weightSum = 0
+
+      for (const row of normalizedRows) {
+        let z = intercept
+        for (const key of featureOrder) z += weights[key] * (row.x[key] ?? 0)
+        const pred = MLScoringModel.sigmoid(z)
+        const error = pred - row.y
+
+        loss +=
+          row.w *
+          -(
+            row.y * Math.log(Math.max(pred, 1e-12)) +
+            (1 - row.y) * Math.log(Math.max(1 - pred, 1e-12))
+          )
+        weightSum += row.w
+
+        gradB += row.w * error
+        for (const key of featureOrder) gradW[key] += row.w * error * (row.x[key] ?? 0)
+      }
+
+      const denom = Math.max(weightSum, 1)
+      intercept -= learningRate * (gradB / denom)
+      for (const key of featureOrder) {
+        // Gradient + L2 shrinkage (bias is not regularized).
+        weights[key] -= learningRate * (gradW[key] / denom + l2 * weights[key])
+      }
+      finalLoss = loss / denom
+    }
+
+    this.weights = {
+      intercept,
+      weights,
+      normalizers,
+      featureOrder,
+      trainedAt: new Date().toISOString(),
+      modelVersion: '1.0.0'
+    }
+
+    // Training-set accuracy as an overfitting smoke-check.
+    let correct = 0
+    for (const e of examples) {
+      const p = this.predict(e.features)
+      if ((p >= 0.5 ? 1 : 0) === (e.label >= 0.5 ? 1 : 0)) correct++
+    }
+
+    return {
+      finalLoss,
+      epochs,
+      learningRate,
+      samples: examples.length,
+      trainAccuracy: correct / examples.length
+    }
+  }
+
+  /**
+   * Predict the probability (0..1) for a feature vector.
+   * @throws if the model has no weights (train or load first).
+   */
+  predict(features: Record<string, number>): number {
+    if (!this.weights) {
+      throw new Error('MLScoringModel.predict: model has no weights (train or loadWeights first)')
+    }
+    const normalized = this.normalize(features, this.weights.normalizers)
+    let z = this.weights.intercept
+    for (const [key, weight] of Object.entries(this.weights.weights)) {
+      z += weight * (normalized[key] ?? 0)
+    }
+    return MLScoringModel.sigmoid(z)
+  }
+
+  loadWeights(weights: ModelWeights): void {
+    this.weights = weights
+  }
+
+  exportWeights(): ModelWeights {
+    if (!this.weights) {
+      throw new Error('MLScoringModel.exportWeights: model has no weights')
+    }
+    return JSON.parse(JSON.stringify(this.weights)) as ModelWeights
+  }
+}

--- a/server/services/MLScoringStrategy.ts
+++ b/server/services/MLScoringStrategy.ts
@@ -1,0 +1,228 @@
+/**
+ * MLScoringStrategy — domain wiring for the {@link MLScoringModel}.
+ *
+ * Responsibilities:
+ *  - Map the prospect signals the ScoringService already fetches (filing
+ *    recency/counts, review sentiment, violations, time-since-default) into a
+ *    numeric feature vector.
+ *  - Provide a reproducible, clearly-SYNTHETIC labeled dataset to seed the model
+ *    (generated from a deterministic PRNG + a latent heuristic + noise).
+ *  - Produce an ML score with HONEST metadata: low confidence and an explicit
+ *    warning that the model is trained on synthetic seed data and must be
+ *    validated against real repayment/closed-deal outcomes before it can be
+ *    relied upon. The rules-based composite score remains the product default.
+ *
+ * @module server/services/MLScoringStrategy
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { MLScoringModel, type ModelWeights, type TrainingExample } from './MLScoringModel'
+
+/**
+ * The raw prospect signals available at scoring time (a subset of what
+ * ScoringService.scoreProspect already computes from the database).
+ */
+export interface MlProspectInput {
+  daysSinceLastFiling: number
+  totalFilings: number
+  activeFilings: number
+  lapsedFilings: number
+  terminatedFilings: number
+  timeSinceDefault: number
+  reviewCount: number
+  /** Average sentiment on a 0..1 scale (as stored in health_scores). */
+  avgSentiment: number
+  violationCount: number
+  /** Latest rules-based health score (0..100), if available. */
+  healthScore: number
+}
+
+export interface MlScoreOutput {
+  /** Raw model probability in [0, 1]. */
+  probability: number
+  /** Probability scaled to a 0..100 score for display. */
+  score: number
+  /**
+   * Confidence in this ML score, intentionally LOW: the model is trained on
+   * synthetic seed data, not validated outcomes.
+   */
+  confidence: number
+  modelVersion: string
+  /** Explicit, user-facing honesty disclosure. */
+  warning: string
+}
+
+// Resolve from the process working directory (the repo root for every way this
+// codebase is run: npm scripts, tsx, vitest, and `node dist/server.cjs`). This
+// avoids __dirname/import.meta differences between the CJS server bundle and the
+// ESM tooling. If the artifact is absent the strategy retrains deterministically
+// in-memory, so a mis-resolved path degrades gracefully rather than breaking.
+const WEIGHTS_PATH = path.resolve(process.cwd(), 'server', 'models', 'ml-scoring-weights.json')
+const SYNTHETIC_SEED = 0x9e3779b9
+const ML_WARNING =
+  'Experimental ML score: trained on synthetic seed data, NOT validated against ' +
+  'real repayment/closed-deal outcomes. Use only alongside the rules-based score; ' +
+  'do not make underwriting decisions on it until validated on labeled history.'
+
+/** Deterministic PRNG (mulberry32) so the synthetic dataset is reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+export class MLScoringStrategy {
+  private readonly model: MLScoringModel
+  private prepared = false
+
+  constructor(model: MLScoringModel = new MLScoringModel()) {
+    this.model = model
+  }
+
+  /**
+   * Derive the numeric feature vector from raw prospect signals. Engineered
+   * features mirror the heuristics the rules engine uses but are left for the
+   * model to weight.
+   */
+  extractFeatures(input: MlProspectInput): Record<string, number> {
+    const totalFilings = Math.max(input.totalFilings, 0)
+    const filingBurden = totalFilings > 0 ? input.activeFilings / totalFilings : 0
+    const terminatedRatio = totalFilings > 0 ? input.terminatedFilings / totalFilings : 0
+    const lapsedRatio = totalFilings > 0 ? input.lapsedFilings / totalFilings : 0
+    const recency = clamp(1 - input.daysSinceLastFiling / 365, 0, 1)
+    // Recovery sweet spot: ~3 months to ~3 years past default.
+    const recoveryWindow = clamp((input.timeSinceDefault - 90) / (1095 - 90), 0, 1)
+
+    return {
+      recency,
+      logFilings: Math.log1p(totalFilings),
+      filingBurden,
+      terminatedRatio,
+      lapsedRatio,
+      recoveryWindow,
+      logReviews: Math.log1p(Math.max(input.reviewCount, 0)),
+      sentiment: clamp(input.avgSentiment, 0, 1),
+      violations: clamp(input.violationCount, 0, 10) / 10,
+      healthNorm: clamp(input.healthScore, 0, 100) / 100
+    }
+  }
+
+  /**
+   * Build a reproducible, clearly-SYNTHETIC labeled dataset. Each example is a
+   * randomly-drawn (seeded) prospect profile; the label is a latent linear rule
+   * over the features plus noise, then thresholded. This is a stand-in for real
+   * outcome labels (repaid vs. defaulted) and is NOT representative of the live
+   * market — it only lets the model learn coherent, inspectable weights.
+   */
+  generateSyntheticTrainingData(count = 240): TrainingExample[] {
+    const rand = mulberry32(SYNTHETIC_SEED)
+
+    // Latent "strong prospect" score (synthetic ground truth) over the features.
+    const latentOf = (f: Record<string, number>): number =>
+      1.4 * f.recency +
+      1.1 * f.recoveryWindow +
+      0.9 * f.terminatedRatio +
+      0.8 * f.sentiment +
+      0.5 * f.healthNorm +
+      0.4 * f.logReviews -
+      1.3 * f.filingBurden -
+      1.0 * f.violations
+
+    // Pass 1: draw feature vectors + their (noise-free) latent score.
+    const drawn: Array<{ features: Record<string, number>; latent: number }> = []
+    for (let i = 0; i < count; i++) {
+      const totalFilings = Math.floor(rand() * 8)
+      const activeFilings = Math.floor(rand() * (totalFilings + 1))
+      const terminatedFilings = Math.floor(rand() * (totalFilings - activeFilings + 1))
+      const lapsedFilings = Math.max(0, totalFilings - activeFilings - terminatedFilings)
+      const features = this.extractFeatures({
+        daysSinceLastFiling: Math.floor(rand() * 1200),
+        totalFilings,
+        activeFilings,
+        lapsedFilings,
+        terminatedFilings,
+        timeSinceDefault: Math.floor(rand() * 1400),
+        reviewCount: Math.floor(rand() * 60),
+        avgSentiment: rand(),
+        violationCount: Math.floor(rand() * 6),
+        healthScore: Math.floor(rand() * 100)
+      })
+      drawn.push({ features, latent: latentOf(features) })
+    }
+
+    // Center the decision boundary at the median latent so the two classes are
+    // balanced regardless of the feature distribution; deterministic noise then
+    // adds realistic overlap (so the data is not trivially separable).
+    const sortedLatents = drawn.map((d) => d.latent).sort((a, b) => a - b)
+    const mid = Math.floor(sortedLatents.length / 2)
+    const median =
+      sortedLatents.length % 2 === 0
+        ? (sortedLatents[mid - 1] + sortedLatents[mid]) / 2
+        : sortedLatents[mid]
+
+    return drawn.map((d) => {
+      const noise = (rand() - 0.5) * 0.5
+      return { features: d.features, label: d.latent - median + noise >= 0 ? 1 : 0 }
+    })
+  }
+
+  /**
+   * Ensure the model has weights: prefer the committed artifact, otherwise train
+   * deterministically on the synthetic seed data (same result the training
+   * script produces). Memoized.
+   */
+  ensureModel(): void {
+    if (this.prepared && this.model.isReady()) return
+
+    const loaded = this.tryLoadWeights()
+    if (loaded) {
+      this.model.loadWeights(loaded)
+    } else {
+      this.model.train(this.generateSyntheticTrainingData(), { epochs: 400, learningRate: 0.05 })
+    }
+    this.prepared = true
+  }
+
+  private tryLoadWeights(): ModelWeights | null {
+    try {
+      if (fs.existsSync(WEIGHTS_PATH)) {
+        const raw = fs.readFileSync(WEIGHTS_PATH, 'utf8')
+        const parsed = JSON.parse(raw) as ModelWeights
+        if (parsed && parsed.weights && parsed.normalizers) return parsed
+      }
+    } catch {
+      // Fall back to deterministic in-memory training.
+    }
+    return null
+  }
+
+  /**
+   * Score a prospect with the ML model. Always returns honest, low-confidence
+   * metadata and a warning; the rules-based score remains the product default.
+   */
+  score(input: MlProspectInput): MlScoreOutput {
+    this.ensureModel()
+    const probability = this.model.predict(this.extractFeatures(input))
+    const version = this.model.isReady() ? this.model.exportWeights().modelVersion : '0.0.0'
+    return {
+      probability,
+      score: Math.round(probability * 100),
+      confidence: 0.3,
+      modelVersion: version,
+      warning: ML_WARNING
+    }
+  }
+}
+
+export const mlScoringStrategy = new MLScoringStrategy()
+export { ML_WARNING, WEIGHTS_PATH }

--- a/server/services/ScoringService.ts
+++ b/server/services/ScoringService.ts
@@ -7,11 +7,19 @@
  * - Position Score: Stack position estimation
  * - Composite Score: Weighted combination
  *
+ * The composite score is a TRANSPARENT, rules-based weighted formula (see
+ * DEFAULT_CONFIG and the INDUSTRY_RISK_MODIFIERS / STATE_MODIFIERS tables) and
+ * is the product default. An OPTIONAL machine-learning score (logistic
+ * regression, see {@link MLScoringStrategy}) can be attached via the `includeMl`
+ * option; it is supplementary, low-confidence, and clearly labeled as trained on
+ * synthetic seed data until validated against real outcomes.
+ *
  * Formula based on MCA industry research and best practices.
  */
 
 import { database } from '../database/connection'
 import { EquipmentLifecycleDetector } from './EquipmentLifecycleDetector'
+import { mlScoringStrategy, type MlScoreOutput } from './MLScoringStrategy'
 
 export interface IntentScoreInput {
   daysSinceLastFiling: number
@@ -68,6 +76,12 @@ export interface ScoringResult {
   }[]
   recommendation: 'high_priority' | 'moderate_priority' | 'low_priority' | 'pass'
   narrative: string
+  /**
+   * Optional supplementary ML score (only present when scored with
+   * `includeMl: true`). The rules-based `compositeScore` remains authoritative;
+   * this is experimental and carries its own (low) confidence + warning.
+   */
+  mlScoring?: MlScoreOutput
 }
 
 export interface ScoringConfig {
@@ -111,8 +125,8 @@ const DEFAULT_CONFIG: ScoringConfig = {
 // Industry risk modifiers (lower = higher risk)
 const INDUSTRY_RISK_MODIFIERS: Record<string, number> = {
   restaurant: 0.85,
-  retail: 0.90,
-  construction: 0.80,
+  retail: 0.9,
+  construction: 0.8,
   healthcare: 0.95,
   manufacturing: 0.88,
   services: 0.92,
@@ -156,7 +170,8 @@ export class ScoringService {
       recencyScore = 90 - (input.daysSinceLastFiling - 30) * 0.3
     } else if (input.daysSinceLastFiling <= 365) {
       recencyScore = 72 - (input.daysSinceLastFiling - 90) * 0.1
-    } else if (input.daysSinceLastFiling <= 1095) { // 3 years
+    } else if (input.daysSinceLastFiling <= 1095) {
+      // 3 years
       recencyScore = 44.5 - (input.daysSinceLastFiling - 365) * 0.02
     } else {
       recencyScore = Math.max(10, 30 - (input.daysSinceLastFiling - 1095) * 0.01)
@@ -183,7 +198,11 @@ export class ScoringService {
       const terminatedRatio = input.terminatedFilings / input.totalFilings
 
       // Terminated is better (paid off), lapsed is neutral, active is concerning
-      patternScore = 50 + terminatedRatio * 30 + lapsedRatio * 10 - (input.activeFilings / input.totalFilings) * 20
+      patternScore =
+        50 +
+        terminatedRatio * 30 +
+        lapsedRatio * 10 -
+        (input.activeFilings / input.totalFilings) * 20
     }
 
     // Trend adjustment
@@ -273,7 +292,7 @@ export class ScoringService {
         score -= 30 // Too leveraged
       } else if (paymentBurden > 0.15) {
         score -= 15
-      } else if (paymentBurden > 0.10) {
+      } else if (paymentBurden > 0.1) {
         score -= 5
       }
       // Low burden is good - no penalty
@@ -362,19 +381,24 @@ export class ScoringService {
     // Intent insight
     if (result.intentScore >= 70) {
       parts.push(`Recent UCC activity suggests active financing interest.`)
-    } else if (Number.isFinite(daysSinceDefault) && daysSinceDefault > 1095) { // 3+ years
+    } else if (Number.isFinite(daysSinceDefault) && daysSinceDefault > 1095) {
+      // 3+ years
       // Guard against missing/NULL time_since_default so we never render
       // "NaN years ago".
-      parts.push(`Last default was ${Math.round(daysSinceDefault / 365)} years ago, indicating potential recovery.`)
+      parts.push(
+        `Last default was ${Math.round(daysSinceDefault / 365)} years ago, indicating potential recovery.`
+      )
     }
 
     // Health insight
     if (result.healthScore >= 75) {
       parts.push(`Business health indicators are positive.`)
     } else if (result.healthScore < 50) {
-      const healthFactors = result.factors.filter(f => f.impact === 'negative' && f.name.includes('health'))
+      const healthFactors = result.factors.filter(
+        (f) => f.impact === 'negative' && f.name.includes('health')
+      )
       if (healthFactors.length > 0) {
-        parts.push(`Health concerns include: ${healthFactors.map(f => f.name).join(', ')}.`)
+        parts.push(`Health concerns include: ${healthFactors.map((f) => f.name).join(', ')}.`)
       }
     }
 
@@ -403,6 +427,8 @@ export class ScoringService {
     options: {
       industry?: string
       state?: string
+      /** Attach an optional, supplementary ML score (default: false). */
+      includeMl?: boolean
     } = {}
   ): Promise<ScoringResult> {
     // Fetch prospect data
@@ -466,12 +492,12 @@ export class ScoringService {
       : 9999
 
     // Count filing statuses
-    const activeFilings = filings.filter(f => f.status === 'active').length
-    const lapsedFilings = filings.filter(f => f.status === 'lapsed').length
-    const terminatedFilings = filings.filter(f => f.status === 'terminated').length
+    const activeFilings = filings.filter((f) => f.status === 'active').length
+    const lapsedFilings = filings.filter((f) => f.status === 'lapsed').length
+    const terminatedFilings = filings.filter((f) => f.status === 'terminated').length
 
     // Determine trend
-    const recentFilings = filings.filter(f => {
+    const recentFilings = filings.filter((f) => {
       const daysAgo = (Date.now() - new Date(f.filing_date).getTime()) / (1000 * 60 * 60 * 24)
       return daysAgo <= 365
     }).length
@@ -502,7 +528,8 @@ export class ScoringService {
       // to 2.5 stars (a penalty). Use == null so a legitimate 0 sentiment is
       // honored rather than defaulting to a neutral 3.
       avgRating: healthData?.avg_sentiment == null ? 3 : 1 + healthData.avg_sentiment * 4,
-      sentimentTrend: (healthData?.sentiment_trend as 'improving' | 'stable' | 'declining') || 'stable',
+      sentimentTrend:
+        (healthData?.sentiment_trend as 'improving' | 'stable' | 'declining') || 'stable',
       violationCount: healthData?.violation_count || 0,
       yearsInBusiness: 3, // Default, would need enrichment
       hasWebsite: true, // Would need enrichment
@@ -556,13 +583,23 @@ export class ScoringService {
       {
         name: 'UCC Recency',
         value: daysSinceLastFiling,
-        impact: daysSinceLastFiling < 365 ? 'positive' : daysSinceLastFiling > 1095 ? 'negative' : 'neutral',
+        impact:
+          daysSinceLastFiling < 365
+            ? 'positive'
+            : daysSinceLastFiling > 1095
+              ? 'negative'
+              : 'neutral',
         weight: this.config.intentRecencyWeight
       },
       {
         name: 'Filing History',
         value: filings.length,
-        impact: filings.length > 0 && filings.length < 5 ? 'positive' : filings.length > 6 ? 'negative' : 'neutral',
+        impact:
+          filings.length > 0 && filings.length < 5
+            ? 'positive'
+            : filings.length > 6
+              ? 'negative'
+              : 'neutral',
         weight: this.config.intentVolumeWeight
       },
       {
@@ -586,7 +623,12 @@ export class ScoringService {
       factors.push({
         name: 'Review Sentiment',
         value: healthData.avg_sentiment,
-        impact: healthData.avg_sentiment > 0.6 ? 'positive' : healthData.avg_sentiment < 0.4 ? 'negative' : 'neutral',
+        impact:
+          healthData.avg_sentiment > 0.6
+            ? 'positive'
+            : healthData.avg_sentiment < 0.4
+              ? 'negative'
+              : 'neutral',
         weight: this.config.healthReviewWeight
       })
 
@@ -631,15 +673,33 @@ export class ScoringService {
       Number.isFinite(prospect.time_since_default) ? prospect.time_since_default : 0
     )
 
-    return { ...result, narrative }
+    // Optional supplementary ML score, computed from the SAME fetched signals
+    // (no extra queries). Kept separate from the authoritative rules-based score.
+    let mlScoring: MlScoreOutput | undefined
+    if (options.includeMl) {
+      mlScoring = mlScoringStrategy.score({
+        daysSinceLastFiling,
+        totalFilings: filings.length,
+        activeFilings,
+        lapsedFilings,
+        terminatedFilings,
+        timeSinceDefault: Number.isFinite(prospect.time_since_default)
+          ? prospect.time_since_default
+          : 0,
+        reviewCount: healthData?.review_count ?? 0,
+        avgSentiment: healthData?.avg_sentiment ?? 0.5,
+        violationCount: healthData?.violation_count ?? 0,
+        healthScore: healthData?.score ?? healthScore
+      })
+    }
+
+    return { ...result, narrative, ...(mlScoring ? { mlScoring } : {}) }
   }
 
   /**
    * Batch score multiple prospects
    */
-  async scoreProspects(
-    prospectIds: string[]
-  ): Promise<Map<string, ScoringResult>> {
+  async scoreProspects(prospectIds: string[]): Promise<Map<string, ScoringResult>> {
     const results = new Map<string, ScoringResult>()
 
     for (const id of prospectIds) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,14 @@
 {
-  "buildCommand": "npm install --legacy-peer-deps && npm run build"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm install --legacy-peer-deps && npm run build",
+  "outputDirectory": "apps/web/dist",
+  "functions": {
+    "api/index.ts": { "maxDuration": 30 },
+    "api/spark-fallback.ts": { "maxDuration": 5 }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api" },
+    { "source": "/_spark/(.*)", "destination": "/api/spark-fallback" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }
-


### PR DESCRIPTION
## What this is

A real-code remediation of the six verified audit defects, **rebased onto current `main`** (`b5a83f6`) and re-verified. Not doc-only — every fix is exercised by tests.

## The six defects, healed

| # | Defect | Fix |
|---|--------|-----|
| 1 | False test claims / failing web suite | Fixed the vitest config-glob bug + jsdom 27 `localStorage` regression (`apps/web/src/test/setup.ts` polyfill). Web suite green. |
| 2 | 5 critical + 8 high dep vulns | `npm overrides` + dependabot reconciliation → **0 critical / 0 high** (11 moderate remain — Expo/RN, need a major-version migration; documented). |
| 3 | "50 states / 60+ agents" but 3 implemented, NY disabled | Re-enabled the NY portal-scraper collector (credential-gated, fail-closed); `getImplementedStates()` → CA/TX/FL/NY. Corrected all "50 states / 60+ agents" overclaims in README/docs. |
| 4 | "ML scoring" was a rules engine | Added a genuinely-trainable logistic-regression model (`MLScoringModel`/`MLScoringStrategy`) with a reproducible weights artifact. **Opt-in, low-confidence, honestly labeled as synthetic-seed-trained**; the transparent rules score stays authoritative. |
| 5 | D&B/Clearbit/ZoomInfo/SAM.gov not wired | Added key-gated, **fail-closed** adapters (named error when unkeyed, real HTTP when keyed). `EnrichmentService` only queries configured sources, preserving honest confidence math. |
| 6 | Live URL has no backend (all `/api/*` + `/_spark/*` → 404) | Added Vercel serverless functions forwarding to the real Express app (`api/index.ts`, `getServerlessApp()`), a benign Spark fallback, and `vercel.json` routing. **Verified locally, not deployed** — see below. |

## Bonus root-cause fix discovered during re-verification

Rebasing surfaced a **pre-existing** failing test (`leadExport`) caused by the Express 5 upgrade: `req.query` became a recomputed getter, so `validateRequest`'s in-place mutation no longer persisted — query-schema coercions (`state`→uppercase, numeric `score`/`limit`/`offset`) were silently dropped repo-wide. Replaced the mutation with `Object.defineProperty`. This fixes coercion for **every** query-validated route, not just lead export.

## Verification (this branch, post-rebase)

- **Tests:** 3,399 passing / 168 files, 0 failures on a clean run.
  - `npm test` → 2,029 / 88 (apps/web jsdom + root project)
  - `npm run test:server` → 1,370 / 80 (+6 skipped)
- **Build:** `npm run build` ✓
- **Audit:** `npm audit` → 0 critical, 0 high, 11 moderate.

## Honest constraints (please read before merging)

- **Deployment #6 is wired + locally proven, not live-deployed.** A real deploy still needs a Vercel project + Postgres/Redis + the secrets in `docs/DEPLOYMENT.md`. Background workers are **not** serverless and must run separately.
- **Commercial enrichment schemas are unverified against paid accounts.** Adapters follow each vendor's published REST shape and fail closed; field mappings should be confirmed against your contract/tier before relying on values.
- **NY collector is wired + unit-tested but the live SoS portal was not exercised** (needs `NY_UCC_DEBTOR_SEEDS` + a live run).
- **ML model is trained on synthetic seed data** pending real outcome labels; it is opt-in and labeled low-confidence by design.
- **11 moderate CVEs remain** (Expo/React Native chain) — require a framework major-version migration, out of scope here.
- **One pre-existing, order-dependent flaky server test** (`outreach` briefing "cache warm") can fail on full-suite runs; it passes in isolation and on re-run and is unrelated to these changes.

## Scope

Two commits: the rebased remediation, and the Express-5 coercion + verified-count correction. No deletions of others' work; the upstream `lead-export` feature, security deployment-gate doc, and dependabot bumps were all preserved and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
