### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-typing-0624] Tighten types in organvm/public-record-data-scrapper

### DIFF
--- a/apps/web/src/lib/services/GenerativeIntelligenceHub.ts
+++ b/apps/web/src/lib/services/GenerativeIntelligenceHub.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// Experimental generative features - disabled strict linting for AI service integration
 /**
  * Generative Intelligence Hub - Central integration point for all AI-powered features
  * Coordinates: LLM, Vector Search, Recursive Enrichment, Personalization, and Generative Content
@@ -13,8 +11,16 @@ import { ConversationAI } from './generative/ConversationAI'
 import { PersonalizationEngine } from './personalization/PersonalizationEngine'
 
 import type { Prospect } from '@public-records/core'
-import type { GenerativeConfig } from '@/types/generative'
-import type { RecursiveEnrichmentConfig } from '@/types/recursive'
+import type { GenerativeConfig, OutreachTemplate, Message } from '@/types/generative'
+import type {
+  RecursiveEnrichmentConfig,
+  EnrichmentTree,
+  EnrichmentNode
+} from '@/types/recursive'
+import type {
+  PersonalizedProspect,
+  PersonalizedDashboard
+} from '@/types/personalization'
 
 /**
  * Main hub for all generative, recursive, and personalized intelligence features
@@ -82,7 +88,7 @@ export class GenerativeIntelligenceHub {
     prospectId: string,
     depth: number = 3
   ): Promise<{
-    enrichmentTree: any
+    enrichmentTree: EnrichmentTree
     insights: string[]
     newDataPoints: number
   }> {
@@ -153,7 +159,10 @@ export class GenerativeIntelligenceHub {
   /**
    * Get personalized prospect recommendations for user
    */
