### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-ci-green-0622] Make organvm/public-record-data-scrapper CI green

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Cold CI runs spend enough CPU on concurrent jsdom workers and transforms
+    // that otherwise-fast interaction tests can exceed Vitest's 5s default.
+    testTimeout: 15000,
     // Pin discovery to this app's own root and source tree. Without this, a
     // root-level `vitest` invocation lets the default `**/*.{test,spec}` glob
     // escape into sibling workspaces (notably the node-environment server

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -34,7 +34,7 @@ const sharedOptions = {
     'assert', 'console',
     // npm packages — keep external (installed via npm install)
     'pg-native', 'bullmq', 'ioredis', 'pg',
-    'puppeteer', 'sharp',
+    'puppeteer', 'sharp', 'fsevents',
     'jsonwebtoken', 'express', 'compression', 'cors', 'helmet',
     'swagger-ui-express', 'yamljs', 'zod', 'dotenv', 'uuid',
     'dompurify', 'marked',


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-ci-green-0622`.

Inspect the latest FAILING checks on organvm/public-record-data-scrapper's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-22 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._