### PR TITLE
Document /api/scrape and /api/keys endpoints in README API table

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ public-record-data-scrapper/
 
 The Express server exposes a RESTful API documented at `/api/docs` when running.
 
+### Scrape API — auth: API key (`X-API-Key: prk_…` or `Authorization: Bearer prk_…`) or JWT
+
+| Method | Endpoint                             | Description                                   |
+| ------ | ------------------------------------ | --------------------------------------------- |
+| `GET`  | `/api/scrape/readiness/:stateCode`   | Check whether a state scraper is available    |
+| `POST` | `/api/scrape/ucc`                    | Search UCC filings by company name and state; body: `company_name`, `state`, optional `limit` (1–1000, default 100) |
+
+### Dashboard API — auth: JWT
+
 | Method  | Endpoint                      | Description                                  |
 | ------- | ----------------------------- | -------------------------------------------- |
 | `GET`   | `/api/prospects`              | List prospects with filtering and pagination |
@@ -200,6 +209,14 @@ The Express server exposes a RESTful API documented at `/api/docs` when running.
 | `PATCH` | `/api/deals/:id/stage`        | Move deal to next pipeline stage             |
 | `POST`  | `/api/communications/send`    | Send email or SMS                            |
 | `GET`   | `/api/compliance/report`      | Generate compliance report                   |
+
+### API key management — auth: JWT, role: admin
+
+| Method   | Endpoint        | Description          |
+| -------- | --------------- | -------------------- |
+| `POST`   | `/api/keys`     | Create an API key    |
+| `GET`    | `/api/keys`     | List API keys        |
+| `DELETE` | `/api/keys/:id` | Revoke an API key    |
 
 Full endpoint list: [server/openapi.yaml](server/openapi.yaml)
 


### PR DESCRIPTION
## Summary

- The README's API section only listed internal dashboard routes; the paid scrape endpoints (`/api/scrape/ucc`, `/api/scrape/readiness/:stateCode`) and API key management routes (`/api/keys`) added in #307 and #309 were absent.
- Reorganised the API table into three auth-labelled groups (Scrape API, Dashboard API, Admin key management) so the auth requirement is immediately visible alongside each endpoint.
- No invented features — every route was verified against `server/routes/scrape.ts`, `server/routes/apiKeys.ts`, and `server/index.ts`.

## Test plan

- [ ] Read the rendered README and confirm all three table sections match live routes in `server/routes/`
- [ ] Confirm `POST /api/scrape/ucc` body params (`company_name`, `state`, `limit`) match `searchUCCSchema` in `server/routes/scrape.ts`
- [ ] Confirm `/api/keys` requires JWT + admin role (verified in `server/index.ts:177`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)