### PR TITLE
[limen HEAL-cifix-organvm-public-record-data-scrapper-338] fix failing CI on organvm/public-record-data-scrapper#338

### DIFF
--- a/apps/web/src/components/__tests__/StatusDashboard.test.tsx
+++ b/apps/web/src/components/__tests__/StatusDashboard.test.tsx
@@ -54,7 +54,9 @@ function createProspect(overrides: Partial<Prospect> = {}): Prospect {
   }
 }
 
-function createPortfolioCompany(overrides: Partial<PortfolioCompany> = {}): PortfolioCompany {
+function createPortfolioCompany(
+  overrides: Partial<PortfolioCompany> = {}
+): PortfolioCompany {
   return {
     id: 'portfolio-1',
     companyName: 'Portfolio Co',
@@ -184,7 +186,9 @@ describe('StatusDashboard', () => {
         prospects={[createProspect()]}
         portfolio={[createPortfolioCompany({ currentStatus: 'at-risk' })]}
         competitors={competitors}
-        userActions={[{ type: 'refresh-data', timestamp: '2026-06-20T10:00:00.000Z', details: {} }]}
+        userActions={[
+          { type: 'refresh-data', timestamp: '2026-06-20T10:00:00.000Z', details: {} }
+        ]}
         isLoading={false}
         loadError={null}
         lastDataRefresh="2026-06-20T11:30:00.000Z"


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-public-record-data-scrapper-338`.

PR organvm/public-record-data-scrapper#338 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/public-record-data-scrapper/pull/338 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/public-record-data-scrapper/pull/338

_Produced in an isolated worktree off origin — review before merge._