### PR TITLE
[limen GEN-organvm-public-record-data-scrapper-security-0629] Security hardening pass on organvm/public-record-data-scrapper

### DIFF
--- a/apps/web/src/components/__tests__/StatusDashboard.test.tsx
+++ b/apps/web/src/components/__tests__/StatusDashboard.test.tsx
@@ -54,7 +54,9 @@ function createProspect(overrides: Partial<Prospect> = {}): Prospect {
   }
 }
 
-function createPortfolioCompany(overrides: Partial<PortfolioCompany> = {}): PortfolioCompany {
+function createPortfolioCompany(
+  overrides: Partial<PortfolioCompany> = {}
+): PortfolioCompany {
   return {
     id: 'portfolio-1',
     companyName: 'Portfolio Co',
@@ -184,7 +186,9 @@ describe('StatusDashboard', () => {
         prospects={[createProspect()]}
         portfolio={[createPortfolioCompany({ currentStatus: 'at-risk' })]}
         competitors={competitors}
-        userActions={[{ type: 'refresh-data', timestamp: '2026-06-20T10:00:00.000Z', details: {} }]}
+        userActions={[
+          { type: 'refresh-data', timestamp: '2026-06-20T10:00:00.000Z', details: {} }
+        ]}
         isLoading={false}
         loadError={null}
         lastDataRefresh="2026-06-20T11:30:00.000Z"

--- a/server/routes/billing.ts
+++ b/server/routes/billing.ts
@@ -13,7 +13,9 @@
 import { Router, Request, Response } from 'express'
 import type Stripe from 'stripe'
 import { asyncHandler } from '../middleware/errorHandler'
+import { validateRequest } from '../middleware/validateRequest'
 import { config } from '../config'
+import { z } from 'zod'
 import {
   createCheckoutSession,
   constructWebhookEvent,
@@ -270,6 +272,20 @@ function resolveCheckoutBaseUrl(req: Request): string | null {
   return configuredBase ?? null
 }
 
+const checkoutQuerySchema = z.object({
+  tier: z.enum(['starter', 'professional', 'enterprise']).optional(),
+  plan: z.enum(['starter', 'professional', 'enterprise']).optional()
+})
+  .superRefine((value, ctx) => {
+    if (value.tier && value.plan && value.tier !== value.plan) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['plan'],
+        message: 'tier and plan must match when both are provided'
+      })
+    }
+  })
+
 router.get('/status', (_req: Request, res: Response) => {
   res.json({
     configured: isStripeConfigured(),
@@ -279,6 +295,7 @@ router.get('/status', (_req: Request, res: Response) => {
 
 router.post(
   '/checkout',
+  validateRequest({ query: checkoutQuerySchema }),
   asyncHandler(async (req: Request, res: Response) => {
     if (!isStripeConfigured()) {
       res.status(503).json({ error: 'Billing not configured' })
@@ -289,7 +306,8 @@ router.post(
     // is mounted with express.raw for the webhook, so req.body is a Buffer here,
     // not parsed JSON). Default to 'starter' to preserve the prior single-SKU
     // behavior, which resolves to STRIPE_PRICE_STARTER || STRIPE_PRICE_ID.
-    const requestedTier = req.query.tier ?? req.query.plan
+    const query = req.query as z.infer<typeof checkoutQuerySchema>
+    const requestedTier = query.tier ?? query.plan
     const tier = requestedTier === undefined ? 'starter' : normalizeCheckoutTier(requestedTier)
     if (!tier) {
       res.status(400).json({

--- a/server/routes/contacts.ts
+++ b/server/routes/contacts.ts
@@ -136,6 +136,15 @@ const logActivitySchema = z.object({
   completed_at: z.string().datetime().optional()
 }).strict()
 
+const activitiesQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(200).default(50),
+  before: z.string().optional()
+})
+
+const prospectIdParamSchema = z.object({
+  prospectId: z.string().uuid()
+})
+
 // GET /api/contacts - List contacts with filters (org_id required)
 router.get(
   '/',
@@ -349,17 +358,16 @@ router.post(
 // GET /api/contacts/:id/activities - Get activity timeline for contact
 router.get(
   '/:id/activities',
-  validateRequest({ params: idParamSchema }),
+  validateRequest({ params: idParamSchema, query: activitiesQuerySchema }),
   asyncHandler(async (req, res) => {
     const contactsService = new ContactsService()
     const { id } = req.params
-    // Parse with explicit radix, guard NaN/non-positive, and cap to a sane max.
-    const parsedLimit = parseInt(req.query.limit as string, 10)
-    const limit =
-      Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 50
-    const before = req.query.before as string | undefined
+    const query = req.query as z.infer<typeof activitiesQuerySchema>
 
-    const activities = await contactsService.getActivityTimeline(id, { limit, before })
+    const activities = await contactsService.getActivityTimeline(id, {
+      limit: query.limit,
+      before: query.before
+    })
 
     res.json({ activities })
   })
@@ -368,6 +376,7 @@ router.get(
 // GET /api/contacts/by-prospect/:prospectId - Get contacts for a prospect
 router.get(
   '/by-prospect/:prospectId',
+  validateRequest({ params: prospectIdParamSchema }),
   asyncHandler(async (req, res) => {
     const contactsService = new ContactsService()
     const { prospectId } = req.params

--- a/server/routes/deals.ts
+++ b/server/routes/deals.ts
@@ -142,6 +142,10 @@ const documentParamsSchema = z.object({
   documentId: z.string().uuid()
 })
 
+const verifyDocumentSchema = z.object({
+  verified_by: z.string().min(1)
+})
+
 // org_id is optional here: the value is derived from the token by resolveOrgId.
 // When supplied it is validated as a UUID and cross-checked against the token.
 const orgIdQuerySchema = z.object({
@@ -515,24 +519,14 @@ async function assertDocumentBelongsToOrg(
 router.patch(
   '/:id/documents/:documentId/verify',
   requireRole('user', 'admin'),
-  validateRequest({ params: documentParamsSchema }),
+  validateRequest({ params: documentParamsSchema, body: verifyDocumentSchema }),
   asyncHandler(async (req, res) => {
     const orgId = resolveOrgId(req as AuthenticatedRequest, res)
     if (!orgId) return
 
     const dealsService = new DealsService()
     const { id, documentId } = req.params
-    const verifiedBy = req.body.verified_by as string
-
-    if (!verifiedBy) {
-      return res.status(400).json({
-        error: {
-          message: 'verified_by is required',
-          code: 'VALIDATION_ERROR',
-          statusCode: 400
-        }
-      })
-    }
+    const { verified_by: verifiedBy } = req.body as z.infer<typeof verifyDocumentSchema>
 
     if (!(await assertDocumentBelongsToOrg(dealsService, id, documentId, orgId, res))) {
       return

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express'
+import { z } from 'zod'
 import { database } from '../database/connection'
 import { asyncHandler } from '../middleware/errorHandler'
+import { validateRequest } from '../middleware/validateRequest'
 import { getResolvedDataTier } from '../middleware/dataTier'
 import { listEnabledIntegrations, resolveUccProvider } from '../config/tieredIntegrations'
 import { getIngestionCoverageTelemetry, resolveStateIngestionStrategyChain } from '../queue/queues'
@@ -162,6 +164,16 @@ const US_STATES: StateDefinition[] = [
   { code: 'WI', name: 'Wisconsin' },
   { code: 'WY', name: 'Wyoming' }
 ]
+
+const stateCodeParamSchema = z.object({
+  stateCode: z
+    .string()
+    .trim()
+    .transform((value) => value.toUpperCase())
+    .refine((value) => /^[A-Z]{2}$/.test(value), {
+      message: 'stateCode must be a 2-letter code'
+    })
+})
 
 function sumRecordsSince(telemetry: RuntimeTelemetry | undefined, days: number): number | null {
   if (!telemetry || telemetry.successes.length === 0) {
@@ -567,13 +579,15 @@ router.get(
 // GET /api/health/coverage/:stateCode - state-specific readiness snapshot
 router.get(
   '/coverage/:stateCode',
+  validateRequest({ params: stateCodeParamSchema }),
   asyncHandler(async (req, res) => {
     const dataTier = getResolvedDataTier(req)
-    const state = getStateCoverageSnapshot(req.params.stateCode, dataTier)
+    const { stateCode } = req.params as z.infer<typeof stateCodeParamSchema>
+    const state = getStateCoverageSnapshot(stateCode, dataTier)
 
     if (!state) {
       res.status(404).json({
-        message: `Unknown state code: ${req.params.stateCode}`
+        message: `Unknown state code: ${stateCode}`
       })
       return
     }

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -620,6 +620,10 @@ function extractEmailAddress(raw: string | undefined): string | null {
  * message as multipart form fields; we only require `from`. Everything else is
  * optional/best-effort.
  */
+const sendgridInboundQuerySchema = z.object({
+  token: z.string().min(1)
+})
+
 const sendgridInboundSchema = z.object({
   from: z.string().min(1),
   to: z.string().optional(),
@@ -644,6 +648,7 @@ const sendgridInboundSchema = z.object({
  */
 router.post(
   '/sendgrid/inbound',
+  validateRequest({ query: sendgridInboundQuerySchema }),
   parseMultipartFields(),
   asyncHandler(async (req: Request, res: Response) => {
     // FAIL CLOSED on the shared secret before doing any work.
@@ -654,8 +659,8 @@ router.post(
         error: { message: 'Inbound parse token not configured', statusCode: 401 }
       })
     }
-    const provided = typeof req.query.token === 'string' ? req.query.token : ''
-    if (!timingSafeEqualStr(provided, expectedToken)) {
+    const { token } = req.query as z.infer<typeof sendgridInboundQuerySchema>
+    if (!timingSafeEqualStr(token, expectedToken)) {
       console.error('[webhooks] Invalid inbound parse token')
       return res.status(401).json({
         error: { message: 'Invalid inbound parse token', statusCode: 401 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-public-record-data-scrapper-security-0629`.

Run the ecosystem audit for organvm/public-record-data-scrapper (npm audit / pip-audit / equivalent), upgrade or pin high-severity advisories, and add input validation at the main untrusted-input entrypoints. Open a PR; keep the build green. [auto-generated 2026-06-29 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._