### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-simplify-0622] Reduce complexity in organvm/public-record-data-scrapper

### DIFF
--- a/server/__tests__/services/secEdgarRegistrantsChannel.test.ts
+++ b/server/__tests__/services/secEdgarRegistrantsChannel.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Rate limiter is a no-op in tests — never block / hit a real bucket.
+vi.mock('@public-records/core/enrichment', () => ({
+  rateLimiterManager: {
+    waitForTokens: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+import { SECEdgarRegistrantsChannel } from '../../services/discovery-channels/SECEdgarRegistrantsChannel'
+import { DiscoveryChannelError } from '../../services/discovery-channels/types'
+
+/** A successful JSON Response wrapping the documented EDGAR envelope. */
+function edgarResponse(hits: unknown[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ hits: { hits } })
+  } as unknown as Response
+}
+
+function hit(source: Record<string, unknown>): unknown {
+  return { _source: source }
+}
+
+describe('SECEdgarRegistrantsChannel', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('always reports as configured (key-less public source)', () => {
+    expect(new SECEdgarRegistrantsChannel().isConfigured()).toBe(true)
+  })
+
+  it('parses registrants, strips the CIK annotation, and scores S-1 above 8-K', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      edgarResponse([
+        hit({
+          display_names: ['ACME, Inc.  (CIK 0001234567)'],
+          biz_states: ['CA'],
+          form: 'S-1',
+          file_date: '2025-01-14',
+          sics: ['7372'],
+          ciks: ['0001234567']
+        }),
+        hit({
+          display_names: ['Beta Co (CIK 0007654321)'],
+          biz_states: ['NY'],
+          form: '8-K',
+          file_date: '2025-01-10',
+          ciks: ['0007654321']
+        })
+      ])
+    )
+
+    const candidates = await new SECEdgarRegistrantsChannel().discover({ limit: 10 })
+
+    expect(candidates.map((c) => c.company_name)).toEqual(['ACME, Inc.', 'Beta Co'])
+    expect(candidates[0]).toMatchObject({
+      state: 'CA',
+      signal_type: 'expansion',
+      signal_strength: 70, // S-1
+      source: 'sec-edgar-registrants'
+    })
+    expect(candidates[0].raw).toMatchObject({ form: 'S-1', cik: '0001234567', sic: '7372' })
+    expect(candidates[1].signal_strength).toBe(55) // 8-K
+  })
+
+  it('dedupes the same filer reported across multiple documents', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      edgarResponse([
+        hit({ display_names: ['Dup LLC (CIK 1)'], biz_states: ['CA'], form: 'S-1' }),
+        hit({ display_names: ['Dup LLC (CIK 1)'], biz_states: ['CA'], form: '8-K' })
+      ])
+    )
+
+    const candidates = await new SECEdgarRegistrantsChannel().discover({ limit: 10 })
+    expect(candidates).toHaveLength(1)
+  })
+
+  it('filters to the requested state', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      edgarResponse([
+        hit({ display_names: ['CA Co (CIK 1)'], biz_states: ['CA'], form: 'S-1' }),
+        hit({ display_names: ['NY Co (CIK 2)'], biz_states: ['NY'], form: 'S-1' })
+      ])
+    )
+
+    const candidates = await new SECEdgarRegistrantsChannel().discover({ state: 'ca', limit: 10 })
+    expect(candidates.map((c) => c.company_name)).toEqual(['CA Co'])
+  })
+
+  it('respects the limit', async () => {
+    const hits = Array.from({ length: 5 }, (_, n) =>
+      hit({ display_names: [`Co ${n} (CIK ${n})`], biz_states: ['CA'], form: 'S-1' })
+    )
+    fetchSpy.mockResolvedValueOnce(edgarResponse(hits))
+
+    const candidates = await new SECEdgarRegistrantsChannel().discover({ limit: 2 })
+    expect(candidates).toHaveLength(2)
+  })
+
+  it('fails closed when the upstream is unreachable', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('network down'))
+    const err = await new SECEdgarRegistrantsChannel().discover({ limit: 10 }).catch((e) => e)
+    expect(err).toBeInstanceOf(DiscoveryChannelError)
+    expect((err as Error).message).toBe('SEC EDGAR unreachable: network down')
+  })
+
+  it('fails closed on a non-2xx response', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    } as unknown as Response)
+
+    await expect(new SECEdgarRegistrantsChannel().discover({ limit: 10 })).rejects.toThrow(
+      /SEC EDGAR returned HTTP 500 Internal Server Error/
+    )
+  })
+
+  it('fails closed when the body is not valid JSON', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        throw new Error('Unexpected token')
+      }
+    } as unknown as Response)
+
+    await expect(new SECEdgarRegistrantsChannel().discover({ limit: 10 })).rejects.toThrow(
+      /SEC EDGAR response was not valid JSON: Unexpected token/
+    )
+  })
+
+  it('fails closed when the documented envelope shape changed', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ unexpected: true })
+    } as unknown as Response)
+
+    await expect(new SECEdgarRegistrantsChannel().discover({ limit: 10 })).rejects.toThrow(
+      /SEC EDGAR response shape changed/
+    )
+  })
+})