-  async getPersonalizedRecommendations(userId: string, prospects: Prospect[]): Promise<any[]> {
+  async getPersonalizedRecommendations(
+    userId: string,
+    prospects: Prospect[]
+  ): Promise<PersonalizedProspect[]> {
     await this.ensureInitialized()
 
     const personalized = await this.personalization.personalizeProspects(userId, prospects)
@@ -165,7 +174,7 @@ export class GenerativeIntelligenceHub {
   /**
    * Get personalized dashboard for user
    */
-  async getPersonalizedDashboard(userId: string): Promise<any> {
+  async getPersonalizedDashboard(userId: string): Promise<PersonalizedDashboard> {
     await this.ensureInitialized()
 
     return await this.personalization.getPersonalizedDashboard(userId)
@@ -174,7 +183,7 @@ export class GenerativeIntelligenceHub {
   /**
    * Track user interaction for learning
    */
-  async trackUserInteraction(userId: string, actionType: string, data: any): Promise<void> {
+  async trackUserInteraction(userId: string, actionType: string, data: unknown): Promise<void> {
     await this.personalization.trackUserAction(userId, {
       actionType,
       timestamp: new Date(),
@@ -187,7 +196,7 @@ export class GenerativeIntelligenceHub {
   /**
    * Generate personalized outreach for prospect
    */
-  async generateOutreach(prospectId: string, userId: string): Promise<any> {
+  async generateOutreach(prospectId: string, userId: string): Promise<OutreachTemplate> {
     await this.ensureInitialized()
 
     const userProfile = await this.personalization.getUserProfile(userId)
@@ -220,7 +229,7 @@ export class GenerativeIntelligenceHub {
   /**
    * Chat with AI assistant
    */
-  async chat(sessionId: string, message: string): Promise<any> {
+  async chat(sessionId: string, message: string): Promise<Message> {
     await this.ensureInitialized()
 
     return await this.conversation.sendMessage(sessionId, message)
@@ -229,7 +238,7 @@ export class GenerativeIntelligenceHub {
   /**
    * Generate insights from data
    */
-  async generateInsights(data: any, context: string): Promise<string[]> {
+  async generateInsights(data: unknown, context: string): Promise<string[]> {
     await this.ensureInitialized()
 
     const prompt = `Analyze this data and generate actionable insights:
@@ -305,7 +314,7 @@ Provide 3-5 key insights in bullet points. Focus on:
   /**
    * Count nodes in enrichment tree
    */
-  private countNodes(node: any): number {
+  private countNodes(node: EnrichmentNode): number {
     let count = 1
     for (const child of node.childNodes || []) {
       count += this.countNodes(child)
@@ -316,7 +325,7 @@ Provide 3-5 key insights in bullet points. Focus on:
   /**
    * Generate insights from enrichment tree
    */
-  private async generateEnrichmentInsights(tree: any): Promise<string[]> {
+  private async generateEnrichmentInsights(tree: EnrichmentTree): Promise<string[]> {
     const insights: string[] = []
 
     // Analyze tree depth

--- a/apps/web/src/lib/services/GenerativeNarrativeEngine.ts
+++ b/apps/web/src/lib/services/GenerativeNarrativeEngine.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Experimental generative AI features - disabled strict linting
 import type {
   Prospect,
@@ -11,6 +11,16 @@ import type {
   GrowthSignal,
   IndustryTrend
 } from '@public-records/core'
+
+/**
+ * Caller-supplied hints that bias narrative generation toward the user's
+ * focus areas and risk appetite. All fields optional.
+ */
+interface NarrativeUserPreferences {
+  industries?: string[]
+  focusAreas?: string[]
+  riskTolerance?: 'low' | 'medium' | 'high'
+}
 
 /**
  * GenerativeNarrativeEngine - AI-powered narrative and insight generation
@@ -34,20 +44,16 @@ export class GenerativeNarrativeEngine {
    */
   async generateNarrative(
     context: GenerativeContext,
-    userPreferences?: {
-      industries?: string[]
-      focusAreas?: string[]
-      riskTolerance?: 'low' | 'medium' | 'high'
-    }
+    userPreferences?: NarrativeUserPreferences
   ): Promise<GenerativeNarrative> {
     const { prospect, marketData, relationships, historicalSignals, industryTrends } = context
 
     // Build comprehensive prompt
     const prompt = this.buildNarrativePrompt(prospect, {
       marketData,
-      relationships: relationships as any,
-      historicalSignals: historicalSignals as any,
-      industryTrends: industryTrends as any,
+      relationships,
+      historicalSignals,
+      industryTrends,
       userPreferences
     })
 
@@ -161,7 +167,7 @@ Format as plain text without markdown.
       relationships?: CompanyGraph
       historicalSignals?: GrowthSignal[]
       industryTrends?: IndustryTrend[]
-      userPreferences?: any
+      userPreferences?: NarrativeUserPreferences
     }
   ): string {
     const { marketData, relationships, historicalSignals, industryTrends, userPreferences } =

--- a/apps/web/src/lib/services/generative/OutreachTemplateGenerator.ts
+++ b/apps/web/src/lib/services/generative/OutreachTemplateGenerator.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Experimental generative features - disabled strict linting for AI service integration
 /**
  * Generative Outreach Template Generator
@@ -308,7 +308,7 @@ Health Grade: ${prospectData.healthScore?.grade || 'N/A'}
 Revenue Estimate: $${prospectData.estimatedRevenue?.toLocaleString()}
 
 Growth Signals:
-${prospectData.growthSignals?.map((s: any) => `- ${s.type}: ${s.description}`).join('\n') || '- None'}
+${prospectData.growthSignals?.map((s) => `- ${s.type}: ${s.description}`).join('\n') || '- None'}
 
 Context:
 - Urgency: ${context.urgency}

--- a/apps/web/src/lib/services/personalization/PersonalizationEngine.ts
+++ b/apps/web/src/lib/services/personalization/PersonalizationEngine.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Experimental personalization features - disabled strict linting
 
 /**
@@ -11,6 +11,8 @@ import type {
   UserPreferences,
   UserBehavior,
   UserAction,
+  UserPerformance,
+  UserSegment,
   PersonalizedProspect,
   PersonalizedDashboard,
   PersonalizedRecommendation,
@@ -18,6 +20,9 @@ import type {
   PersonalizationModel,
   PersonalizedWidget,
   PersonalizedInsight,
+  LearnedPreference,
+  TimingModel,
+  ChannelModel,
   QuickAction,
   ActivityItem,
   ChannelMetrics
@@ -94,7 +99,7 @@ export class PersonalizationEngine {
   async trackSearch(
     userId: string,
     query: string,
-    filters: any,
+    filters: Record<string, unknown>,
     resultsCount: number
   ): Promise<void> {
     await this.trackUserAction(userId, {
@@ -153,7 +158,7 @@ export class PersonalizationEngine {
     userId: string,
     prospectId: string,
     outcome: 'success' | 'failure',
-    details: any
+    details: Record<string, unknown>
   ): Promise<void> {
     await this.trackUserAction(userId, {
       actionType: 'outcome',
@@ -405,9 +410,9 @@ export class PersonalizationEngine {
   /**
    * Learn preferences from behavior
    */
-  private learnPreferences(behavior: UserBehavior): any[] {
+  private learnPreferences(behavior: UserBehavior): LearnedPreference[] {
     // Analyze successful deal characteristics
-    const preferences: any[] = []
+    const preferences: LearnedPreference[] = []
 
     // Most common industries in successful deals
     const industries = behavior.successfulDealCharacteristics.map((d) => d.industry)
@@ -428,7 +433,7 @@ export class PersonalizationEngine {
   /**
    * Build timing model
    */
-  private buildTimingModel(behavior: UserBehavior): any {
+  private buildTimingModel(behavior: UserBehavior): TimingModel {
     // Analyze time of day patterns
     const patterns = behavior.timeOfDayPatterns
 
@@ -452,7 +457,10 @@ export class PersonalizationEngine {
         confidence: 0.8
       },
       optimalFollowUpInterval: 3,
-      responsePatterns: patterns
+      // timeOfDayPatterns are TimePatterns, not ResponsePatterns — they describe
+      // activity windows, not message-response behavior. Left empty until real
+      // response-time data is collected rather than coercing a mismatched shape.
+      responsePatterns: []
     }
   }
 
@@ -461,7 +469,7 @@ export class PersonalizationEngine {
    *
    * Returns equal weights until real channel effectiveness data is collected.
    */
-  private buildChannelModel(_behavior: UserBehavior): any {
+  private buildChannelModel(_behavior: UserBehavior): ChannelModel {
     return {
       channelPreferences: {
         email: 0.5,
@@ -470,7 +478,7 @@ export class PersonalizationEngine {
         linkedin: 0.5,
         direct_mail: 0.5
       },
-      channelEffectiveness: {},
+      channelEffectiveness: {} as Record<OutreachChannel, ChannelMetrics>,
       contextualPreferences: []
     }
   }
@@ -478,7 +486,7 @@ export class PersonalizationEngine {
   /**
    * Determine user segment
    */
-  private determineUserSegment(performance: any): any {
+  private determineUserSegment(performance: UserPerformance): UserSegment {
     if (performance.conversionRate > 0.35) return 'high_performer'
     if (performance.conversionRate > 0.25) return 'growing'
     return 'struggling'


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-typing-0624`.

Eliminate the worst untyped hotspots in organvm/public-record-data-scrapper's most-imported module (remove `any` / add type hints / fix loose signatures). Keep the build and tests green. [auto-generated 2026-06-24 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._