### PR TITLE
fix(auth): mount dataTierRouter after authMiddleware — paid orgs resolved free-tier (fixes #348)

### DIFF
--- a/server/__tests__/middleware/dataTier.test.ts
+++ b/server/__tests__/middleware/dataTier.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
 
 // Mock the database module so entitlement lookups are controllable.
 vi.mock('../../database/connection', () => ({
@@ -7,6 +8,20 @@ vi.mock('../../database/connection', () => ({
     query: vi.fn()
   }
 }))
+
+// Config mock for the real authMiddleware used by the mount-order regression
+// tests below (dataTier.ts itself never reads config — inert elsewhere).
+vi.mock('../../config', () => ({
+  config: {
+    jwt: {
+      secret: 'test-secret',
+      orgClaim: 'org_id',
+      tierClaim: 'tier'
+    }
+  }
+}))
+
+import { authMiddleware } from '../../middleware/authMiddleware'
 
 import { database } from '../../database/connection'
 import {
@@ -211,6 +226,55 @@ describe('dataTier middleware', () => {
 
     it('fails closed when the router has not run', () => {
       const req = makeReq()
+      expect(getResolvedDataTier(req as unknown as Request)).toBe('free-tier')
+    })
+  })
+
+  // Mount-order regression (#348): the tier is resolved from req.user, which
+  // only exists AFTER authMiddleware. A global pre-auth dataTierRouter mount
+  // resolved free-tier for every caller, silently applying the free-tier
+  // min-score floor to paid orgs (server/index.ts now mounts it per-route,
+  // after auth). These tests pin the ordering dependency itself.
+  describe('mount order vs authMiddleware (#348 regression)', () => {
+    const runChain = async (order: 'auth-first' | 'tier-first', token: string) => {
+      const req = makeReq({ headers: { authorization: `Bearer ${token}` } })
+      const res = { ...makeRes(), status: vi.fn().mockReturnThis(), json: vi.fn() }
+      const chain =
+        order === 'auth-first' ? [authMiddleware, dataTierRouter] : [dataTierRouter, authMiddleware]
+      for (const mw of chain) {
+        const next = vi.fn() as NextFunction
+        mw(req as unknown as Request, res as unknown as Response, next)
+        await vi.waitFor(() => expect(next).toHaveBeenCalled())
+      }
+      return req
+    }
+
+    it('resolves the paid tier when mounted AFTER auth (the fixed order)', async () => {
+      const token = jwt.sign(
+        { sub: 'u1', role: 'admin', org_id: 'org-1', tier: 'professional' },
+        'test-secret'
+      )
+      const req = await runChain('auth-first', token)
+      expect(getResolvedDataTier(req as unknown as Request)).toBe('starter-tier')
+    })
+
+    it('resolves via the org subscription_tier DB fallback when the token has no tier claim', async () => {
+      mockQuery.mockResolvedValueOnce([{ subscription_tier: 'professional' }] as never)
+      const token = jwt.sign({ sub: 'u1', role: 'admin', org_id: 'org-2' }, 'test-secret')
+      const req = await runChain('auth-first', token)
+      expect(getResolvedDataTier(req as unknown as Request)).toBe('starter-tier')
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT subscription_tier FROM organizations WHERE id = $1',
+        ['org-2']
+      )
+    })
+
+    it('documents the regression: mounted BEFORE auth, a paid org still resolves free-tier', async () => {
+      const token = jwt.sign(
+        { sub: 'u1', role: 'admin', org_id: 'org-3', tier: 'professional' },
+        'test-secret'
+      )
+      const req = await runChain('tier-first', token)
       expect(getResolvedDataTier(req as unknown as Request)).toBe('free-tier')
     })
   })

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,8 +122,12 @@ export class Server {
     // Logging
     this.app.use(requestLogger)
 
-    // Data tier routing (OSS -> free-tier, paid -> starter-tier)
-    this.app.use(dataTierRouter)
+    // NOTE: dataTierRouter is deliberately NOT mounted here (#348). Tier
+    // resolution reads req.user (JWT tier claim, then the org's
+    // subscription_tier), and req.user is populated by the per-route
+    // authMiddleware — a global pre-auth mount always resolved free-tier,
+    // which silently applied the free-tier min-score floor to every caller.
+    // It is mounted per-route AFTER auth in setupRoutes().
 
     // Rate limiting (Redis-based in production, in-memory in development)
     this.app.use(createRateLimiter())
@@ -139,8 +143,10 @@ export class Server {
     // Public status page (no auth, bookmarkable)
     this.app.use(statusRouter)
 
-    // Public routes (no authentication required)
-    this.app.use('/api/health', healthRouter)
+    // Public routes (no authentication required). dataTierRouter resolves
+    // free-tier here (no req.user) — explicit, and keeps health's tier read
+    // honest rather than relying on the fail-closed accessor default.
+    this.app.use('/api/health', dataTierRouter, healthRouter)
 
     // Webhook routes (signature verification, no JWT auth)
     this.app.use('/api/webhooks', webhooksRouter)
@@ -157,28 +163,35 @@ export class Server {
     // orgContextMiddleware runs AFTER authMiddleware (so req.user.orgId is
     // populated) and BEFORE the routers, binding the tenant context that the
     // core DB client uses to SET app.current_org_id for RLS (migration 018).
-    this.app.use('/api/prospects', authMiddleware, orgContextMiddleware, prospectsRouter)
-    this.app.use('/api/competitors', authMiddleware, orgContextMiddleware, competitorsRouter)
-    this.app.use('/api/portfolio', authMiddleware, orgContextMiddleware, portfolioRouter)
-    this.app.use('/api/enrichment', authMiddleware, orgContextMiddleware, enrichmentRouter)
-    this.app.use('/api/jobs', authMiddleware, orgContextMiddleware, jobsRouter)
-    this.app.use('/api/contacts', authMiddleware, orgContextMiddleware, contactsRouter)
-    this.app.use('/api/deals', authMiddleware, orgContextMiddleware, dealsRouter)
-    this.app.use('/api/competitive', authMiddleware, orgContextMiddleware, competitiveRouter)
-    this.app.use('/api/outreach', authMiddleware, orgContextMiddleware, outreachRouter)
-    this.app.use('/api/communications', authMiddleware, orgContextMiddleware, communicationsRouter)
-    this.app.use('/api/compliance', authMiddleware, orgContextMiddleware, complianceRouter)
-    this.app.use('/api/discovery', authMiddleware, orgContextMiddleware, discoveryRouter)
-    this.app.use('/api/agentic', authMiddleware, orgContextMiddleware, agenticRouter)
+    // dataTierRouter likewise runs AFTER authMiddleware (#348): it resolves the
+    // entitlement from req.user (tier claim, then the org's subscription_tier),
+    // so mounted pre-auth it always failed closed to free-tier — which silently
+    // applied the free-tier min-score floor to every authenticated caller.
+    this.app.use('/api/prospects', authMiddleware, orgContextMiddleware, dataTierRouter, prospectsRouter)
+    this.app.use('/api/competitors', authMiddleware, orgContextMiddleware, dataTierRouter, competitorsRouter)
+    this.app.use('/api/portfolio', authMiddleware, orgContextMiddleware, dataTierRouter, portfolioRouter)
+    this.app.use('/api/enrichment', authMiddleware, orgContextMiddleware, dataTierRouter, enrichmentRouter)
+    this.app.use('/api/jobs', authMiddleware, orgContextMiddleware, dataTierRouter, jobsRouter)
+    this.app.use('/api/contacts', authMiddleware, orgContextMiddleware, dataTierRouter, contactsRouter)
+    this.app.use('/api/deals', authMiddleware, orgContextMiddleware, dataTierRouter, dealsRouter)
+    this.app.use('/api/competitive', authMiddleware, orgContextMiddleware, dataTierRouter, competitiveRouter)
+    this.app.use('/api/outreach', authMiddleware, orgContextMiddleware, dataTierRouter, outreachRouter)
+    this.app.use('/api/communications', authMiddleware, orgContextMiddleware, dataTierRouter, communicationsRouter)
+    this.app.use('/api/compliance', authMiddleware, orgContextMiddleware, dataTierRouter, complianceRouter)
+    this.app.use('/api/discovery', authMiddleware, orgContextMiddleware, dataTierRouter, discoveryRouter)
+    this.app.use('/api/agentic', authMiddleware, orgContextMiddleware, dataTierRouter, agenticRouter)
     // API key management (JWT + admin only - API keys must not be able to mint more keys)
     this.app.use(
       '/api/keys',
       authMiddleware,
       requireRole('admin'),
       orgContextMiddleware,
+      dataTierRouter,
       apiKeysRouter
     )
-    this.app.use('/api/scrape', apiKeyOrJwtAuth, scrapeRouter)
+    // scrape authenticates via API key OR JWT — either way req.user carries the
+    // org/tier context by the time dataTierRouter resolves.
+    this.app.use('/api/scrape', apiKeyOrJwtAuth, dataTierRouter, scrapeRouter)
 
     // Root endpoint
     this.app.get('/', (req, res) => {


### PR DESCRIPTION
## Root cause (supersedes the issue's original RLS theory)
`dataTierRouter` resolves entitlement from `req.user` (verified `tier` claim → org `subscription_tier` DB lookup → fail closed). It was mounted **globally, before any per-route `authMiddleware`** — so `req.user` was always empty at resolution time and **every request resolved `free-tier`**. `applyProspectTierConstraints` then injected the free-tier `min_score` floor, which filters out unscored rows — including the caller's own fresh discovery seeds (`priority_score` null). That's why `POST /api/discovery/run` inserted 4 rows and `GET /api/prospects` returned 0 (DEMO_RUNBOOK §2.1).

Not RLS: the `tenant_isolation` policies are non-FORCE and the repro ran as table owner (BYPASSRLS), per `orgContext.ts`'s own doc.

## Fix
- Remove the global pre-auth mount (comment left in place explaining why it can't live there).
- Mount `dataTierRouter` per-route **after** `authMiddleware`/`orgContextMiddleware` on all protected chains (matching the documented ordering rationale), after `apiKeyOrJwtAuth` on `/api/scrape`, standalone on public `/api/health`.
- Regression tests pin the ordering dependency: fixed order resolves `starter-tier` for a professional JWT (claim path AND the DB `subscription_tier` fallback the runbook exercises); the pre-auth order is documented as resolving `free-tier` — the exact regression.

## Proof
- `dataTier.test.ts`: 21/21 (18 existing + 3 new); `serverlessApp.test.ts`: 6/6; `tsc -b --noCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)