--- a/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
+++ b/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Rate limiter is a no-op in tests — never block / hit a real bucket.
+vi.mock('@public-records/core/enrichment', () => ({
+  rateLimiterManager: {
+    waitForTokens: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+import { SocrataBuildingPermitsChannel } from '../../services/discovery-channels/SocrataBuildingPermitsChannel'
+import { DiscoveryChannelError } from '../../services/discovery-channels/types'
+
+/** A successful JSON Response wrapping a Socrata row array. */
+function rowsResponse(rows: Record<string, unknown>[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => rows
+  } as unknown as Response
+}
+
+const NY_FIELD = 'permittee_s_business_name'
+const CA_FIELD = 'contractors_business_name'
+
+describe('SocrataBuildingPermitsChannel', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('always reports as configured (key-less public source)', () => {
+    expect(new SocrataBuildingPermitsChannel().isConfigured()).toBe(true)
+  })
+
+  it('maps NY rows to permit candidates and dedupes by business name', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      rowsResponse([
+        { [NY_FIELD]: 'Acme Builders' },
+        { [NY_FIELD]: 'Acme Builders' }, // duplicate within the page
+        { [NY_FIELD]: 'Beta Contractors' }
+      ])
+    )
+
+    const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+
+    expect(candidates.map((c) => c.company_name)).toEqual(['Acme Builders', 'Beta Contractors'])
+    expect(candidates[0]).toMatchObject({
+      state: 'NY',
+      signal_type: 'permit',
+      signal_strength: 60,
+      source: 'socrata-building-permits'
+    })
+    expect(candidates[0].raw).toMatchObject({ dataset_state: 'NY', business_field: NY_FIELD })
+  })
+
+  it('queries every registered dataset when no state is given', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(rowsResponse([{ [NY_FIELD]: 'NY Co' }]))
+      .mockResolvedValueOnce(rowsResponse([{ [CA_FIELD]: 'CA Co' }]))
+
+    const candidates = await new SocrataBuildingPermitsChannel().discover({ limit: 10 })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(candidates.map((c) => `${c.state}:${c.company_name}`)).toEqual(['NY:NY Co', 'CA:CA Co'])
+  })
+
+  it('caps the total candidates at the requested limit', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      rowsResponse(
+        Array.from({ length: 10 }, (_, n) => ({ [NY_FIELD]: `Co ${n}` }))
+      )
+    )
+
+    const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 3 })
+    expect(candidates).toHaveLength(3)
+  })
+
+  it('fails closed for a state with no registered dataset', async () => {
+    const err = await new SocrataBuildingPermitsChannel()
+      .discover({ state: 'TX', limit: 10 })
+      .catch((e) => e)
+    expect(err).toBeInstanceOf(DiscoveryChannelError)
+    expect((err as Error).message).toMatch(/no building-permit dataset registered for state 'TX'/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the upstream is unreachable', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('connection reset'))
+    await expect(
+      new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    ).rejects.toThrow('Socrata (NY) unreachable: connection reset')
+  })
+
+  it('fails closed on a non-2xx response', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    } as unknown as Response)
+
+    await expect(
+      new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    ).rejects.toThrow(/Socrata \(NY\) returned HTTP 500 Internal Server Error/)
+  })
+
+  it('fails closed when the body is not a JSON array', async () => {
+    fetchSpy.mockResolvedValueOnce(rowsResponse({} as unknown as Record<string, unknown>[]))
+    await expect(
+      new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    ).rejects.toThrow(/Socrata \(NY\) response shape changed: expected a JSON array of rows/)
+  })
+
+  it('fails closed when the documented business field is absent from every row', async () => {
+    fetchSpy.mockResolvedValueOnce(rowsResponse([{ some_other_field: 'x' }, { another: 'y' }]))
+    await expect(
+      new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    ).rejects.toThrow(/Socrata \(NY\) schema changed: field 'permittee_s_business_name' absent/)
+  })
+})

