### PR TITLE
Add API-key auth to unblock first paying customer on scrape API

### DIFF
--- a/database/migrations/023_api_keys.sql
+++ b/database/migrations/023_api_keys.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- Migration 023: API keys for programmatic access
+--
+-- First-paying-customer revenue path: the on-demand UCC scrape endpoints
+-- (server/routes/scrape.ts) are the data-as-a-service product, but they sat
+-- behind JWT-only auth. A JWT requires an interactive IdP/login flow, so there
+-- was no credential an operator could hand a paying stranger to call the API.
+--
+-- This adds long-lived, revocable API keys scoped to an organization. The
+-- secret itself is NEVER stored — only a SHA-256 hash (for lookup) and a short
+-- non-secret prefix (for display, e.g. "prk_AbC12…"). A presented key is
+-- hashed and matched against key_hash; the row carries the org_id and role that
+-- populate the request's auth context, so the existing org-scoping / RLS and
+-- requireRole machinery work unchanged.
+--
+-- Migration style: the runner (scripts/migrate.ts) executes each file as one
+-- pool.query() inside a transaction; this mirrors the repo's transactional,
+-- plain-CREATE convention (no CONCURRENTLY).
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    -- Human label so an operator can tell keys apart ("acme-prod", "trial-bob").
+    name VARCHAR(120) NOT NULL,
+    -- Non-secret leading characters of the full key, safe to display in UIs/logs.
+    key_prefix VARCHAR(16) NOT NULL,
+    -- SHA-256 (hex) of the full presented key. The plaintext key is shown to the
+    -- caller exactly once at creation and never persisted.
+    key_hash CHAR(64) NOT NULL,
+    -- Role granted to requests authenticated with this key. Mirrors the role
+    -- vocabulary the scrape routes gate on via requireRole().
+    role VARCHAR(20) NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
+    -- Best-effort usage timestamp, updated on successful verification. Foundation
+    -- for per-key usage metering / billing.
+    last_used_at TIMESTAMP WITH TIME ZONE,
+    -- Optional expiry; NULL means the key never expires until revoked.
+    expires_at TIMESTAMP WITH TIME ZONE,
+    -- Soft revocation; set to disable a key without losing its audit trail.
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Unique on the hash: verification is a single point lookup by hashed key, and
+-- two keys must never collide to the same secret.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
+
+-- List/manage keys for an org; partial index keeps the common "active keys"
+-- listing cheap.
+CREATE INDEX IF NOT EXISTS idx_api_keys_org ON api_keys(org_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_org_active
+    ON api_keys(org_id) WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE api_keys IS 'Org-scoped programmatic API keys for the data-as-a-service scrape endpoints. Stores a SHA-256 hash of the secret, never the plaintext.';
+COMMENT ON COLUMN api_keys.key_hash IS 'SHA-256 hex digest of the full key; the plaintext is returned once at creation and never stored.';
+COMMENT ON COLUMN api_keys.key_prefix IS 'Non-secret display prefix (e.g. prk_AbC12) for identifying a key without exposing the secret.';
+COMMENT ON COLUMN api_keys.last_used_at IS 'Updated on successful verification; basis for per-key usage metering.';
+
+COMMIT;

--- a/database/migrations/023_down.sql
+++ b/database/migrations/023_down.sql
@@ -1,0 +1,13 @@
+-- 023_down.sql
+--
+-- Reverses migration 023: drops the api_keys table and its indexes.
+--
+-- Destructive: removes all issued API keys. Any caller authenticating with an
+-- API key will fall back to JWT-only access (401 if they have no JWT). The
+-- migration runner wraps this in a transaction.
+
+BEGIN;
+
+DROP TABLE IF EXISTS api_keys;
+
+COMMIT;

--- a/server/__tests__/middleware/apiKeyAuth.test.ts
+++ b/server/__tests__/middleware/apiKeyAuth.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Response, NextFunction } from 'express'
+
+// Mock the JWT auth middleware so we can assert delegation without real tokens.
+vi.mock('../../middleware/authMiddleware', () => ({
+  authMiddleware: vi.fn((_req, _res, next) => next())
+}))
+
+// Mock ApiKeyService.verify. Use a method (not an instance field) that defers
+// to the hoisted mock at call time — apiKeyAuth.ts constructs ApiKeyService at
+// module load, before `verifyMock` would be initialized for a field initializer.
+const { verifyMock } = vi.hoisted(() => ({ verifyMock: vi.fn() }))
+vi.mock('../../services/ApiKeyService', () => ({
+  API_KEY_PREFIX: 'prk_',
+  ApiKeyService: class {
+    verify(...args: unknown[]) {
+      return verifyMock(...args)
+    }
+  }
+}))
+
+import { apiKeyOrJwtAuth, extractApiKey } from '../../middleware/apiKeyAuth'
+import { authMiddleware, type AuthenticatedRequest } from '../../middleware/authMiddleware'
+
+const authMiddlewareMock = vi.mocked(authMiddleware)
+
+function makeReq(headers: Record<string, string> = {}): AuthenticatedRequest {
+  return { headers } as unknown as AuthenticatedRequest
+}
+
+function makeRes(): Response & { statusCode?: number; body?: unknown } {
+  const res = {} as Response & { statusCode?: number; body?: unknown }
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code
+    return res
+  }) as unknown as Response['status']
+  res.json = vi.fn((payload: unknown) => {
+    res.body = payload
+    return res
+  }) as unknown as Response['json']
+  return res
+}
+
+describe('extractApiKey', () => {
+  it('reads X-API-Key header', () => {
+    expect(extractApiKey(makeReq({ 'x-api-key': 'prk_abc' }))).toBe('prk_abc')
+  })
+
+  it('reads a prk_-prefixed Bearer token', () => {
+    expect(extractApiKey(makeReq({ authorization: 'Bearer prk_xyz' }))).toBe('prk_xyz')
+  })
+
+  it('ignores a JWT Bearer token (no prk_ prefix)', () => {
+    expect(extractApiKey(makeReq({ authorization: 'Bearer eyJhbGci.jwt' }))).toBeUndefined()
+  })
+
+  it('returns undefined when no key is present', () => {
+    expect(extractApiKey(makeReq())).toBeUndefined()
+  })
+})
+
+describe('apiKeyOrJwtAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('delegates to JWT auth when no API key is present', async () => {
+    const req = makeReq({ authorization: 'Bearer somejwt' })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await apiKeyOrJwtAuth(req, res, next)
+
+    expect(authMiddlewareMock).toHaveBeenCalledTimes(1)
+    expect(verifyMock).not.toHaveBeenCalled()
+  })
+
+  it('populates req.user and authMethod for a valid API key', async () => {
+    verifyMock.mockResolvedValueOnce({ keyId: 'key-1', orgId: 'org-7', role: 'user' })
+    const req = makeReq({ 'x-api-key': 'prk_valid' })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await apiKeyOrJwtAuth(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(authMiddlewareMock).not.toHaveBeenCalled()
+    expect(req.user).toEqual({ id: 'apikey:key-1', orgId: 'org-7', role: 'user' })
+    expect(req.authMethod).toBe('api_key')
+  })
+
+  it('returns 401 for an invalid API key (no JWT fall-through)', async () => {
+    verifyMock.mockResolvedValueOnce(null)
+    const req = makeReq({ 'x-api-key': 'prk_bad' })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await apiKeyOrJwtAuth(req, res, next)
+
+    expect(res.statusCode).toBe(401)
+    expect(next).not.toHaveBeenCalled()
+    expect(authMiddlewareMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when verification throws', async () => {
+    verifyMock.mockRejectedValueOnce(new Error('db down'))
+    const req = makeReq({ 'x-api-key': 'prk_boom' })
+    const res = makeRes()
+    const next = vi.fn() as NextFunction
+
+    await apiKeyOrJwtAuth(req, res, next)
+
+    expect(res.statusCode).toBe(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/__tests__/services/ApiKeyService.test.ts
+++ b/server/__tests__/services/ApiKeyService.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import crypto from 'crypto'
+import { ApiKeyService, API_KEY_PREFIX } from '../../services/ApiKeyService'
+import { ValidationError } from '../../errors'
+
+// Mock the database module
+vi.mock('../../database/connection', () => ({
+  database: {
+    query: vi.fn()
+  }
+}))
+
+import { database } from '../../database/connection'
+
+const mockQuery = vi.mocked(database.query)
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+describe('ApiKeyService', () => {
+  let service: ApiKeyService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new ApiKeyService()
+  })
+
+  describe('create', () => {
+    it('mints a key, stores only the hash, and returns the plaintext once', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: 'key-1',
+          org_id: 'org-1',
+          name: 'acme-prod',
+          key_prefix: 'prk_AAAAAAAA',
+          role: 'user',
+          last_used_at: null,
+          expires_at: null,
+          revoked_at: null,
+          created_at: '2026-06-23T00:00:00Z'
+        }
+      ])
+
+      const created = await service.create({ orgId: 'org-1', name: 'acme-prod' })
+
+      // Plaintext key returned and well-formed
+      expect(created.key).toMatch(new RegExp(`^${API_KEY_PREFIX}`))
+      expect(created.id).toBe('key-1')
+      expect(created.role).toBe('user')
+
+      // The INSERT must persist the SHA-256 hash of the full key, never the plaintext
+      const [sql, params] = mockQuery.mock.calls[0]
+      expect(sql).toContain('INSERT INTO api_keys')
+      const storedHash = (params as unknown[])[3]
+      expect(storedHash).toBe(sha256(created.key))
+      expect(JSON.stringify(params)).not.toContain(created.key)
+    })
+
+    it('defaults role to user and rejects unknown roles via the param', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: 'key-2',
+          org_id: 'org-1',
+          name: 'admin-key',
+          key_prefix: 'prk_BBBBBBBB',
+          role: 'admin',
+          last_used_at: null,
+          expires_at: null,
+          revoked_at: null,
+          created_at: '2026-06-23T00:00:00Z'
+        }
+      ])
+
+      const created = await service.create({ orgId: 'org-1', name: 'admin-key', role: 'admin' })
+      expect(created.role).toBe('admin')
+      expect((mockQuery.mock.calls[0][1] as unknown[])[4]).toBe('admin')
+    })
+
+    it('throws ValidationError on a blank name', async () => {
+      await expect(service.create({ orgId: 'org-1', name: '   ' })).rejects.toBeInstanceOf(
+        ValidationError
+      )
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('verify', () => {
+    it('returns null for a missing or wrong-prefix key without hitting the db', async () => {
+      expect(await service.verify(undefined)).toBeNull()
+      expect(await service.verify('not-a-key')).toBeNull()
+      expect(mockQuery).not.toHaveBeenCalled()
+    })
+
+    it('resolves auth context for a valid key and stamps last_used_at', async () => {
+      const key = `${API_KEY_PREFIX}secretsecret`
+      mockQuery
+        .mockResolvedValueOnce([
+          { id: 'key-1', org_id: 'org-9', role: 'user', expires_at: null, revoked_at: null }
+        ])
+        .mockResolvedValueOnce([]) // the best-effort last_used_at UPDATE
+
+      const result = await service.verify(key)
+
+      expect(result).toEqual({ keyId: 'key-1', orgId: 'org-9', role: 'user' })
+
+      // Lookup is by the hash of the presented key
+      expect((mockQuery.mock.calls[0][1] as unknown[])[0]).toBe(sha256(key))
+      // Usage stamp issued
+      expect(mockQuery.mock.calls[1][0]).toContain('last_used_at = NOW()')
+    })
+
+    it('returns null for an unknown key', async () => {
+      mockQuery.mockResolvedValueOnce([])
+      expect(await service.verify(`${API_KEY_PREFIX}nope`)).toBeNull()
+    })
+
+    it('returns null for a revoked key', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: 'key-1',
+          org_id: 'org-1',
+          role: 'user',
+          expires_at: null,
+          revoked_at: '2026-06-01T00:00:00Z'
+        }
+      ])
+      expect(await service.verify(`${API_KEY_PREFIX}revoked`)).toBeNull()
+    })
+
+    it('returns null for an expired key', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: 'key-1',
+          org_id: 'org-1',
+          role: 'user',
+          expires_at: '2000-01-01T00:00:00Z',
+          revoked_at: null
+        }
+      ])
+      expect(await service.verify(`${API_KEY_PREFIX}expired`)).toBeNull()
+    })
+
+    it('still succeeds when the best-effort usage stamp write fails', async () => {
+      mockQuery
+        .mockResolvedValueOnce([
+          { id: 'key-1', org_id: 'org-1', role: 'admin', expires_at: null, revoked_at: null }
+        ])
+        .mockRejectedValueOnce(new Error('write failed'))
+
+      const result = await service.verify(`${API_KEY_PREFIX}ok`)
+      expect(result).toEqual({ keyId: 'key-1', orgId: 'org-1', role: 'admin' })
+    })
+  })
+
+  describe('list', () => {
+    it('returns org keys mapped to camelCase without secrets', async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: 'key-1',
+          org_id: 'org-1',
+          name: 'k',
+          key_prefix: 'prk_CCCCCCCC',
+          role: 'user',
+          last_used_at: '2026-06-22T00:00:00Z',
+          expires_at: null,
+          revoked_at: null,
+          created_at: '2026-06-20T00:00:00Z'
+        }
+      ])
+
+      const keys = await service.list('org-1')
+      expect(keys).toHaveLength(1)
+      expect(keys[0]).toMatchObject({ id: 'key-1', orgId: 'org-1', keyPrefix: 'prk_CCCCCCCC' })
+      expect(keys[0]).not.toHaveProperty('key')
+      expect(keys[0]).not.toHaveProperty('keyHash')
+      expect((mockQuery.mock.calls[0][1] as unknown[])[0]).toBe('org-1')
+    })
+  })
+
+  describe('revoke', () => {
+    it('returns true when a key was revoked', async () => {
+      mockQuery.mockResolvedValueOnce([{ id: 'key-1' }])
+      expect(await service.revoke('org-1', 'key-1')).toBe(true)
+      const [sql, params] = mockQuery.mock.calls[0]
+      expect(sql).toContain('revoked_at = COALESCE(revoked_at, NOW())')
+      expect(params).toEqual(['key-1', 'org-1'])
+    })
+
+    it('returns false when no matching key exists for the org', async () => {
+      mockQuery.mockResolvedValueOnce([])
+      expect(await service.revoke('org-1', 'missing')).toBe(false)
+    })
+  })
+})

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,8 @@ import { database } from './database/connection'
 import { errorHandler, notFoundHandler } from './middleware/errorHandler'
 import { requestLogger } from './middleware/requestLogger'
 import { createRateLimiter, closeRateLimiterConnection } from './middleware/rateLimiter'
