### PR TITLE
feat(ci): add lint as blocking gate step

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -57,6 +57,9 @@ jobs:
         # --ignore-scripts: don't run untrusted PR lifecycle scripts on the runner.
         run: npm ci --ignore-scripts
 
+      - name: Lint
+        run: npm run lint
+
       - name: Type check (non-blocking — see #236)
         continue-on-error: true
         run: npx tsc --noEmit || echo "::warning::TypeScript reported errors (non-blocking; tracked in #236)"


### PR DESCRIPTION
## Summary

- CI was already green on `main`; this adds the single most valuable missing enforcement.
- `npm run lint` ran in `ci.yml` but that workflow is informational (noted in ci-gate.yml comments).
- Promoting ESLint into the **enforced CI Gate** makes lint failures block merges, preventing rule regressions from silently accumulating.

## Verification

- `npm run lint` locally: 0 errors, 1 warning (pre-existing react-refresh warning in StatusDashboard.tsx — not a gate blocker).
- No existing gate steps touched; only additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)