--- a/server/services/discovery-channels/SBALoansChannel.ts
+++ b/server/services/discovery-channels/SBALoansChannel.ts
@@ -33,6 +33,7 @@ import {
   DiscoveryParams,
   DiscoveryChannelError
 } from './types'
+import { clampLimit, normalizeState, errorMessage, fetchWithTimeout, fetchJson } from './utils'
 
 const CHANNEL = 'sba-7a-loans'
 const CKAN_PACKAGE_ID = '0ff8e8e9-b967-4f4e-987c-6ac78c575087'
@@ -41,7 +42,6 @@ const CKAN_PACKAGE_SHOW = `https://data.sba.gov/api/3/action/package_show?id=${C
 const RECENT_7A_RESOURCE_STEM = 'foia-7a-fy2020-present'
 const RATE_BUCKET = 'sba'
 const REQUEST_TIMEOUT_MS = 20000
-const DEFAULT_LIMIT = 25
 const REQUIRED_COLUMNS = ['borrname', 'borrstate', 'approvaldate'] as const
 
 interface CkanResource {
@@ -71,33 +71,13 @@ export class SBALoansChannel implements DiscoveryChannel {
 
   /** Resolve the rotating recent-7(a) CSV resource URL via CKAN. */
   private async resolveRecentCsvUrl(): Promise<string> {
-    let response: Response
-    try {
-      response = await fetchWithTimeout(CKAN_PACKAGE_SHOW, {
-        headers: { Accept: 'application/json' }
-      })
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SBA CKAN unreachable: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
-    if (!response.ok) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SBA CKAN returned HTTP ${response.status} ${response.statusText}`
-      )
-    }
-
-    let body: unknown
-    try {
-      body = await response.json()
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SBA CKAN response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
+    const body = await fetchJson(
+      CHANNEL,
+      CKAN_PACKAGE_SHOW,
+      { headers: { Accept: 'application/json' } },
+      'SBA CKAN',
+      REQUEST_TIMEOUT_MS
+    )
 
     const resources = (body as { result?: { resources?: unknown } })?.result?.resources
     if (!Array.isArray(resources)) {
@@ -141,12 +121,13 @@ export class SBALoansChannel implements DiscoveryChannel {
     const abort = new AbortController()
     let response: Response
     try {
-      response = await fetchWithTimeout(url, { headers: { Accept: 'text/csv' } }, abort.signal)
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SBA CSV unreachable: ${err instanceof Error ? err.message : String(err)}`
+      response = await fetchWithTimeout(
+        url,
+        { headers: { Accept: 'text/csv' } },
+        { timeoutMs: REQUEST_TIMEOUT_MS, externalSignal: abort.signal }
       )
+    } catch (err) {
+      throw new DiscoveryChannelError(CHANNEL, `SBA CSV unreachable: ${errorMessage(err)}`)
     }
     if (!response.ok) {
       throw new DiscoveryChannelError(
@@ -212,10 +193,7 @@ export class SBALoansChannel implements DiscoveryChannel {
       // DiscoveryChannelError — propagate it unchanged. Only genuine stream/IO
       // faults get the generic wrapper.
       if (err instanceof DiscoveryChannelError) throw err
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SBA CSV stream failed: ${err instanceof Error ? err.message : String(err)}`
-      )
+      throw new DiscoveryChannelError(CHANNEL, `SBA CSV stream failed: ${errorMessage(err)}`)
     } finally {
       // Stop the download and free the reader. cancel() rejects the underlying
       // stream so the remaining (potentially hundreds of MB) bytes are never
@@ -339,37 +317,4 @@ function parseCsvLine(line: string): string[] {
   }
   fields.push(current)
   return fields
-}
-
-function normalizeState(state?: string): string | null {
-  if (!state) return null
-  const trimmed = state.trim().toUpperCase()
-  return trimmed.length === 2 ? trimmed : null
-}
-
-function clampLimit(limit?: number): number {
-  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT
-  return Math.min(Math.floor(limit), 200)
-}
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  externalSignal?: AbortSignal
-): Promise<Response> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-  // Forward an external abort (e.g. "limit reached" on a stream) into the
-  // timeout controller so a single signal tears the fetch down either way.
-  const onExternalAbort = () => controller.abort()
-  if (externalSignal) {
-    if (externalSignal.aborted) controller.abort()
-    else externalSignal.addEventListener('abort', onExternalAbort, { once: true })
-  }
-  try {
-    return await fetch(url, { ...init, signal: controller.signal })
-  } finally {
-    clearTimeout(timer)
-    if (externalSignal) externalSignal.removeEventListener('abort', onExternalAbort)
-  }
 }