-import { authMiddleware } from './middleware/authMiddleware'
+import { authMiddleware, requireRole } from './middleware/authMiddleware'
+import { apiKeyOrJwtAuth } from './middleware/apiKeyAuth'
 import { orgContextMiddleware } from './middleware/orgContext'
 import { httpsRedirect } from './middleware/httpsRedirect'
 import { dataTierRouter } from './middleware/dataTier'
@@ -40,6 +41,7 @@ import discoveryRouter from './routes/discovery'
 import metricsRouter from './routes/metrics'
 import agenticRouter from './routes/agentic'
 import scrapeRouter from './routes/scrape'
+import apiKeysRouter from './routes/apiKeys'
 
 // Import queue infrastructure
 import {
@@ -168,7 +170,21 @@ export class Server {
     this.app.use('/api/compliance', authMiddleware, orgContextMiddleware, complianceRouter)
     this.app.use('/api/discovery', authMiddleware, orgContextMiddleware, discoveryRouter)
     this.app.use('/api/agentic', authMiddleware, orgContextMiddleware, agenticRouter)
-    this.app.use('/api/scrape', authMiddleware, scrapeRouter)
+
+    // API key management — JWT + admin only, so an API key can never mint or
+    // manage other keys. orgContext binds the admin's org for tenant scoping.
+    this.app.use(
+      '/api/keys',
+      authMiddleware,
+      orgContextMiddleware,
+      requireRole('admin'),
+      apiKeysRouter
+    )
+
+    // On-demand scrape (the data-as-a-service revenue endpoint). Accepts either
+    // a customer API key (X-API-Key / Bearer prk_…) or a JWT, then binds org
+    // context so per-tenant scoping/RLS applies to either credential.
+    this.app.use('/api/scrape', apiKeyOrJwtAuth, orgContextMiddleware, scrapeRouter)
 
     // Root endpoint
     this.app.get('/', (req, res) => {
@@ -192,6 +208,7 @@ export class Server {
           compliance: '/api/compliance',
           discovery: '/api/discovery',
           scrape: '/api/scrape',
+          keys: '/api/keys',
           metrics: '/api/metrics',
           webhooks: '/api/webhooks'
         }

--- a/server/middleware/apiKeyAuth.ts
+++ b/server/middleware/apiKeyAuth.ts
@@ -1,0 +1,90 @@
+/**
+ * API-key authentication middleware.
+ *
+ * Lets a paying customer authenticate to the data-as-a-service scrape endpoints
+ * with a long-lived API key instead of an interactive JWT. A key may be sent as
+ * either:
+ *   - `X-API-Key: prk_…`
+ *   - `Authorization: Bearer prk_…`  (the `prk_` prefix distinguishes it from a JWT)
+ *
+ * When a key is present it is verified against the api_keys table and, on
+ * success, populates `req.user` (id/orgId/role) exactly like JWT auth — so the
+ * downstream orgContext + requireRole machinery works unchanged. When no API
+ * key is present the request falls through to the standard JWT auth middleware,
+ * so existing dashboard/JWT callers keep working on the same routes.
+ *
+ * @module server/middleware/apiKeyAuth
+ */
+
+import { Response, NextFunction } from 'express'
+import { authMiddleware, type AuthenticatedRequest } from './authMiddleware'
+import { ApiKeyService, API_KEY_PREFIX } from '../services/ApiKeyService'
+
+const apiKeyService = new ApiKeyService()
+
+/**
+ * Pull an API key out of the request, supporting both the dedicated
+ * `X-API-Key` header and an `Authorization: Bearer prk_…` token. Returns
+ * undefined when neither carries an API key.
+ */
+export function extractApiKey(req: AuthenticatedRequest): string | undefined {
+  const headerKey = req.headers['x-api-key']
+  if (typeof headerKey === 'string' && headerKey.length > 0) {
+    return headerKey.trim()
+  }
+
+  const authHeader = req.headers.authorization
+  if (typeof authHeader === 'string') {
+    const parts = authHeader.split(' ')
+    if (parts.length === 2 && parts[0] === 'Bearer' && parts[1].startsWith(API_KEY_PREFIX)) {
+      return parts[1]
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Authenticate with an API key if one is presented, otherwise fall back to JWT.
+ *
+ * - API key present + valid   → req.user populated, req.authMethod = 'api_key'
+ * - API key present + invalid → 401 (does NOT silently fall through to JWT, so a
+ *   bad key can't be probed against the JWT path)
+ * - No API key                → delegates to authMiddleware (JWT)
+ */
+export const apiKeyOrJwtAuth = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const presentedKey = extractApiKey(req)
+
+  if (!presentedKey) {
+    authMiddleware(req, res, next)
+    return
+  }
+
+  try {
+    const verified = await apiKeyService.verify(presentedKey)
+    if (!verified) {
+      res.status(401).json({
+        error: 'Unauthorized',
+        message: 'Invalid or expired API key'
+      })
+      return
+    }
+
+    req.user = {
+      id: `apikey:${verified.keyId}`,
+      orgId: verified.orgId,
+      role: verified.role
+    }
+    req.authMethod = 'api_key'
+    next()
+  } catch {
+    res.status(401).json({
+      error: 'Unauthorized',
+      message: 'API key verification failed'
+    })
+  }
+}

--- a/server/middleware/authMiddleware.ts
+++ b/server/middleware/authMiddleware.ts
@@ -10,6 +10,12 @@ export interface AuthenticatedRequest extends Request {
     orgId?: string
     tier?: string
   }
+  /**
+   * How the request was authenticated. Set by the auth middleware that ran:
+   * 'jwt' for a Bearer JWT, 'api_key' for an org-scoped API key. Useful for
+   * audit logging and for gating key-management routes to JWT sessions only.
+   */
+  authMethod?: 'jwt' | 'api_key'
 }
 
 interface JwtPayload {
@@ -143,6 +149,7 @@ export const authMiddleware = (req: AuthenticatedRequest, res: Response, next: N
     const decoded = jwt.verify(token, config.jwt.secret, getVerifyOptions()) as JwtPayload
 
     req.user = buildUser(decoded)
+    req.authMethod = 'jwt'
 
     next()
   } catch (error) {

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -38,9 +38,14 @@ tags:
     description: Deal pipeline management
   - name: Webhooks
     description: External service webhooks
+  - name: Scrape
+    description: On-demand UCC filing search (data-as-a-service)
+  - name: API Keys
+    description: Programmatic API key management (admin only)
 
 security:
   - bearerAuth: []
+  - apiKeyAuth: []
 
 paths:
   # ===========================================
@@ -1731,6 +1736,189 @@ paths:
         '401':
           description: Invalid signature
 
+  # ===========================================
+  # Scrape Endpoints (data-as-a-service)
+  # ===========================================
+  /api/scrape/ucc:
+    post:
+      tags:
+        - Scrape
+      summary: Search UCC filings on demand
+      description: >
+        Search UCC filings by company name and state. The primary
+        data-as-a-service endpoint. Authenticate with an API key
+        (`X-API-Key: prk_…`) or a JWT.
+      security:
+        - apiKeyAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - company_name
+                - state
+              properties:
+                company_name:
+                  type: string
+                  minLength: 2
+                  maxLength: 200
+                  example: Acme Logistics LLC
+                state:
+                  type: string
+                  minLength: 2
+                  maxLength: 2
+                  description: Two-letter US state code (case-insensitive)
+                  example: CA
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 1000
+                  default: 100
+      responses:
+        '200':
+          description: UCC filings matching the search
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      filings:
+                        type: array
+                        items:
+                          type: object
+                      total:
+                        type: integer
+                      state:
+                        type: string
+                      companyName:
+                        type: string
+                      timestamp:
+                        type: string
+                        format: date-time
+                  meta:
+                    type: object
+                    properties:
+                      requestedAt:
+                        type: string
+                        format: date-time
+        '400':
+          description: Validation failed or unsupported state
+        '401':
+          description: Missing or invalid credentials
+
+  # ===========================================
+  # API Key Management (admin only)
+  # ===========================================
+  /api/keys:
+    post:
+      tags:
+        - API Keys
+      summary: Create an API key
+      description: >
+        Mint a new org-scoped API key. The plaintext key is returned ONCE in the
+        response and cannot be retrieved again. Admin (JWT) only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 120
+                  example: acme-production
+                role:
+                  type: string
+                  enum: [user, admin]
+                  default: user
+                expires_at:
+                  type: string
+                  format: date-time
+                  description: Optional ISO-8601 expiry; omit for a non-expiring key
+      responses:
+        '201':
+          description: Key created; plaintext key returned once
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      key:
+                        type: string
+                        description: Plaintext key, shown only once
+                        example: prk_AbC123...
+                      keyPrefix:
+                        type: string
+                      role:
+                        type: string
+                      expiresAt:
+                        type: string
+                        nullable: true
+                  meta:
+                    type: object
+        '400':
+          description: Validation failed or no org context
+        '403':
+          description: Caller is not an admin
+    get:
+      tags:
+        - API Keys
+      summary: List API keys
+      description: List the org's API keys (metadata only; never returns secrets). Admin (JWT) only.
+      responses:
+        '200':
+          description: The org's API keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+        '403':
+          description: Caller is not an admin
+
+  /api/keys/{id}:
+    delete:
+      tags:
+        - API Keys
+      summary: Revoke an API key
+      description: Revoke an API key by id within the caller's org. Admin (JWT) only.
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+      responses:
+        '200':
+          description: Key revoked
+        '403':
+          description: Caller is not an admin
+        '404':
+          description: Key not found
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1738,6 +1926,15 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: JWT token for API authentication
+
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: >
+        Org-scoped API key (prefixed `prk_`) for programmatic access to the
+        on-demand scrape endpoints. May also be sent as `Authorization: Bearer
+        prk_…`. Mint and revoke keys via the `/api/keys` endpoints (admin only).
 
     twilioSignature:
       type: apiKey

--- a/server/routes/apiKeys.ts
+++ b/server/routes/apiKeys.ts
@@ -1,0 +1,112 @@
+/**
+ * API Key Management Routes
+ *
+ * Lets an organization admin mint, list, and revoke the API keys that paying
+ * customers use to call the data-as-a-service scrape endpoints. These routes
+ * are JWT + admin only (mounted behind authMiddleware + requireRole('admin') in
+ * server/index.ts) so an API key can never mint or manage other keys.
+ *
+ *   POST   /api/keys      create a key (returns the plaintext key ONCE)
+ *   GET    /api/keys      list the org's keys (metadata only, never secrets)
+ *   DELETE /api/keys/:id  revoke a key
+ *
+ * @module server/routes/apiKeys
+ */
+
+import { Router } from 'express'
+import { z } from 'zod'
+import { validateRequest } from '../middleware/validateRequest'
+import { asyncHandler } from '../middleware/errorHandler'
+import type { AuthenticatedRequest } from '../middleware/authMiddleware'
+import { ApiKeyService } from '../services/ApiKeyService'
+
+const router = Router()
+const apiKeyService = new ApiKeyService()
+
+const createKeySchema = z.object({
+  name: z.string().min(1).max(120),
+  role: z.enum(['user', 'admin']).default('user'),
+  // Optional ISO-8601 expiry; rejected if not a valid future-or-any date string.
+  expires_at: z.string().datetime().optional()
+})
+
+const keyIdParamSchema = z.object({
+  id: z.string().uuid()
+})
+
+// POST /api/keys - mint a new API key for the caller's org
+router.post(
+  '/',
+  validateRequest({ body: createKeySchema }),
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const orgId = req.user?.orgId
+    if (!orgId) {
+      return res.status(400).json({
+        error: 'BadRequest',
+        message: 'No organization context on the authenticated session'
+      })
+    }
+
+    const body = req.body as z.infer<typeof createKeySchema>
+    const created = await apiKeyService.create({
+      orgId,
+      name: body.name,
+      role: body.role,
+      expiresAt: body.expires_at ? new Date(body.expires_at) : null,
+      createdBy: req.user?.id
+    })
+
+    // The plaintext `key` is returned ONCE here and never again.
+    res.status(201).json({
+      success: true,
+      data: created,
+      meta: {
+        notice: 'Store this key securely — it is shown only once and cannot be retrieved later.'
+      }
+    })
+  })
+)
+
+// GET /api/keys - list the org's keys (metadata only)
+router.get(
+  '/',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const orgId = req.user?.orgId
+    if (!orgId) {
+      return res.status(400).json({
+        error: 'BadRequest',
+        message: 'No organization context on the authenticated session'
+      })
+    }
+
+    const keys = await apiKeyService.list(orgId)
+    res.json({ success: true, data: keys })
+  })
+)
+
+// DELETE /api/keys/:id - revoke a key
+router.delete(
+  '/:id',
+  validateRequest({ params: keyIdParamSchema }),
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const orgId = req.user?.orgId
+    if (!orgId) {
+      return res.status(400).json({
+        error: 'BadRequest',
+        message: 'No organization context on the authenticated session'
+      })
+    }
+
+    const revoked = await apiKeyService.revoke(orgId, req.params.id)
+    if (!revoked) {
+      return res.status(404).json({
+        error: 'NotFound',
+        message: 'API key not found'
+      })
+    }
+
+    res.json({ success: true, data: { id: req.params.id, revoked: true } })
+  })
+)
+
+export default router

--- a/server/routes/scrape.ts
+++ b/server/routes/scrape.ts
@@ -6,6 +6,11 @@
  *
  *   POST /api/scrape/ucc  search for UCC filings by company name + state
  *
+ * Auth: mounted behind apiKeyOrJwtAuth (server/index.ts), so a paying customer
+ * can authenticate with an org-scoped API key (`X-API-Key: prk_…` or
+ * `Authorization: Bearer prk_…`) or an internal JWT. requireRole gates on the
+ * role carried by whichever credential authenticated the request.
+ *
  * @module server/routes/scrape
  */
 

--- a/server/services/ApiKeyService.ts
+++ b/server/services/ApiKeyService.ts
@@ -1,0 +1,207 @@
+/**
+ * ApiKeyService
+ *
+ * Issues and verifies long-lived, org-scoped API keys for the data-as-a-service
+ * scrape endpoints. API keys are the credential an operator hands a paying
+ * customer so they can call the API without an interactive JWT/IdP login.
+ *
+ * Security model:
+ *  - The plaintext key (`prk_<secret>`) is returned EXACTLY ONCE at creation
+ *    and never persisted. Only its SHA-256 hash is stored.
+ *  - Verification hashes the presented key and does a single point lookup on
+ *    the unique key_hash index, then checks revocation/expiry.
+ *  - A short, non-secret prefix is stored for display ("which key is this?").
+ *
+ * @module server/services/ApiKeyService
+ */
+
+import crypto from 'crypto'
+import { database } from '../database/connection'
+import { ValidationError } from '../errors'
+
+/** Prefix on every issued key; lets middleware cheaply distinguish keys from JWTs. */
+export const API_KEY_PREFIX = 'prk_'
+
+/** Number of leading characters (including the prefix) retained for display. */
+const DISPLAY_PREFIX_LENGTH = 12
+
+export type ApiKeyRole = 'user' | 'admin'
+
+export interface ApiKeyRecord {
+  id: string
+  orgId: string
+  name: string
+  keyPrefix: string
+  role: ApiKeyRole
+  lastUsedAt: string | null
+  expiresAt: string | null
+  revokedAt: string | null
+  createdAt: string
+}
+
+/** Result of {@link ApiKeyService.create}: the record plus the one-time plaintext key. */
+export interface CreatedApiKey extends ApiKeyRecord {
+  /** Full plaintext key, shown once. Persist nothing about it server-side beyond the hash. */
+  key: string
+}
+
+/** Auth context resolved from a verified key, shaped for the request `user`. */
+export interface VerifiedApiKey {
+  keyId: string
+  orgId: string
+  role: ApiKeyRole
+}
+
+interface ApiKeyRow {
+  id: string
+  org_id: string
+  name: string
+  key_prefix: string
+  role: string
+  last_used_at: string | null
+  expires_at: string | null
+  revoked_at: string | null
+  created_at: string
+}
+
+interface VerifyRow {
+  id: string
+  org_id: string
+  role: string
+  expires_at: string | null
+  revoked_at: string | null
+}
+
+export interface CreateApiKeyInput {
+  orgId: string
+  name: string
+  role?: ApiKeyRole
+  /** Optional absolute expiry. Omit for a key that lives until revoked. */
+  expiresAt?: Date | null
+  /** Optional user id of the creator, recorded for the audit trail. */
+  createdBy?: string | null
+}
+
+/** SHA-256 hex digest used for both storage and lookup of keys. */
+function hashKey(key: string): string {
+  return crypto.createHash('sha256').update(key, 'utf8').digest('hex')
+}
+
+function mapRow(row: ApiKeyRow): ApiKeyRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    name: row.name,
+    keyPrefix: row.key_prefix,
+    role: row.role === 'admin' ? 'admin' : 'user',
+    lastUsedAt: row.last_used_at,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    createdAt: row.created_at
+  }
+}
+
+export class ApiKeyService {
+  /**
+   * Mint a new API key for an organization. Returns the record plus the
+   * one-time plaintext `key` — the caller MUST surface it to the user
+   * immediately; it cannot be recovered later.
+   */
+  async create(input: CreateApiKeyInput): Promise<CreatedApiKey> {
+    const name = input.name?.trim()
+    if (!name) {
+      throw new ValidationError('API key name is required')
+    }
+
+    const role: ApiKeyRole = input.role === 'admin' ? 'admin' : 'user'
+    const secret = crypto.randomBytes(32).toString('base64url')
+    const key = `${API_KEY_PREFIX}${secret}`
+    const keyHash = hashKey(key)
+    const keyPrefix = key.slice(0, DISPLAY_PREFIX_LENGTH)
+
+    const rows = await database.query<ApiKeyRow>(
+      `INSERT INTO api_keys (org_id, name, key_prefix, key_hash, role, expires_at, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, org_id, name, key_prefix, role, last_used_at, expires_at, revoked_at, created_at`,
+      [
+        input.orgId,
+        name,
+        keyPrefix,
+        keyHash,
+        role,
+        input.expiresAt ?? null,
+        input.createdBy ?? null
+      ]
+    )
+
+    return { ...mapRow(rows[0]), key }
+  }
+
+  /**
+   * Verify a presented key. Returns the auth context on success, or `null` if
+   * the key is malformed, unknown, revoked, or expired. On success the key's
+   * `last_used_at` is updated best-effort (failures are swallowed so a metering
+   * write never blocks an otherwise-valid request).
+   */
+  async verify(presentedKey: string | undefined | null): Promise<VerifiedApiKey | null> {
+    if (typeof presentedKey !== 'string' || !presentedKey.startsWith(API_KEY_PREFIX)) {
+      return null
+    }
+
+    const keyHash = hashKey(presentedKey)
+    const rows = await database.query<VerifyRow>(
+      `SELECT id, org_id, role, expires_at, revoked_at
+       FROM api_keys
+       WHERE key_hash = $1`,
+      [keyHash]
+    )
+
+    const row = rows[0]
+    if (!row) return null
+    if (row.revoked_at !== null) return null
+    if (row.expires_at !== null && new Date(row.expires_at).getTime() <= Date.now()) {
+      return null
+    }
+
+    // Best-effort usage stamp; never let a metering write fail the request.
+    try {
+      await database.query(`UPDATE api_keys SET last_used_at = NOW() WHERE id = $1`, [row.id])
+    } catch {
+      // ignore — verification already succeeded
+    }
+
+    return {
+      keyId: row.id,
+      orgId: row.org_id,
+      role: row.role === 'admin' ? 'admin' : 'user'
+    }
+  }
+
+  /** List an organization's keys (newest first). Never returns secrets/hashes. */
+  async list(orgId: string): Promise<ApiKeyRecord[]> {
+    const rows = await database.query<ApiKeyRow>(
+      `SELECT id, org_id, name, key_prefix, role, last_used_at, expires_at, revoked_at, created_at
+       FROM api_keys
+       WHERE org_id = $1
+       ORDER BY created_at DESC`,
+      [orgId]
+    )
+    return rows.map(mapRow)
+  }
+
+  /**
+   * Revoke a key by id within an org. Idempotent: re-revoking an already-revoked
+   * key is a no-op that still resolves true. Returns false when no such key
+   * exists for the org.
+   */
+  async revoke(orgId: string, keyId: string): Promise<boolean> {
+    const rows = await database.query<{ id: string }>(
+      `UPDATE api_keys
+       SET revoked_at = COALESCE(revoked_at, NOW())
+       WHERE id = $1 AND org_id = $2
+       RETURNING id`,
+      [keyId, orgId]
+    )
+    return rows.length > 0
+  }
+}


