### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-ci-green-0622] Make organvm/public-record-data-scrapper CI green

### DIFF
--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -38,6 +38,9 @@ const sharedOptions = {
     'jsonwebtoken', 'express', 'compression', 'cors', 'helmet',
     'swagger-ui-express', 'yamljs', 'zod', 'dotenv', 'uuid',
     'dompurify', 'marked',
+    // Optional native macOS watcher dependency pulled through transitive tooling.
+    // Bundling it makes esbuild try to load fsevents.node; keep it runtime-resolved.
+    'fsevents',
   ],
   sourcemap: true,
   minify: false,


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-ci-green-0622`.

Inspect the latest FAILING checks on organvm/public-record-data-scrapper's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-22 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._