--- a/server/services/discovery-channels/SECEdgarRegistrantsChannel.ts
+++ b/server/services/discovery-channels/SECEdgarRegistrantsChannel.ts
@@ -42,6 +42,7 @@ import {
   DiscoveryParams,
   DiscoveryChannelError
 } from './types'
+import { clampLimit, normalizeState, fetchJson } from './utils'
 
 const CHANNEL = 'sec-edgar-registrants'
 const ENDPOINT = 'https://efts.sec.gov/LATEST/search-index'
@@ -49,7 +50,6 @@ const ENDPOINT = 'https://efts.sec.gov/LATEST/search-index'
 const FORMS = ['S-1', '8-K']
 const USER_AGENT = 'UCC-MCA-Intelligence lead-discovery contact@example.com'
 const REQUEST_TIMEOUT_MS = 12000
-const DEFAULT_LIMIT = 25
 
 interface EdgarHitSource {
   display_names?: unknown
@@ -85,34 +85,13 @@ export class SECEdgarRegistrantsChannel implements DiscoveryChannel {
     })
     const url = `${ENDPOINT}?${qs.toString()}`
 
-    let response: Response
-    try {
-      response = await fetchWithTimeout(url, {
-        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' }
-      })
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SEC EDGAR unreachable: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
-
-    if (!response.ok) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SEC EDGAR returned HTTP ${response.status} ${response.statusText}`
-      )
-    }
-
-    let body: unknown
-    try {
-      body = await response.json()
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `SEC EDGAR response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
+    const body = await fetchJson(
+      CHANNEL,
+      url,
+      { headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' } },
+      'SEC EDGAR',
+      REQUEST_TIMEOUT_MS
+    )
 
     // Fail closed: the documented envelope is { hits: { hits: [...] } }.
     const hits = (body as { hits?: { hits?: unknown } })?.hits?.hits
@@ -192,27 +171,6 @@ function stringOr(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback
 }
 
-function normalizeState(state?: string): string | null {
-  if (!state) return null
-  const trimmed = state.trim().toUpperCase()
-  return trimmed.length === 2 ? trimmed : null
-}
-
 function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10)
-}
-
-function clampLimit(limit?: number): number {
-  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT
-  return Math.min(Math.floor(limit), 200)
-}
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-  try {
-    return await fetch(url, { ...init, signal: controller.signal })
-  } finally {
-    clearTimeout(timer)
-  }
 }

--- a/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
+++ b/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
@@ -35,10 +35,10 @@ import {
   DiscoveryParams,
   DiscoveryChannelError
 } from './types'
+import { clampLimit, fetchJson } from './utils'
 
 const CHANNEL = 'socrata-building-permits'
 const REQUEST_TIMEOUT_MS = 12000
-const DEFAULT_LIMIT = 25
 const RATE_BUCKET = 'socrata'
 
 interface SocrataSource {
@@ -125,32 +125,13 @@ export class SocrataBuildingPermitsChannel implements DiscoveryChannel {
     })
     const url = `${source.url}?${qs.toString()}`
 
