### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-simplify-0624] Reduce complexity in organvm/public-record-data-scrapper

### DIFF
--- a/scripts/scrapers/base-puppeteer-scraper.test.ts
+++ b/scripts/scrapers/base-puppeteer-scraper.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Browser, Page } from 'puppeteer'
+import { BasePuppeteerScraper } from './base-puppeteer-scraper'
+import type { ScraperResult } from './base-scraper'
+
+const puppeteerMock = vi.hoisted(() => ({
+  launch: vi.fn()
+}))
+
+vi.mock('puppeteer', () => ({
+  default: {
+    launch: puppeteerMock.launch
+  }
+}))
+
+class TestScraper extends BasePuppeteerScraper {
+  constructor(options?: { keepPageOpenOnFailure?: boolean; headless?: boolean }) {
+    super(
+      {
+        state: 'CA',
+        baseUrl: 'https://example.test',
+        rateLimit: 1,
+        timeout: 1000,
+        retryAttempts: 0
+      },
+      options
+    )
+  }
+
+  async runSearch(result: ScraperResult): Promise<ScraperResult> {
+    return this.withSearchPage(async (page, finalize) => {
+      await this.initializePage(page)
+      return finalize(result)
+    })
+  }
+}
+
+type PageMock = Page & {
+  url: ReturnType<typeof vi.fn>
+  isClosed: ReturnType<typeof vi.fn>
+  setUserAgent: ReturnType<typeof vi.fn>
+  setViewport: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  screenshot: ReturnType<typeof vi.fn>
+  content: ReturnType<typeof vi.fn>
+}
+
+function createMockPage(): PageMock {
+  let closed = false
+
+  const page = {
+    setUserAgent: vi.fn(async () => undefined),
+    setViewport: vi.fn(async () => undefined),
+    close: vi.fn(async () => {
+      closed = true
+    }),
+    isClosed: vi.fn(() => closed),
+    screenshot: vi.fn(async (options: { path?: string } = {}) => {
+      if (options.path) {
+        writeFileSync(options.path, 'screenshot-bytes')
+      }
+    }),
+    content: vi.fn(async () => '<!doctype html><html><body>ok</body></html>'),
+    url: vi.fn(() => 'https://example.test')
+  } as unknown as PageMock
+
+  return page
+}
+
+function createMockBrowser(page: Page): Browser {
+  return {
+    newPage: vi.fn(async () => page),
+    close: vi.fn(async () => undefined)
+  } as unknown as Browser
+}
+
+describe('BasePuppeteerScraper', () => {
+  beforeEach(() => {
+    puppeteerMock.launch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('initializes page settings before running a page workflow', async () => {
+    const page = createMockPage()
+    puppeteerMock.launch.mockResolvedValue(createMockBrowser(page))
+    const scraper = new TestScraper()
+
+    await scraper.runSearch({
+      success: true,
+      timestamp: new Date().toISOString()
+    })
+
+    expect(page.setUserAgent).toHaveBeenCalledWith(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    )
+    expect(page.setViewport).toHaveBeenCalledWith({ width: 1920, height: 1080 })
+    expect(page.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a failed page open only when configured to do so', async () => {
+    const keptOpenPage = createMockPage()
+    const closedPage = createMockPage()
+    puppeteerMock.launch.mockResolvedValueOnce(createMockBrowser(keptOpenPage))
+    puppeteerMock.launch.mockResolvedValueOnce(createMockBrowser(closedPage))
+
+    const keepOpen = new TestScraper({ keepPageOpenOnFailure: true })
+    const closeNormally = new TestScraper()
+
+    await keepOpen.runSearch({
+      success: false,
+      error: 'blocked',
+      timestamp: new Date().toISOString()
+    })
+    expect(keptOpenPage.close).toHaveBeenCalledTimes(0)
+
+    await closeNormally.runSearch({
+      success: false,
+      error: 'blocked',
+      timestamp: new Date().toISOString()
+    })
+    expect(closedPage.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes screenshot and html diagnostics for active pages', async () => {
+    const page = createMockPage()
+    const scraper = new TestScraper()
+    const tempDir = mkdtempSync(join(tmpdir(), 'scraper-diagnostics-'))
+    const resultPath = join(tempDir, 'ca-test')
+
+    ;(scraper as unknown as { lastPage: PageMock }).lastPage = page
+
+    const result = await scraper.captureDiagnostics(tempDir, 'ca-test')
+
+    expect(result).toEqual({
+      screenshotPath: `${resultPath}.png`,
+      htmlPath: `${resultPath}.html`
+    })
+    expect(page.screenshot).toHaveBeenCalledWith({ path: `${resultPath}.png`, fullPage: true })
+    expect(page.content).toHaveBeenCalledTimes(1)
+
+    const html = readFileSync(`${resultPath}.html`, 'utf8')
+    expect(html).toContain('ok')
+    expect(existsSync(`${resultPath}.png`)).toBe(true)
+
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('releases browser resources and clears tracked pages on close', async () => {
+    const page = createMockPage()
+    const browser = createMockBrowser(page)
+    puppeteerMock.launch.mockResolvedValue(browser)
+    const scraper = new TestScraper()
+
+    await scraper.runSearch({
+      success: true,
+      timestamp: new Date().toISOString()
+    })
+    await scraper.closeBrowser()
+
+    expect(browser.close).toHaveBeenCalledTimes(1)
+    expect((scraper as unknown as { lastPage: Page | null }).lastPage).toBeNull()
+  })
+})

--- a/scripts/scrapers/base-puppeteer-scraper.ts
+++ b/scripts/scrapers/base-puppeteer-scraper.ts
@@ -1,0 +1,136 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import puppeteer, { Browser, Page } from 'puppeteer'
+
+import { BaseScraper, ScraperConfig, ScraperResult } from './base-scraper'
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+const DEFAULT_VIEWPORT = { width: 1920, height: 1080 }
+
+const DEFAULT_LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-accelerated-2d-canvas',
+  '--disable-gpu',
+  '--window-size=1920x1080'
+]
+
+interface PuppeteerScraperOptions {
+  headless?: boolean
+  keepPageOpenOnFailure?: boolean
+}
+
+export abstract class BasePuppeteerScraper extends BaseScraper {
+  protected browser: Browser | null = null
+  protected lastPage: Page | null = null
+  private readonly headless: boolean
+  private readonly keepPageOpenOnFailure: boolean
+
+  protected constructor(config: ScraperConfig, options: PuppeteerScraperOptions = {}) {
+    super(config)
+    this.headless = options.headless ?? true
+    this.keepPageOpenOnFailure = options.keepPageOpenOnFailure ?? false
+  }
+
+  protected async getBrowser(): Promise<Browser> {
+    if (!this.browser) {
+      this.browser = await puppeteer.launch({
+        headless: this.headless,
+        args: DEFAULT_LAUNCH_ARGS
+      })
+    }
+    return this.browser
+  }
+
+  protected async initializePage(page: Page): Promise<void> {
+    await page.setUserAgent(DEFAULT_USER_AGENT)
+    await page.setViewport(DEFAULT_VIEWPORT)
+  }
+
+  protected async withSearchPage<TResult extends ScraperResult>(
+    execute: (page: Page, finalize: (result: TResult) => TResult) => Promise<TResult>
+  ): Promise<TResult> {
+    let page: Page | null = null
+    const outcome: { result: TResult | null } = { result: null }
+    const finalize = (next: TResult): TResult => {
+      outcome.result = next
+      return next
+    }
+
+    try {
+      const browser = await this.getBrowser()
+      page = await browser.newPage()
+      this.lastPage = page
+      return await execute(page, finalize)
+    } finally {
+      if (page) {
+        const keepPageOpen =
+          this.keepPageOpenOnFailure && outcome.result !== null && !outcome.result.success
+        if (!keepPageOpen) {
+          await page.close().catch((error) => {
+            this.log('warn', 'Error closing page', {
+              error: error instanceof Error ? error.message : String(error)
+            })
+          })
+        }
+      }
+    }
+  }
+
+  async closeBrowser(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close()
+      this.browser = null
+      this.lastPage = null
+      this.onBrowserClosed()
+    }
+  }
+
+  protected onBrowserClosed(): void {
+    // optional override hook
+  }
+
+  async captureDiagnostics(
+    outputDir: string,
+    baseName: string
+  ): Promise<{ screenshotPath?: string; htmlPath?: string }> {
+    if (!this.lastPage || this.lastPage.isClosed()) {
+      return {}
+    }
+
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true })
+    }
+
+    const screenshotPath = join(outputDir, `${baseName}.png`)
+    const htmlPath = join(outputDir, `${baseName}.html`)
+    let savedScreenshot = false
+    let savedHtml = false
+
+    try {
+      await this.lastPage.screenshot({ path: screenshotPath, fullPage: true })
+      savedScreenshot = true
+    } catch (error) {
+      this.log('warn', 'Failed to capture screenshot', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+
+    try {
+      const html = await this.lastPage.content()
+      writeFileSync(htmlPath, html)
+      savedHtml = true
+    } catch (error) {
+      this.log('warn', 'Failed to capture HTML snapshot', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+
+    return {
+      screenshotPath: savedScreenshot ? screenshotPath : undefined,
+      htmlPath: savedHtml ? htmlPath : undefined
+    }
+  }
+}

--- a/scripts/scrapers/states/california.ts
+++ b/scripts/scrapers/states/california.ts
@@ -5,18 +5,12 @@
  * Uses Puppeteer for real web scraping with anti-detection measures
  */
 
-import { BaseScraper, ScraperResult, UCCFiling } from '../base-scraper'
-import puppeteer, { Browser, Page } from 'puppeteer'
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { ScraperResult, UCCFiling } from '../base-scraper'
+import { BasePuppeteerScraper } from '../base-puppeteer-scraper'
 import type { Frame } from 'puppeteer'
 import { PaginationHandler } from '../pagination-handler'
 
-export class CaliforniaScraper extends BaseScraper {
-  private browser: Browser | null = null
-  private lastPage: Page | null = null
-  private headless: boolean
-  private keepPageOpenOnFailure: boolean
+export class CaliforniaScraper extends BasePuppeteerScraper {
 
   constructor(options: { headless?: boolean; keepPageOpenOnFailure?: boolean } = {}) {
     super({
@@ -25,83 +19,7 @@ export class CaliforniaScraper extends BaseScraper {
       rateLimit: 4, // 4 requests per minute (conservative for state portal)
       timeout: 45000, // Increased timeout for CA SOS portal
       retryAttempts: 2
-    })
-    this.headless = options.headless ?? true
-    this.keepPageOpenOnFailure = options.keepPageOpenOnFailure ?? false
-  }
-
-  /**
-   * Initialize browser instance
-   */
-  private async getBrowser(): Promise<Browser> {
-    if (!this.browser) {
-      this.browser = await puppeteer.launch({
-        headless: this.headless,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-accelerated-2d-canvas',
-          '--disable-gpu',
-          '--window-size=1920x1080'
-        ]
-      })
-    }
-    return this.browser
-  }
-
-  /**
-   * Close browser instance
-   */
-  async closeBrowser(): Promise<void> {
-    if (this.browser) {
-      await this.browser.close()
-      this.browser = null
-      this.lastPage = null
-    }
-  }
-
-  async captureDiagnostics(
-    outputDir: string,
-    baseName: string
-  ): Promise<{ screenshotPath?: string; htmlPath?: string }> {
-    if (!this.lastPage || this.lastPage.isClosed()) {
-      return {}
-    }
-
-    if (!existsSync(outputDir)) {
-      mkdirSync(outputDir, { recursive: true })
-    }
-
-    const screenshotPath = join(outputDir, `${baseName}.png`)
-    const htmlPath = join(outputDir, `${baseName}.html`)
-
-    let savedScreenshot = false
-    let savedHtml = false
-
-    try {
-      await this.lastPage.screenshot({ path: screenshotPath, fullPage: true })
-      savedScreenshot = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture screenshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    try {
-      const html = await this.lastPage.content()
-      writeFileSync(htmlPath, html)
-      savedHtml = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture HTML snapshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    return {
-      screenshotPath: savedScreenshot ? screenshotPath : undefined,
-      htmlPath: savedHtml ? htmlPath : undefined
-    }
+    }, options)
   }
 
   /**
@@ -161,31 +79,14 @@ export class CaliforniaScraper extends BaseScraper {
    * Offers free searches but may require account for advanced features
    */
   private async performSearch(companyName: string, searchUrl: string): Promise<ScraperResult> {
-    let page: Page | null = null
-    // Held on an object property (not a let binding): TS control-flow analysis
-    // does not track assignments made through the `finalize` closure, so a
-    // plain `let` still reads as null in the `finally` block.
-    const outcome: { result: ScraperResult | null } = { result: null }
-    const finalize = (next: ScraperResult): ScraperResult => {
-      outcome.result = next
-      return next
-    }
-
-    try {
-      const browser = await this.getBrowser()
-      page = await browser.newPage()
-      this.lastPage = page
+    return this.withSearchPage(async (page, finalize) => {
       // Non-null alias for use inside closures below — TS resets the
       // null-narrowing of `page` inside nested functions.
       const activePage = page
 
       this.log('info', 'Browser page created', { companyName })
 
-      // Set user agent and viewport
-      await page.setUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-      )
-      await page.setViewport({ width: 1920, height: 1080 })
+      await this.initializePage(page)
 
       // Navigate to California UCC search page
       this.log('info', 'Navigating to CA UCC search page', { companyName, searchUrl })
@@ -709,19 +610,7 @@ export class CaliforniaScraper extends BaseScraper {
         timestamp: new Date().toISOString(),
         parsingErrors: validationErrors.length > 0 ? validationErrors : undefined
       })
-    } finally {
-      // Cleanup page in all cases
-      if (page) {
-        const keepPage = this.keepPageOpenOnFailure && outcome.result && !outcome.result.success
-        if (!keepPage) {
-          await page.close().catch((err) => {
-            this.log('warn', 'Error closing page', {
-              error: err instanceof Error ? err.message : String(err)
-            })
-          })
-        }
-      }
-    }
+    })
   }
 
   /**

--- a/scripts/scrapers/states/florida.ts
+++ b/scripts/scrapers/states/florida.ts
@@ -5,17 +5,11 @@
  * Uses Puppeteer for real web scraping with anti-detection measures
  */
 
-import { BaseScraper, ScraperResult, UCCFiling } from '../base-scraper'
-import puppeteer, { Browser, Page } from 'puppeteer'
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { ScraperResult, UCCFiling } from '../base-scraper'
+import { BasePuppeteerScraper } from '../base-puppeteer-scraper'
 import { PaginationHandler } from '../pagination-handler'
 
-export class FloridaScraper extends BaseScraper {
-  private browser: Browser | null = null
-  private lastPage: Page | null = null
-  private headless: boolean
-  private keepPageOpenOnFailure: boolean
+export class FloridaScraper extends BasePuppeteerScraper {
 
   constructor(options: { headless?: boolean; keepPageOpenOnFailure?: boolean } = {}) {
     super({
@@ -24,77 +18,7 @@ export class FloridaScraper extends BaseScraper {
       rateLimit: 4, // 4 requests per minute (conservative for privatized system)
       timeout: 45000, // Increased timeout for third-party portal
       retryAttempts: 2
-    })
-    this.headless = options.headless ?? true
-    this.keepPageOpenOnFailure = options.keepPageOpenOnFailure ?? false
-  }
-
-  private async getBrowser(): Promise<Browser> {
-    if (!this.browser) {
-      this.browser = await puppeteer.launch({
-        headless: this.headless,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-accelerated-2d-canvas',
-          '--disable-gpu',
-          '--window-size=1920x1080'
-        ]
-      })
-    }
-    return this.browser
-  }
-
-  async closeBrowser(): Promise<void> {
-    if (this.browser) {
-      await this.browser.close()
-      this.browser = null
-      this.lastPage = null
-    }
-  }
-
-  async captureDiagnostics(
-    outputDir: string,
-    baseName: string
-  ): Promise<{ screenshotPath?: string; htmlPath?: string }> {
-    if (!this.lastPage || this.lastPage.isClosed()) {
-      return {}
-    }
-
-    if (!existsSync(outputDir)) {
-      mkdirSync(outputDir, { recursive: true })
-    }
-
-    const screenshotPath = join(outputDir, `${baseName}.png`)
-    const htmlPath = join(outputDir, `${baseName}.html`)
-
-    let savedScreenshot = false
-    let savedHtml = false
-
-    try {
-      await this.lastPage.screenshot({ path: screenshotPath, fullPage: true })
-      savedScreenshot = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture screenshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    try {
-      const html = await this.lastPage.content()
-      writeFileSync(htmlPath, html)
-      savedHtml = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture HTML snapshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    return {
-      screenshotPath: savedScreenshot ? screenshotPath : undefined,
-      htmlPath: savedHtml ? htmlPath : undefined
-    }
+    }, options)
   }
 
   /**
@@ -154,28 +78,13 @@ export class FloridaScraper extends BaseScraper {
    * The search is picky about exact name matches and formatting.
    */
   private async performSearch(companyName: string, searchUrl: string): Promise<ScraperResult> {
-    let page: Page | null = null
-    // Held on an object property (not a let binding): TS control-flow analysis
-    // does not track assignments made through the `finalize` closure, so a
-    // plain `let` still reads as null in the `finally` block.
-    const outcome: { result: ScraperResult | null } = { result: null }
-    const finalize = (next: ScraperResult): ScraperResult => {
-      outcome.result = next
-      return next
-    }
-
-    try {
-      const browser = await this.getBrowser()
-      page = await browser.newPage()
-      this.lastPage = page
-
+    return this.withSearchPage(async (page, finalize) => {
+      // Held on an object property (not a let binding): TS control-flow analysis
+      // does not track assignments made through the `finalize` closure, so a
+      // plain `let` still reads as null in the `finally` block.
       this.log('info', 'Browser page created', { companyName })
 
-      // Set user agent and viewport
-      await page.setUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-      )
-      await page.setViewport({ width: 1920, height: 1080 })
+      await this.initializePage(page)
 
       // Navigate to Florida UCC search page
       this.log('info', 'Navigating to FL UCC search page', { companyName, searchUrl })
@@ -565,18 +474,7 @@ export class FloridaScraper extends BaseScraper {
         timestamp: new Date().toISOString(),
         parsingErrors: validationErrors.length > 0 ? validationErrors : undefined
       })
-    } finally {
-      if (page) {
-        const keepPage = this.keepPageOpenOnFailure && outcome.result && !outcome.result.success
-        if (!keepPage) {
-          await page.close().catch((err) => {
-            this.log('warn', 'Error closing page', {
-              error: err instanceof Error ? err.message : String(err)
-            })
-          })
-        }
-      }
-    }
+    })
   }
 
   /**

--- a/scripts/scrapers/states/texas.ts
+++ b/scripts/scrapers/states/texas.ts
@@ -8,19 +8,14 @@
  * Set TX_UCC_USERNAME and TX_UCC_PASSWORD environment variables.
  */
 
-import { BaseScraper, ScraperResult, UCCFiling } from '../base-scraper'
-import puppeteer, { Browser, Page } from 'puppeteer'
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import type { Page } from 'puppeteer'
+import { ScraperResult, UCCFiling } from '../base-scraper'
+import { BasePuppeteerScraper } from '../base-puppeteer-scraper'
 import { getTexasCredentials, hasTexasAuth } from '../auth-config'
 import { PaginationHandler } from '../pagination-handler'
 
-export class TexasScraper extends BaseScraper {
-  private browser: Browser | null = null
+export class TexasScraper extends BasePuppeteerScraper {
   private isAuthenticated: boolean = false
-  private lastPage: Page | null = null
-  private headless: boolean
-  private keepPageOpenOnFailure: boolean
 
   constructor(options: { headless?: boolean; keepPageOpenOnFailure?: boolean } = {}) {
     super({
@@ -29,78 +24,12 @@ export class TexasScraper extends BaseScraper {
       rateLimit: 3, // 3 requests per minute (conservative for new portal)
       timeout: 45000, // Increased timeout for portal that requires login
       retryAttempts: 2
-    })
-    this.headless = options.headless ?? true
-    this.keepPageOpenOnFailure = options.keepPageOpenOnFailure ?? false
-  }
-
-  private async getBrowser(): Promise<Browser> {
-    if (!this.browser) {
-      this.browser = await puppeteer.launch({
-        headless: this.headless,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-accelerated-2d-canvas',
-          '--disable-gpu',
-          '--window-size=1920x1080'
-        ]
-      })
-    }
-    return this.browser
+    }, options)
   }
 
   async closeBrowser(): Promise<void> {
-    if (this.browser) {
-      await this.browser.close()
-      this.browser = null
-      this.isAuthenticated = false
-      this.lastPage = null
-    }
-  }
-
-  async captureDiagnostics(
-    outputDir: string,
-    baseName: string
-  ): Promise<{ screenshotPath?: string; htmlPath?: string }> {
-    if (!this.lastPage || this.lastPage.isClosed()) {
-      return {}
-    }
-
-    if (!existsSync(outputDir)) {
-      mkdirSync(outputDir, { recursive: true })
-    }
-
-    const screenshotPath = join(outputDir, `${baseName}.png`)
-    const htmlPath = join(outputDir, `${baseName}.html`)
-
-    let savedScreenshot = false
-    let savedHtml = false
-
-    try {
-      await this.lastPage.screenshot({ path: screenshotPath, fullPage: true })
-      savedScreenshot = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture screenshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    try {
-      const html = await this.lastPage.content()
-      writeFileSync(htmlPath, html)
-      savedHtml = true
-    } catch (error) {
-      this.log('warn', 'Failed to capture HTML snapshot', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-
-    return {
-      screenshotPath: savedScreenshot ? screenshotPath : undefined,
-      htmlPath: savedHtml ? htmlPath : undefined
-    }
+    await super.closeBrowser()
+    this.isAuthenticated = false
   }
 
   /**
@@ -301,28 +230,13 @@ export class TexasScraper extends BaseScraper {
    * authentication credentials to be configured.
    */
   private async performSearch(companyName: string): Promise<ScraperResult> {
-    let page: Page | null = null
-    // Held on an object property (not a let binding): TS control-flow analysis
-    // does not track assignments made through the `finalize` closure, so a
-    // plain `let` still reads as null in the `finally` block.
-    const outcome: { result: ScraperResult | null } = { result: null }
-    const finalize = (next: ScraperResult): ScraperResult => {
-      outcome.result = next
-      return next
-    }
-
-    try {
-      const browser = await this.getBrowser()
-      page = await browser.newPage()
-      this.lastPage = page
-
+    return this.withSearchPage(async (page, finalize) => {
+      // Held on an object property (not a let binding): TS control-flow analysis
+      // does not track assignments made through the `finalize` closure, so a
+      // plain `let` still reads as null in the `finally` block.
       this.log('info', 'Browser page created', { companyName })
 
-      // Set user agent and viewport
-      await page.setUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-      )
-      await page.setViewport({ width: 1920, height: 1080 })
+      await this.initializePage(page)
 
       // Authenticate against SOSDirect (required for TX UCC searches)
       if (!this.isAuthenticated) {
@@ -641,18 +555,7 @@ export class TexasScraper extends BaseScraper {
         timestamp: new Date().toISOString(),
         parsingErrors: validationErrors.length > 0 ? validationErrors : undefined
       })
-    } finally {
-      if (page) {
-        const keepPage = this.keepPageOpenOnFailure && outcome.result && !outcome.result.success
-        if (!keepPage) {
-          await page.close().catch((err) => {
-            this.log('warn', 'Error closing page', {
-              error: err instanceof Error ? err.message : String(err)
-            })
-          })
-        }
-      }
-    }
+    })
   }
 
   /**


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-simplify-0624`.

Identify the most complex or most-duplicated module in organvm/public-record-data-scrapper and refactor it for clarity, with tests proving behavior is unchanged. Net lines should not grow without cause. [auto-generated 2026-06-24 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._