### PR TITLE
fix(discovery): survive the SBA portal migration; register FL/TX permit datasets (fixes #347)

### DIFF
--- a/server/__tests__/services/sbaLoansChannel.test.ts
+++ b/server/__tests__/services/sbaLoansChannel.test.ts
@@ -164,16 +164,56 @@ describe('SBALoansChannel (streaming)', () => {
     )
   })
 
-  it('fails closed when the recent 7(a) resource is absent from CKAN', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => ({ result: { resources: [{ format: 'CSV', url: 'https://x/other.csv' }] } })
-    } as unknown as Response)
+  it('falls through to the DCAT catalog when CKAN is gone (2026 Drupal migration)', async () => {
+    // CKAN rung: the post-migration portal answers every /api/3/action/* with
+    // an HTML 404 — modelled here as a non-2xx response.
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({})
+      } as unknown as Response)
+      // DCAT rung: data.json carries the dataset distribution.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          dataset: [
+            { distribution: [{ format: 'pdf', downloadURL: 'https://x/notes.pdf' }] },
+            { distribution: [{ downloadURL: CKAN_RESOURCE_URL }] }
+          ]
+        })
+      } as unknown as Response)
+      .mockResolvedValueOnce(streamingResponse([HEADER, row('Dcat Co', 'CA')]))
+
+    const candidates = await new SBALoansChannel().discover({ limit: 10 })
+
+    expect(candidates.map((c) => c.company_name)).toEqual(['Dcat Co'])
+  })
+
+  it('fails closed with a named unavailability reason when CKAN and DCAT both lack the dataset', async () => {
+    fetchSpy
+      // CKAN answers but the recent-7(a) resource is gone.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          result: { resources: [{ format: 'CSV', url: 'https://x/other.csv' }] }
+        })
+      } as unknown as Response)
+      // DCAT catalog exists but has no matching distribution.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ dataset: [{ distribution: [{ downloadURL: 'https://x/a.csv' }] }] })
+      } as unknown as Response)
 
     await expect(new SBALoansChannel().discover({ limit: 10 })).rejects.toThrow(
-      /recent 7\(a\) CSV resource/
+      /SBA 7\(a\) FOIA dataset unavailable/
     )
   })
 })