-    let response: Response
-    try {
-      response = await fetchWithTimeout(url, { headers: { Accept: 'application/json' } })
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `Socrata (${source.state}) unreachable: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
-
-    if (!response.ok) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `Socrata (${source.state}) returned HTTP ${response.status} ${response.statusText}`
-      )
-    }
-
-    let body: unknown
-    try {
-      body = await response.json()
-    } catch (err) {
-      throw new DiscoveryChannelError(
-        CHANNEL,
-        `Socrata (${source.state}) response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
+    const body = await fetchJson(
+      CHANNEL,
+      url,
+      { headers: { Accept: 'application/json' } },
+      `Socrata (${source.state})`,
+      REQUEST_TIMEOUT_MS
+    )
 
     if (!Array.isArray(body)) {
       throw new DiscoveryChannelError(
@@ -201,20 +182,5 @@ export class SocrataBuildingPermitsChannel implements DiscoveryChannel {
     }
 
     return out
-  }
-}
-
-function clampLimit(limit?: number): number {
-  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT
-  return Math.min(Math.floor(limit), 200)
-}
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-  try {
-    return await fetch(url, { ...init, signal: controller.signal })
-  } finally {
-    clearTimeout(timer)
   }
 }

--- a/server/services/discovery-channels/utils.ts
+++ b/server/services/discovery-channels/utils.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared primitives for discovery channels.
+ *
+ * Every key-less channel repeats the same handful of concerns: clamp the
+ * caller's `limit`, normalise a two-letter state code, fetch with a hard
+ * timeout, and wrap the fetch→ok→json dance in {@link DiscoveryChannelError}s
+ * with a channel-specific label. These were copy-pasted into each channel;
+ * they now live here so the behaviour (and its fail-closed error messages) is
+ * defined exactly once.
+ *
+ * @module server/services/discovery-channels/utils
+ */
+
+import { DiscoveryChannelError } from './types'
+
+/** Default candidate cap when the caller does not specify one. */
+export const DEFAULT_LIMIT = 25
+/** Hard upper bound on candidates a single channel will return. */
+export const MAX_LIMIT = 200
+
+/**
+ * Coerce a caller-supplied `limit` into a sane positive integer in
+ * `[1, MAX_LIMIT]`, falling back to {@link DEFAULT_LIMIT} for missing or
+ * non-finite values.
+ */
+export function clampLimit(limit?: number): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT
+  return Math.min(Math.floor(limit), MAX_LIMIT)
+}
+
+/**
+ * Normalise a state filter to an upper-case two-letter code, or null when
+ * absent / not exactly two characters (a malformed filter is treated as "no
+ * filter" rather than silently matching nothing).
+ */
+export function normalizeState(state?: string): string | null {
+  if (!state) return null
+  const trimmed = state.trim().toUpperCase()
+  return trimmed.length === 2 ? trimmed : null
+}
+
+/** Human-readable message for an unknown thrown value. */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * `fetch` with a hard timeout. An optional `externalSignal` (e.g. a stream
+ * "limit reached" abort) is forwarded into the timeout controller so a single
+ * signal tears the request down either way.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  { timeoutMs, externalSignal }: { timeoutMs: number; externalSignal?: AbortSignal }
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  const onExternalAbort = () => controller.abort()
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort()
+    else externalSignal.addEventListener('abort', onExternalAbort, { once: true })
+  }
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+    if (externalSignal) externalSignal.removeEventListener('abort', onExternalAbort)
+  }
+}
+
+/**
+ * Fetch a URL expected to return JSON, failing closed at each step with a
+ * named {@link DiscoveryChannelError}. `label` prefixes every message (e.g.
+ * `'SEC EDGAR'` → `'SEC EDGAR unreachable: ...'`). Returns the parsed body as
+ * `unknown`; callers validate its documented shape.
+ */
+export async function fetchJson(
+  channel: string,
+  url: string,
+  init: RequestInit,
+  label: string,
+  timeoutMs: number
+): Promise<unknown> {
+  let response: Response
+  try {
+    response = await fetchWithTimeout(url, init, { timeoutMs })
+  } catch (err) {
+    throw new DiscoveryChannelError(channel, `${label} unreachable: ${errorMessage(err)}`)
+  }
+  if (!response.ok) {
+    throw new DiscoveryChannelError(
+      channel,
+      `${label} returned HTTP ${response.status} ${response.statusText}`
+    )
+  }
+  try {
+    return await response.json()
+  } catch (err) {
+    throw new DiscoveryChannelError(
+      channel,
+      `${label} response was not valid JSON: ${errorMessage(err)}`
+    )
+  }
+}


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-simplify-0622`.

Identify the most complex or most-duplicated module in organvm/public-record-data-scrapper and refactor it for clarity, with tests proving behavior is unchanged. Net lines should not grow without cause. [auto-generated 2026-06-22 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._