### PR DESCRIPTION
## Task
`REV-organvm-public-record-data-scrapper-revenue-readiness-0623` — First-paying-customer readiness pass.

## The gap (highest-leverage, first-dollar)
The data-as-a-service revenue endpoint `POST /api/scrape/ucc` sat behind **JWT-only** auth. A JWT requires an interactive IdP/login flow, so there was **no credential an operator could hand a paying stranger** to run a one-off scrape gig. API keys are the canonical first-dollar primitive — this was the single thing blocking revenue, so this PR closes it.

## Changes
- **Migration 023** (`api_keys` + down): org-scoped keys. Stores only a **SHA-256 hash** of the secret plus a non-secret display prefix — never the plaintext. Carries `role`, optional `expires_at`, soft `revoked_at`, and `last_used_at` (foundation for usage metering/billing).
- **`ApiKeyService`**: `create` (returns plaintext **once**), `verify` (hash lookup + revocation/expiry checks + best-effort usage stamp), `list`, `revoke`.
- **`apiKeyOrJwtAuth` middleware**: authenticates `X-API-Key: prk_…` or `Authorization: Bearer prk_…`, else falls back to JWT. A presented-but-invalid key returns 401 rather than silently probing the JWT path. Populates `req.user` so existing org-context/RLS + `requireRole` work unchanged.
- **`/api/keys` routes** (JWT + **admin only**, so an API key can never mint or manage keys): create / list / revoke.
- **`/api/scrape`** now mounts behind `apiKeyOrJwtAuth` + `orgContext`.
- **OpenAPI**: documents the `apiKeyAuth` security scheme and the scrape + keys endpoints.

## Tests / CI
- 20 new tests (ApiKeyService + middleware); full server suite green (**1426 passed**, 6 skipped).
- `build:render` server bundle builds; new files lint-clean and type-clean.

## First-dollar flow this enables
1. Operator (admin) `POST /api/keys` → hands the customer the one-time `prk_…` key.
2. Customer calls `POST /api/scrape/ucc` with `X-API-Key`.
3. `last_used_at` per key gives the metering hook for invoicing/usage billing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)