--- a/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
+++ b/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
@@ -22,6 +22,8 @@ function rowsResponse(rows: Record<string, unknown>[]): Response {
 
 const NY_FIELD = 'permittee_s_business_name'
 const CA_FIELD = 'contractors_business_name'
+const FL_FIELD = 'contractor_name'
+const TX_FIELD = 'contractor_company_name'
 
 describe('SocrataBuildingPermitsChannel', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
@@ -64,11 +66,36 @@ describe('SocrataBuildingPermitsChannel', () => {
     fetchSpy
       .mockResolvedValueOnce(rowsResponse([{ [NY_FIELD]: 'NY Co' }]))
       .mockResolvedValueOnce(rowsResponse([{ [CA_FIELD]: 'CA Co' }]))
+      .mockResolvedValueOnce(rowsResponse([{ [FL_FIELD]: 'FL Co' }]))
+      .mockResolvedValueOnce(rowsResponse([{ [TX_FIELD]: 'TX Co' }]))
 
     const candidates = await new SocrataBuildingPermitsChannel().discover({ limit: 10 })
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2)
-    expect(candidates.map((c) => `${c.state}:${c.company_name}`)).toEqual(['NY:NY Co', 'CA:CA Co'])
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+    expect(candidates.map((c) => `${c.state}:${c.company_name}`)).toEqual([
+      'NY:NY Co',
+      'CA:CA Co',
+      'FL:FL Co',
+      'TX:TX Co'
+    ])
+  })
+
+  it('serves FL from the Orlando dataset and requires a non-null order field', async () => {
+    fetchSpy.mockResolvedValueOnce(rowsResponse([{ [FL_FIELD]: 'Sunshine Builders LLC' }]))
+
+    const candidates = await new SocrataBuildingPermitsChannel().discover({
+      state: 'FL',
+      limit: 5
+    })
+
+    expect(candidates.map((c) => `${c.state}:${c.company_name}`)).toEqual([
+      'FL:Sunshine Builders LLC'
+    ])
+    // URLSearchParams encodes spaces as '+' — normalize before asserting.
+    const url = decodeURIComponent(String(fetchSpy.mock.calls[0][0]).replace(/\+/g, ' '))
+    expect(url).toContain('data.cityoforlando.net/resource/ryhf-m453.json')
+    // SODA sorts DESC NULL FIRST — the null-guard keeps unissued applications out.
+    expect(url).toContain('issue_permit_date IS NOT NULL')
   })
 
   it('caps the total candidates at the requested limit', async () => {
@@ -84,10 +111,10 @@ describe('SocrataBuildingPermitsChannel', () => {
 
   it('fails closed for a state with no registered dataset', async () => {
     const err = await new SocrataBuildingPermitsChannel()
-      .discover({ state: 'TX', limit: 10 })
+      .discover({ state: 'WA', limit: 10 })
       .catch((e) => e)
     expect(err).toBeInstanceOf(DiscoveryChannelError)
-    expect((err as Error).message).toMatch(/no building-permit dataset registered for state 'TX'/)
+    expect((err as Error).message).toMatch(/no building-permit dataset registered for state 'WA'/)
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 

--- a/server/services/discovery-channels/SBALoansChannel.ts
+++ b/server/services/discovery-channels/SBALoansChannel.ts
@@ -5,16 +5,23 @@
  * financing event and a strong 'contract' (capital-secured) growth signal.
  *
  * ── Dataset (public FOIA release, NO API KEY) ───────────────────────────────
- *   SBA "7(a) & 504 FOIA" — CKAN dataset
- *     id: 0ff8e8e9-b967-4f4e-987c-6ac78c575087  (data.sba.gov)
+ *   SBA "7(a) & 504 FOIA" — loan-level borrower records
+ *     legacy CKAN id: 0ff8e8e9-b967-4f4e-987c-6ac78c575087  (data.sba.gov)
  *   We fetch the recent 7(a) CSV resource (FY2020-present). The "as-of" date
- *   is embedded in the filename, so the concrete file URL is resolved through
- *   the CKAN package_show API at runtime (the package id is stable; the
- *   resource filename rotates). If the recent 7(a) resource cannot be located,
- *   that is a fail-closed condition.
+ *   is embedded in the filename, so the concrete file URL must be resolved at
+ *   runtime. Resolution is a self-healing chain (#347):
  *
- *   CKAN: GET https://data.sba.gov/api/3/action/package_show?id=<pkgId>
- *         → result.resources[] : { format, url, name }
+ *   1. Legacy CKAN package_show — the pre-2026 portal API. data.sba.gov's
+ *      2026 Drupal 11 migration dropped every /api/3/action/* path (they now
+ *      return the portal's HTML 404), but the rung is kept first so the
+ *      channel heals itself if SBA restores CKAN.
+ *      GET https://data.sba.gov/api/3/action/package_show?id=<pkgId>
+ *        → result.resources[] : { format, url, name }
+ *   2. DCAT catalog — the federal open-data surface the Drupal portal DOES
+ *      serve. The 7(a)/504 FOIA dataset is absent from it as of 2026-07 but
+ *      this is where it should reappear.
+ *      GET https://data.sba.gov/data.json → dataset[].distribution[].downloadURL
+ *   3. Fail closed with a named unavailability reason (never a raw HTTP code).
  *
  * ── CSV shape (documented header; parser fails closed if columns change) ────
  *   asofdate,program,locationid,borrname,borrstreet,borrcity,borrstate,
@@ -38,6 +45,8 @@ import { clampLimit, normalizeState, errorMessage, fetchWithTimeout, fetchJson }
 const CHANNEL = 'sba-7a-loans'
 const CKAN_PACKAGE_ID = '0ff8e8e9-b967-4f4e-987c-6ac78c575087'
 const CKAN_PACKAGE_SHOW = `https://data.sba.gov/api/3/action/package_show?id=${CKAN_PACKAGE_ID}`
+// Project Open Data (DCAT) catalog the post-2026 Drupal portal serves.
+const DCAT_CATALOG_URL = 'https://data.sba.gov/data.json'
 // Filename stem of the recent 7(a) CSV resource (date suffix rotates).
 const RECENT_7A_RESOURCE_STEM = 'foia-7a-fy2020-present'
 const RATE_BUCKET = 'sba'
@@ -69,8 +78,33 @@ export class SBALoansChannel implements DiscoveryChannel {
     return this.streamCsvCandidates(csvUrl, wantState, limit)
   }
 
-  /** Resolve the rotating recent-7(a) CSV resource URL via CKAN. */
+  /**
+   * Resolve the rotating recent-7(a) CSV resource URL via the self-healing
+   * chain documented in the module header: legacy CKAN → DCAT catalog →
+   * named unavailability error. A CKAN answer that lacks the resource falls
+   * through to DCAT the same as a dead CKAN — only the final rung throws.
+   */
   private async resolveRecentCsvUrl(): Promise<string> {
+    let ckanReason: string
+    try {
+      return await this.resolveViaCkan()
+    } catch (err) {
+      ckanReason = errorMessage(err)
+    }
+    try {
+      return await this.resolveViaDcat()
+    } catch (dcatErr) {
+      throw new DiscoveryChannelError(
+        CHANNEL,
+        'SBA 7(a) FOIA dataset unavailable: the 2026 data.sba.gov migration dropped the CKAN API ' +
+          'and the loan-level dataset is absent from the DCAT catalog — no candidates until SBA ' +
+          `republishes (CKAN: ${ckanReason}; DCAT: ${errorMessage(dcatErr)})`
+      )
+    }
+  }
+
+  /** Rung 1 — legacy CKAN package_show (pre-2026 portal). */
+  private async resolveViaCkan(): Promise<string> {
     const body = await fetchJson(
       CHANNEL,
       CKAN_PACKAGE_SHOW,
@@ -100,6 +134,39 @@ export class SBALoansChannel implements DiscoveryChannel {
       )
     }
     return match.url
+  }
+
+  /** Rung 2 — DCAT catalog (data.json) served by the post-2026 Drupal portal. */
+  private async resolveViaDcat(): Promise<string> {
+    const body = await fetchJson(
+      CHANNEL,
+      DCAT_CATALOG_URL,
+      { headers: { Accept: 'application/json' } },
+      'SBA DCAT',
+      REQUEST_TIMEOUT_MS
+    )
+
+    const datasets = (body as { dataset?: unknown })?.dataset
+    if (!Array.isArray(datasets)) {
+      throw new DiscoveryChannelError(
+        CHANNEL,
+        'SBA DCAT response shape changed: expected dataset[] array'
+      )
+    }
+
+    for (const ds of datasets as { distribution?: unknown }[]) {
+      const dists = ds?.distribution
+      if (!Array.isArray(dists)) continue
+      for (const dist of dists as { downloadURL?: unknown }[]) {
+        const url = typeof dist.downloadURL === 'string' ? dist.downloadURL : ''
+        if (url.toLowerCase().includes(RECENT_7A_RESOURCE_STEM)) return url
+      }
+    }
+
+    throw new DiscoveryChannelError(
+      CHANNEL,
+      `recent 7(a) CSV ('${RECENT_7A_RESOURCE_STEM}') absent from the DCAT catalog`
+    )
   }
 
   /**

--- a/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
+++ b/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
@@ -16,10 +16,24 @@
  *       Business field:  contractors_business_name
  *       State:           implicit CA (LA dataset)
  *       Date field:      issue_date  (ISO 8601)
+ *  FL → City of Orlando "Permit Applications" (updated daily; verified live
+ *       2026-07-16 — Miami-Dade's Socrata is gone, 302 → ArcGIS legacy)
+ *       https://data.cityoforlando.net/resource/ryhf-m453.json
+ *       Business field:  contractor_name
+ *       State:           implicit FL (Orlando dataset)
+ *       Date field:      issue_permit_date  (ISO 8601; null until issuance —
+ *                        see the $where null-guard below)
+ *  TX → City of Austin "Issued Construction Permits"
+ *       https://data.austintexas.gov/resource/3syk-w9eu.json
+ *       Business field:  contractor_company_name
+ *       State:           implicit TX (Austin dataset)
+ *       Date field:      issue_date  (ISO 8601)
  *
- *  Both accept SODA query params ($limit, $order, $where). We request newest
- *  first and cap rows. Each row maps to one candidate (deduped per-business
- *  within the page). Courtesy rate-limit via the shared 'socrata' bucket.
+ *  All accept SODA query params ($limit, $order, $where). We request newest
+ *  first and cap rows; SODA sorts DESC with NULL FIRST, so the $where also
+ *  requires the order field non-null (else never-issued applications lead
+ *  the page). Each row maps to one candidate (deduped per-business within
+ *  the page). Courtesy rate-limit via the shared 'socrata' bucket.
  *
  * Fail-closed: a non-2xx response, non-array body, or a payload missing the
  * documented business-name field for EVERY row throws a named error rather
@@ -64,6 +78,18 @@ const SOURCES: Record<string, SocrataSource> = {
     state: 'CA',
     url: 'https://data.lacity.org/resource/xnhu-aczu.json',
     businessField: 'contractors_business_name',
+    orderField: 'issue_date'
+  },
+  FL: {
+    state: 'FL',
+    url: 'https://data.cityoforlando.net/resource/ryhf-m453.json',
+    businessField: 'contractor_name',
+    orderField: 'issue_permit_date'
+  },
+  TX: {
+    state: 'TX',
+    url: 'https://data.austintexas.gov/resource/3syk-w9eu.json',
+    businessField: 'contractor_company_name',
     orderField: 'issue_date'
   }
 }
@@ -121,7 +147,9 @@ export class SocrataBuildingPermitsChannel implements DiscoveryChannel {
     const qs = new URLSearchParams({
       $limit: String(rowLimit),
       $order: `${source.orderField} DESC`,
-      $where: `${source.businessField} IS NOT NULL`
+      // SODA orders DESC with NULL FIRST — without the order-field guard,
+      // rows that never reached issuance (null date) lead every page.
+      $where: `${source.businessField} IS NOT NULL AND ${source.orderField} IS NOT NULL`
     })
     const url = `${source.url}?${qs.toString()}`
 


### PR DESCRIPTION
## Problem (#347)
- `sba-7a-loans`: data.sba.gov migrated to Drupal 11 in 2026 — the CKAN API is gone (HTML 404 on every `/api/3/action/*` path; verified with direct probes) and the loan-level FOIA dataset is absent from the portal's DCAT `data.json`. catalog.data.gov still points at the dead page. The channel emitted a raw `SBA CKAN returned HTTP 404` for every state.
- `socrata-building-permits`: registry covered only NY/CA — an FL discovery run returned zero candidates while FL is a live-state.

## Fix
- **SBA resolver chain**: legacy CKAN → DCAT `data.json` scan → named unavailability error. Self-heals if SBA republishes on either surface; never emits a raw status code again.
- **FL registered**: City of Orlando `ryhf-m453` (`contractor_name` / `issue_permit_date`) — updated daily, schema-verified live today. (Miami-Dade's Socrata is dead: 302 → hub.arcgis.com/legacy.)
- **TX registered**: City of Austin `3syk-w9eu` (`contractor_company_name` / `issue_date`) — schema-verified live today.
- **Order-field null-guard** in the SODA `$where` for all states: SODA sorts `DESC NULL FIRST`, so never-issued (null-date) applications previously led every page.

## Proof
- `vitest --config vitest.config.server.ts` on both channel test files: **19/19 pass** (incl. new DCAT-fallback, named-unavailability, and FL/null-guard tests); `tsc -b --noCheck` clean.
- Live probes: Orlando returns same-day rows (`issue_permit_date = 2026-07-16`) with the exact $where the channel now issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)