### PR TITLE
fix(pages): reaccept public data demo and scrapers

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,8 +17,11 @@ on:
     paths:
       - 'apps/web/**'
       - 'packages/**'
+      - 'scripts/verify-pages-public-demo.mjs'
+      - 'scripts/verify-pages-public-demo.test.mjs'
       - 'package.json'
       - 'package-lock.json'
+      - 'tsconfig.json'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
@@ -41,7 +44,14 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci --no-audit --no-fund
-      - run: npm --workspace apps/web run build -- --base=/public-record-data-scrapper/
+      - name: Test public data deployment gate
+        run: node --test scripts/verify-pages-public-demo.test.mjs
+      - name: Verify receipt-bound public data source
+        run: node scripts/verify-pages-public-demo.mjs apps/web/public/data/austin-building-permits.receipt.json
+      - name: Build receipt-bound public data demo
+        env:
+          VITE_PUBLIC_DEMO_RECEIPT_URL: data/austin-building-permits.receipt.json
+        run: npm --workspace apps/web run build -- --base=/public-record-data-scrapper/
       # Vite's outDir points at the repo root, but with the workspace invocation
       # the bundle has been observed at apps/web/dist — accept either, fail loud
       # on neither (never upload a guessed path).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,3 +7,21 @@ Common commands (from repo root):
 - `npm run dev` (web dev server)
 - `npm run build` (web build)
 - `npm run test` (web unit tests)
+
+## GitHub Pages public-data mode
+
+GitHub Pages has no same-origin Express API. The Pages workflow therefore sets
+`VITE_PUBLIC_DEMO_RECEIPT_URL=data/austin-building-permits.receipt.json` and renders a read-only
+public-data surface instead of allowing the authenticated dashboard to send doomed `/api` requests.
+The tracked receipt selects four non-contact fields from City of Austin dataset `3syk-w9eu`; the
+deployment gate verifies the live metadata, JSON endpoint, and Pages-readable CORS before building.
+Other deployments remain on the normal dashboard/API path unless they explicitly set this variable.
+
+Focused verification from the repository root:
+
+```bash
+node --test scripts/verify-pages-public-demo.test.mjs
+node scripts/verify-pages-public-demo.mjs apps/web/public/data/austin-building-permits.receipt.json
+VITE_PUBLIC_DEMO_RECEIPT_URL=data/austin-building-permits.receipt.json npm --workspace apps/web run build -- --base=/public-record-data-scrapper/
+npx --no-install playwright test --config playwright.pages-demo.config.ts
+```

--- a/apps/web/public/data/austin-building-permits.receipt.json
+++ b/apps/web/public/data/austin-building-permits.receipt.json
@@ -1,0 +1,33 @@
+{
+  "schema": "public-records.pages_public_demo_source.v1",
+  "receipt_id": "austin-issued-construction-permits-3syk-w9eu",
+  "mode": "read_only_live_public_data",
+  "source": {
+    "owner": "City of Austin",
+    "dataset_id": "3syk-w9eu",
+    "dataset_name": "Issued Construction Permits",
+    "dataset_page_url": "https://data.austintexas.gov/Building-and-Development/Issued-Construction-Permits/3syk-w9eu",
+    "metadata_url": "https://data.austintexas.gov/api/views/3syk-w9eu",
+    "api_url": "https://data.austintexas.gov/resource/3syk-w9eu.json"
+  },
+  "fields": {
+    "record_id": "permit_number",
+    "company_name": "contractor_company_name",
+    "event_date": "issue_date",
+    "record_type": "permit_type_desc"
+  },
+  "rejected_fields": ["issued_date"],
+  "query": {
+    "limit": 24
+  },
+  "privacy": {
+    "displayed_fields": [
+      "permit_number",
+      "contractor_company_name",
+      "issue_date",
+      "permit_type_desc"
+    ],
+    "excluded_categories": ["address", "contact", "owner", "applicant"],
+    "browser_writes": false
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,8 +43,9 @@ import { ExportFormat } from '@/lib/exportUtils'
 import { UserAction } from '@/lib/agentic/types'
 import { logUserAction } from '@/lib/api/userActions'
 import { toast } from 'sonner'
+import { PublicDataDemo } from '@/components/PublicDataDemo'
 
-function App() {
+function DashboardApp() {
   const [selectedProspect, setSelectedProspect] = useState<Prospect | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [exportFormat, setExportFormat] = useKV<ExportFormat>('export-format', 'json')
@@ -334,6 +335,11 @@ function App() {
       />
     </div>
   )
+}
+
+function App() {
+  const publicDemoReceipt = String(import.meta.env.VITE_PUBLIC_DEMO_RECEIPT_URL ?? '').trim()
+  return publicDemoReceipt ? <PublicDataDemo receiptPath={publicDemoReceipt} /> : <DashboardApp />
 }
 
 export default App

--- a/apps/web/src/components/PublicDataDemo.tsx
+++ b/apps/web/src/components/PublicDataDemo.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ArrowClockwise, ArrowSquareOut, Buildings, Database } from '@phosphor-icons/react'
+import { Badge } from '@public-records/ui/badge'
+import { Button } from '@public-records/ui/button'
+import { Card } from '@public-records/ui/card'
+import {
+  loadPublicDemoData,
+  type PublicDemoData,
+  resolvePublicDemoReceiptUrl
+} from '@/lib/publicDemo'
+
+interface PublicDataDemoProps {
+  receiptPath: string
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeZone: 'UTC' }).format(date)
+}
+
+export function PublicDataDemo({ receiptPath }: PublicDataDemoProps) {
+  const receiptUrl = resolvePublicDemoReceiptUrl(
+    receiptPath,
+    import.meta.env.BASE_URL,
+    window.location.origin
+  )
+  const [data, setData] = useState<PublicDemoData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true)
+      setError(null)
+      try {
+        setData(await loadPublicDemoData(receiptUrl, signal))
+      } catch (reason) {
+        if (signal?.aborted) return
+        setError(reason instanceof Error ? reason.message : 'Unable to load public data')
+      } finally {
+        if (!signal?.aborted) setLoading(false)
+      }
+    },
+    [receiptUrl]
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void refresh(controller.signal)
+    return () => controller.abort()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="mica-effect border-b-2 border-primary/20">
+        <div className="container mx-auto px-4 py-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl sm:text-2xl font-bold">Austin Issued Construction Permits</h1>
+              <Badge className="bg-emerald-500/20 text-emerald-200 border border-emerald-500/30">
+                PUBLIC DATA DEMO
+              </Badge>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Receipt-bound, read-only records from the City of Austin open-data API.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => void refresh()} disabled={loading}>
+            <ArrowClockwise size={16} className="mr-2" />
+            Refresh source
+          </Button>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8 space-y-6">
+        <Card className="glass-effect p-5 border-primary/20">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 font-semibold">
+                <Database size={20} weight="fill" />
+                Source contract
+              </div>
+              <p className="text-sm text-muted-foreground max-w-3xl">
+                This Pages build does not call a same-origin <code>/api</code> that does not exist.
+                It loads only permit number, contractor company, issue date, and permit type. No
+                scores, defaults, outreach claims, addresses, contacts, or owners are inferred.
+              </p>
+              {data ? (
+                <p className="text-xs text-muted-foreground" data-testid="source-receipt-id">
+                  Receipt: {data.receipt.receipt_id}
+                  {data.sourceLastModified ? ` · Source modified ${data.sourceLastModified}` : ''}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {data ? (
+                <a
+                  href={data.receipt.source.dataset_page_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center rounded-md border px-3 py-2 text-sm hover:bg-muted"
+                >
+                  City dataset <ArrowSquareOut size={14} className="ml-2" />
+                </a>
+              ) : null}
+              <a
+                href={receiptUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center rounded-md border px-3 py-2 text-sm hover:bg-muted"
+              >
+                Source receipt <ArrowSquareOut size={14} className="ml-2" />
+              </a>
+            </div>
+          </div>
+        </Card>
+
+        {loading ? (
+          <Card className="p-6 text-sm text-muted-foreground">Loading current permit records…</Card>
+        ) : null}
+
+        {error ? (
+          <Card className="p-6 border-red-500/40" role="alert">
+            <p className="font-semibold text-red-300">Public source unavailable</p>
+            <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+          </Card>
+        ) : null}
+
+        {!loading && !error && data ? (
+          <section aria-labelledby="permit-records-heading">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 id="permit-records-heading" className="text-lg font-semibold">
+                Latest issued permits
+              </h2>
+              <span className="text-sm text-muted-foreground">{data.permits.length} records</span>
+            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {data.permits.map((permit) => (
+                <Card key={`${permit.id}-${permit.companyName}`} className="p-5 glass-effect">
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-lg bg-primary/10 p-2 text-primary">
+                      <Buildings size={22} weight="fill" />
+                    </div>
+                    <div className="min-w-0">
+                      <h3 className="font-semibold break-words">{permit.companyName}</h3>
+                      <p className="mt-1 text-sm text-muted-foreground">{permit.permitType}</p>
+                    </div>
+                  </div>
+                  <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm">
+                    <dt className="text-muted-foreground">Permit</dt>
+                    <dd className="font-mono break-all">{permit.id}</dd>
+                    <dt className="text-muted-foreground">Issued</dt>
+                    <dd>{formatDate(permit.issueDate)}</dd>
+                  </dl>
+                </Card>
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/lib/__tests__/publicDemo.test.ts
+++ b/apps/web/src/lib/__tests__/publicDemo.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildPublicDemoSourceUrl,
+  loadPublicDemoData,
+  parsePublicDemoReceipt,
+  resolvePublicDemoReceiptUrl
+} from '../publicDemo'
+
+const receipt = {
+  schema: 'public-records.pages_public_demo_source.v1',
+  receipt_id: 'austin-issued-construction-permits-3syk-w9eu',
+  mode: 'read_only_live_public_data',
+  source: {
+    owner: 'City of Austin',
+    dataset_id: '3syk-w9eu',
+    dataset_name: 'Issued Construction Permits',
+    dataset_page_url:
+      'https://data.austintexas.gov/Building-and-Development/Issued-Construction-Permits/3syk-w9eu',
+    metadata_url: 'https://data.austintexas.gov/api/views/3syk-w9eu',
+    api_url: 'https://data.austintexas.gov/resource/3syk-w9eu.json'
+  },
+  fields: {
+    record_id: 'permit_number',
+    company_name: 'contractor_company_name',
+    event_date: 'issue_date',
+    record_type: 'permit_type_desc'
+  },
+  rejected_fields: ['issued_date'],
+  query: { limit: 24 },
+  privacy: {
+    displayed_fields: [
+      'permit_number',
+      'contractor_company_name',
+      'issue_date',
+      'permit_type_desc'
+    ],
+    excluded_categories: ['address', 'contact', 'owner', 'applicant'],
+    browser_writes: false
+  }
+} as const
+
+function jsonResponse(value: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...headers }
+  })
+}
+
+describe('public Pages demo source', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves a relative receipt below the deployed Pages base path', () => {
+    expect(
+      resolvePublicDemoReceiptUrl(
+        'data/austin-building-permits.receipt.json',
+        '/public-record-data-scrapper/',
+        'https://organvm.github.io'
+      )
+    ).toBe(
+      'https://organvm.github.io/public-record-data-scrapper/data/austin-building-permits.receipt.json'
+    )
+  })
+
+  it('builds the source query from issue_date, never the obsolete issued_date alias', () => {
+    const sourceUrl = decodeURIComponent(
+      buildPublicDemoSourceUrl(parsePublicDemoReceipt(receipt)).replaceAll('+', ' ')
+    )
+    expect(sourceUrl).toContain('issue_date IS NOT NULL')
+    expect(sourceUrl).toContain('issue_date DESC')
+    expect(sourceUrl).not.toContain('issued_date')
+  })
+
+  it('loads a same-origin receipt then a credential-free public endpoint', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(receipt))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [
+            {
+              permit_number: '2026-000001 PP',
+              contractor_company_name: 'Example Plumbing LLC',
+              issue_date: '2026-07-16T00:00:00.000',
+              permit_type_desc: 'Plumbing Permit'
+            }
+          ],
+          { 'last-modified': 'Thu, 16 Jul 2026 12:57:51 GMT' }
+        )
+      )
+
+    const data = await loadPublicDemoData(
+      'https://organvm.github.io/public-record-data-scrapper/data/austin-building-permits.receipt.json',
+      undefined,
+      fetchImpl
+    )
+
+    expect(data.permits).toEqual([
+      {
+        id: '2026-000001 PP',
+        companyName: 'Example Plumbing LLC',
+        issueDate: '2026-07-16T00:00:00.000',
+        permitType: 'Plumbing Permit'
+      }
+    ])
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('austin-building-permits.receipt.json'),
+      expect.objectContaining({ credentials: 'same-origin' })
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('data.austintexas.gov/resource/3syk-w9eu.json'),
+      expect.objectContaining({ credentials: 'omit' })
+    )
+  })
+
+  it('fails closed when a non-empty source response violates the field contract', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(receipt))
+      .mockResolvedValueOnce(jsonResponse([{ issued_date: '2026-07-16' }]))
+
+    await expect(
+      loadPublicDemoData('https://organvm.github.io/receipt.json', undefined, fetchImpl)
+    ).rejects.toThrow('no longer matches the receipt field contract')
+  })
+})

--- a/apps/web/src/lib/publicDemo.ts
+++ b/apps/web/src/lib/publicDemo.ts
@@ -1,0 +1,276 @@
+const RECEIPT_SCHEMA = 'public-records.pages_public_demo_source.v1'
+const FIELD_NAME = /^[a-z][a-z0-9_]*$/
+const MAX_ROWS = 50
+
+export interface PublicDemoReceipt {
+  schema: typeof RECEIPT_SCHEMA
+  receipt_id: string
+  mode: 'read_only_live_public_data'
+  source: {
+    owner: string
+    dataset_id: string
+    dataset_name: string
+    dataset_page_url: string
+    metadata_url: string
+    api_url: string
+  }
+  fields: {
+    record_id: string
+    company_name: string
+    event_date: string
+    record_type: string
+  }
+  rejected_fields: string[]
+  query: {
+    limit: number
+  }
+  privacy: {
+    displayed_fields: string[]
+    excluded_categories: string[]
+    browser_writes: false
+  }
+}
+
+export interface PublicDemoPermit {
+  id: string
+  companyName: string
+  issueDate: string
+  permitType: string
+}
+
+export interface PublicDemoData {
+  receipt: PublicDemoReceipt
+  permits: PublicDemoPermit[]
+  sourceUrl: string
+  sourceLastModified: string | null
+}
+
+type FetchLike = typeof fetch
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Public demo receipt field '${key}' must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function requiredRecord(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = record[key]
+  if (!isRecord(value)) {
+    throw new Error(`Public demo receipt field '${key}' must be an object`)
+  }
+  return value
+}
+
+function stringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key]
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Public demo receipt field '${key}' must be an array of strings`)
+  }
+  return value.map((item) => item.trim())
+}
+
+function requireHttpsUrl(value: string, key: string): URL {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`Public demo receipt field '${key}' must be an absolute URL`)
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Public demo receipt field '${key}' must use HTTPS`)
+  }
+  return parsed
+}
+
+export function parsePublicDemoReceipt(value: unknown): PublicDemoReceipt {
+  if (!isRecord(value)) {
+    throw new Error('Public demo receipt must be a JSON object')
+  }
+  if (value.schema !== RECEIPT_SCHEMA) {
+    throw new Error(`Unsupported public demo receipt schema '${String(value.schema)}'`)
+  }
+  if (value.mode !== 'read_only_live_public_data') {
+    throw new Error("Public demo receipt mode must be 'read_only_live_public_data'")
+  }
+
+  const source = requiredRecord(value, 'source')
+  const fields = requiredRecord(value, 'fields')
+  const query = requiredRecord(value, 'query')
+  const privacy = requiredRecord(value, 'privacy')
+
+  const datasetId = requiredString(source, 'dataset_id')
+  const apiUrl = requireHttpsUrl(requiredString(source, 'api_url'), 'source.api_url')
+  const metadataUrl = requireHttpsUrl(requiredString(source, 'metadata_url'), 'source.metadata_url')
+  const datasetPageUrl = requireHttpsUrl(
+    requiredString(source, 'dataset_page_url'),
+    'source.dataset_page_url'
+  )
+
+  if (!apiUrl.pathname.endsWith(`/resource/${datasetId}.json`)) {
+    throw new Error('Public demo API URL does not match its dataset_id')
+  }
+  if (!metadataUrl.pathname.endsWith(`/api/views/${datasetId}`)) {
+    throw new Error('Public demo metadata URL does not match its dataset_id')
+  }
+  if (apiUrl.hostname !== metadataUrl.hostname || apiUrl.hostname !== datasetPageUrl.hostname) {
+    throw new Error('Public demo source URLs must share one owner hostname')
+  }
+
+  const parsedFields = {
+    record_id: requiredString(fields, 'record_id'),
+    company_name: requiredString(fields, 'company_name'),
+    event_date: requiredString(fields, 'event_date'),
+    record_type: requiredString(fields, 'record_type')
+  }
+  for (const field of Object.values(parsedFields)) {
+    if (!FIELD_NAME.test(field)) {
+      throw new Error(`Unsafe public demo source field '${field}'`)
+    }
+  }
+
+  const rejectedFields = stringArray(value, 'rejected_fields')
+  if (rejectedFields.some((field) => !FIELD_NAME.test(field))) {
+    throw new Error('Public demo rejected_fields contains an unsafe field name')
+  }
+  if (rejectedFields.includes(parsedFields.event_date)) {
+    throw new Error('Public demo event-date field cannot also be rejected')
+  }
+
+  const limit = query.limit
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_ROWS) {
+    throw new Error(`Public demo query.limit must be an integer from 1 to ${MAX_ROWS}`)
+  }
+
+  const displayedFields = stringArray(privacy, 'displayed_fields')
+  const selectedFields = Object.values(parsedFields)
+  if (selectedFields.some((field) => !displayedFields.includes(field))) {
+    throw new Error('Public demo privacy.displayed_fields must cover every selected field')
+  }
+  if (privacy.browser_writes !== false) {
+    throw new Error('Public demo receipt must explicitly disable browser writes')
+  }
+
+  return {
+    schema: RECEIPT_SCHEMA,
+    receipt_id: requiredString(value, 'receipt_id'),
+    mode: 'read_only_live_public_data',
+    source: {
+      owner: requiredString(source, 'owner'),
+      dataset_id: datasetId,
+      dataset_name: requiredString(source, 'dataset_name'),
+      dataset_page_url: datasetPageUrl.toString(),
+      metadata_url: metadataUrl.toString(),
+      api_url: apiUrl.toString()
+    },
+    fields: parsedFields,
+    rejected_fields: rejectedFields,
+    query: { limit: limit as number },
+    privacy: {
+      displayed_fields: displayedFields,
+      excluded_categories: stringArray(privacy, 'excluded_categories'),
+      browser_writes: false
+    }
+  }
+}
+
+export function buildPublicDemoSourceUrl(receipt: PublicDemoReceipt): string {
+  const selectedFields = Object.values(receipt.fields)
+  const params = new URLSearchParams({
+    $select: selectedFields.join(','),
+    $where: `${receipt.fields.company_name} IS NOT NULL AND ${receipt.fields.event_date} IS NOT NULL`,
+    $order: `${receipt.fields.event_date} DESC`,
+    $limit: String(receipt.query.limit)
+  })
+  return `${receipt.source.api_url}?${params.toString()}`
+}
+
+export function resolvePublicDemoReceiptUrl(
+  configuredUrl: string,
+  baseUrl: string,
+  origin: string
+): string {
+  const deploymentBase = new URL(baseUrl, origin)
+  return new URL(configuredUrl, deploymentBase).toString()
+}
+
+async function responseJson(response: Response, label: string): Promise<unknown> {
+  if (!response.ok) {
+    throw new Error(`${label} returned HTTP ${response.status}`)
+  }
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error(`${label} returned non-JSON content`)
+  }
+  return response.json()
+}
+
+export async function loadPublicDemoData(
+  receiptUrl: string,
+  signal?: AbortSignal,
+  fetchImpl: FetchLike = fetch
+): Promise<PublicDemoData> {
+  const receiptResponse = await fetchImpl(receiptUrl, {
+    headers: { Accept: 'application/json' },
+    credentials: 'same-origin',
+    signal
+  })
+  const receipt = parsePublicDemoReceipt(
+    await responseJson(receiptResponse, 'Public demo source receipt')
+  )
+  const sourceUrl = buildPublicDemoSourceUrl(receipt)
+  const sourceResponse = await fetchImpl(sourceUrl, {
+    headers: { Accept: 'application/json' },
+    credentials: 'omit',
+    signal
+  })
+  const body = await responseJson(sourceResponse, receipt.source.dataset_name)
+  if (!Array.isArray(body)) {
+    throw new Error(`${receipt.source.dataset_name} changed shape: expected an array`)
+  }
+
+  const seen = new Set<string>()
+  const permits: PublicDemoPermit[] = []
+  for (const value of body) {
+    if (!isRecord(value)) continue
+    const recordId = value[receipt.fields.record_id]
+    const companyName = value[receipt.fields.company_name]
+    const issueDate = value[receipt.fields.event_date]
+    const permitType = value[receipt.fields.record_type]
+    if (
+      typeof recordId !== 'string' ||
+      typeof companyName !== 'string' ||
+      typeof issueDate !== 'string'
+    ) {
+      continue
+    }
+    const key = `${recordId.trim()}\u0000${companyName.trim()}`
+    if (!recordId.trim() || !companyName.trim() || !issueDate.trim() || seen.has(key)) continue
+    seen.add(key)
+    permits.push({
+      id: recordId.trim(),
+      companyName: companyName.trim(),
+      issueDate: issueDate.trim(),
+      permitType:
+        typeof permitType === 'string' && permitType.trim().length > 0
+          ? permitType.trim()
+          : 'Construction permit'
+    })
+  }
+
+  if (body.length > 0 && permits.length === 0) {
+    throw new Error(`${receipt.source.dataset_name} no longer matches the receipt field contract`)
+  }
+
+  return {
+    receipt,
+    permits,
+    sourceUrl,
+    sourceLastModified: sourceResponse.headers.get('last-modified')
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,7 +9,12 @@ import './main.css'
 import './styles/theme.css'
 import './index.css'
 
-if (typeof window !== 'undefined') {
+const publicDemoEnabled = Boolean(String(import.meta.env.VITE_PUBLIC_DEMO_RECEIPT_URL ?? '').trim())
+
+// The static Pages demo is explicitly zero-write. Loading the Spark runtime
+// would POST its normal `/_spark/loaded` telemetry to an endpoint that GitHub
+// Pages neither owns nor serves, so retain Spark for normal app builds only.
+if (typeof window !== 'undefined' && !publicDemoEnabled) {
   import('@github/spark/spark').catch((error) => {
     console.warn(
       '[main] Unable to load Spark runtime; falling back to local storage state management.',

--- a/playwright.pages-demo.config.ts
+++ b/playwright.pages-demo.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = 'http://127.0.0.1:4173/public-record-data-scrapper/'
+
+export default defineConfig({
+  testDir: './tests/e2e-pages-demo',
+  outputDir: './dist/playwright-pages-demo-results',
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    channel: 'chrome',
+    trace: 'retain-on-failure',
+    ...devices['Desktop Chrome']
+  },
+  projects: [{ name: 'chromium' }],
+  webServer: {
+    command:
+      'npm --workspace apps/web run preview -- --host 127.0.0.1 --port 4173 --base=/public-record-data-scrapper/',
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 60_000
+  },
+  timeout: 30_000,
+  expect: { timeout: 5_000 }
+})

--- a/scripts/verify-pages-public-demo.mjs
+++ b/scripts/verify-pages-public-demo.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const RECEIPT_SCHEMA = 'public-records.pages_public_demo_source.v1'
+const DEFAULT_PAGES_ORIGIN = 'https://organvm.github.io'
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function httpsUrl(value, label) {
+  const parsed = new URL(nonEmptyString(value, label))
+  if (parsed.protocol !== 'https:') throw new Error(`${label} must use HTTPS`)
+  return parsed
+}
+
+export function validateReceipt(value) {
+  if (!isRecord(value) || value.schema !== RECEIPT_SCHEMA) {
+    throw new Error(`Receipt schema must be ${RECEIPT_SCHEMA}`)
+  }
+  if (value.mode !== 'read_only_live_public_data') {
+    throw new Error('Receipt must declare read_only_live_public_data mode')
+  }
+  if (!isRecord(value.source) || !isRecord(value.fields) || !isRecord(value.query)) {
+    throw new Error('Receipt source, fields, and query must be objects')
+  }
+  if (!isRecord(value.privacy) || value.privacy.browser_writes !== false) {
+    throw new Error('Receipt must explicitly deny browser writes')
+  }
+
+  const datasetId = nonEmptyString(value.source.dataset_id, 'source.dataset_id')
+  const apiUrl = httpsUrl(value.source.api_url, 'source.api_url')
+  const metadataUrl = httpsUrl(value.source.metadata_url, 'source.metadata_url')
+  const datasetPageUrl = httpsUrl(value.source.dataset_page_url, 'source.dataset_page_url')
+  if (!apiUrl.pathname.endsWith(`/resource/${datasetId}.json`)) {
+    throw new Error('source.api_url does not match source.dataset_id')
+  }
+  if (!metadataUrl.pathname.endsWith(`/api/views/${datasetId}`)) {
+    throw new Error('source.metadata_url does not match source.dataset_id')
+  }
+  if (apiUrl.hostname !== metadataUrl.hostname || apiUrl.hostname !== datasetPageUrl.hostname) {
+    throw new Error('Source URLs must share one owner hostname')
+  }
+
+  const fields = {
+    record_id: nonEmptyString(value.fields.record_id, 'fields.record_id'),
+    company_name: nonEmptyString(value.fields.company_name, 'fields.company_name'),
+    event_date: nonEmptyString(value.fields.event_date, 'fields.event_date'),
+    record_type: nonEmptyString(value.fields.record_type, 'fields.record_type')
+  }
+  const fieldPattern = /^[a-z][a-z0-9_]*$/
+  if (Object.values(fields).some((field) => !fieldPattern.test(field))) {
+    throw new Error('Receipt contains an unsafe source field')
+  }
+
+  if (!Array.isArray(value.rejected_fields)) {
+    throw new Error('rejected_fields must be an array')
+  }
+  const rejectedFields = value.rejected_fields.map((field) =>
+    nonEmptyString(field, 'rejected_fields entry')
+  )
+  if (rejectedFields.some((field) => !fieldPattern.test(field))) {
+    throw new Error('rejected_fields contains an unsafe field')
+  }
+  if (rejectedFields.includes(fields.event_date)) {
+    throw new Error('Event-date field cannot also be rejected')
+  }
+
+  if (
+    !Array.isArray(value.privacy.displayed_fields) ||
+    value.privacy.displayed_fields.some((field) => typeof field !== 'string')
+  ) {
+    throw new Error('privacy.displayed_fields must be an array of strings')
+  }
+  if (Object.values(fields).some((field) => !value.privacy.displayed_fields.includes(field))) {
+    throw new Error('privacy.displayed_fields must cover every selected source field')
+  }
+
+  const limit = value.query.limit
+  if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+    throw new Error('query.limit must be an integer from 1 to 50')
+  }
+
+  return {
+    ...value,
+    source: {
+      ...value.source,
+      dataset_id: datasetId,
+      api_url: apiUrl.toString(),
+      metadata_url: metadataUrl.toString(),
+      dataset_page_url: datasetPageUrl.toString()
+    },
+    fields,
+    rejected_fields: rejectedFields,
+    query: { ...value.query, limit }
+  }
+}
+
+export function buildDataUrl(receipt) {
+  const params = new URLSearchParams({
+    $select: Object.values(receipt.fields).join(','),
+    $where: `${receipt.fields.company_name} IS NOT NULL AND ${receipt.fields.event_date} IS NOT NULL`,
+    $order: `${receipt.fields.event_date} DESC`,
+    $limit: String(receipt.query.limit)
+  })
+  return `${receipt.source.api_url}?${params.toString()}`
+}
+
+function assertCors(response, label, pagesOrigin) {
+  const allowOrigin = response.headers.get('access-control-allow-origin')
+  if (allowOrigin !== '*' && allowOrigin !== pagesOrigin) {
+    throw new Error(
+      `${label} does not allow the Pages origin (got ${allowOrigin ?? 'no CORS header'})`
+    )
+  }
+  return allowOrigin
+}
+
+async function fetchJson(fetchImpl, url, label, pagesOrigin) {
+  const response = await fetchImpl(url, {
+    headers: { Accept: 'application/json', Origin: pagesOrigin },
+    signal: AbortSignal.timeout(12000)
+  })
+  if (!response.ok) throw new Error(`${label} returned HTTP ${response.status}`)
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error(`${label} returned non-JSON content`)
+  }
+  const cors = assertCors(response, label, pagesOrigin)
+  return { body: await response.json(), cors }
+}
+
+export async function verifyPublicDemoSource(
+  rawReceipt,
+  { fetchImpl = fetch, pagesOrigin = DEFAULT_PAGES_ORIGIN } = {}
+) {
+  const receipt = validateReceipt(rawReceipt)
+  const metadataResult = await fetchJson(
+    fetchImpl,
+    receipt.source.metadata_url,
+    'Socrata metadata endpoint',
+    pagesOrigin
+  )
+  if (!isRecord(metadataResult.body) || metadataResult.body.id !== receipt.source.dataset_id) {
+    throw new Error('Metadata endpoint returned the wrong dataset')
+  }
+  if (!Array.isArray(metadataResult.body.columns)) {
+    throw new Error('Metadata endpoint omitted its columns contract')
+  }
+  const liveFields = new Set(
+    metadataResult.body.columns
+      .filter(isRecord)
+      .map((column) => column.fieldName)
+      .filter((field) => typeof field === 'string')
+  )
+  const requiredFields = Object.values(receipt.fields)
+  const missingFields = requiredFields.filter((field) => !liveFields.has(field))
+  if (missingFields.length > 0) {
+    throw new Error(`Metadata endpoint is missing required fields: ${missingFields.join(', ')}`)
+  }
+  const obsoleteFieldsPresent = receipt.rejected_fields.filter((field) => liveFields.has(field))
+  if (obsoleteFieldsPresent.length > 0) {
+    throw new Error(
+      `Metadata endpoint unexpectedly exposes rejected fields: ${obsoleteFieldsPresent.join(', ')}`
+    )
+  }
+
+  const sourceUrl = buildDataUrl(receipt)
+  const dataResult = await fetchJson(fetchImpl, sourceUrl, 'Socrata resource endpoint', pagesOrigin)
+  if (!Array.isArray(dataResult.body) || dataResult.body.length === 0) {
+    throw new Error('Socrata resource endpoint returned no source rows')
+  }
+  const matchingRows = dataResult.body.filter(
+    (row) =>
+      isRecord(row) &&
+      requiredFields.every((field) => typeof row[field] === 'string' && row[field].trim())
+  )
+  if (matchingRows.length === 0) {
+    throw new Error('Socrata resource rows do not satisfy the receipt field contract')
+  }
+
+  return {
+    schema: 'public-records.pages_public_demo_verification.v1',
+    receipt_id: receipt.receipt_id,
+    dataset_id: receipt.source.dataset_id,
+    pages_origin: pagesOrigin,
+    metadata_cors: metadataResult.cors,
+    resource_cors: dataResult.cors,
+    event_date_field: receipt.fields.event_date,
+    rejected_fields_absent: receipt.rejected_fields,
+    rows_observed: dataResult.body.length,
+    rows_matching_contract: matchingRows.length,
+    source_url: sourceUrl,
+    status: 'pass'
+  }
+}
+
+async function main() {
+  const receiptPath = process.argv[2]
+  if (!receiptPath) {
+    throw new Error('usage: node scripts/verify-pages-public-demo.mjs <receipt.json>')
+  }
+  const rawReceipt = JSON.parse(await readFile(resolve(receiptPath), 'utf8'))
+  const result = await verifyPublicDemoSource(rawReceipt)
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).toString()
+if (isMain) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/verify-pages-public-demo.test.mjs
+++ b/scripts/verify-pages-public-demo.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  buildDataUrl,
+  validateReceipt,
+  verifyPublicDemoSource
+} from './verify-pages-public-demo.mjs'
+
+const receipt = {
+  schema: 'public-records.pages_public_demo_source.v1',
+  receipt_id: 'austin-issued-construction-permits-3syk-w9eu',
+  mode: 'read_only_live_public_data',
+  source: {
+    owner: 'City of Austin',
+    dataset_id: '3syk-w9eu',
+    dataset_name: 'Issued Construction Permits',
+    dataset_page_url:
+      'https://data.austintexas.gov/Building-and-Development/Issued-Construction-Permits/3syk-w9eu',
+    metadata_url: 'https://data.austintexas.gov/api/views/3syk-w9eu',
+    api_url: 'https://data.austintexas.gov/resource/3syk-w9eu.json'
+  },
+  fields: {
+    record_id: 'permit_number',
+    company_name: 'contractor_company_name',
+    event_date: 'issue_date',
+    record_type: 'permit_type_desc'
+  },
+  rejected_fields: ['issued_date'],
+  query: { limit: 24 },
+  privacy: {
+    displayed_fields: [
+      'permit_number',
+      'contractor_company_name',
+      'issue_date',
+      'permit_type_desc'
+    ],
+    browser_writes: false
+  }
+}
+
+function jsonResponse(body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'access-control-allow-origin': '*',
+      ...headers
+    }
+  })
+}
+
+test('Pages deployment watches every receipt verification input', async () => {
+  const workflow = await readFile('.github/workflows/deploy-pages.yml', 'utf8')
+  assert.match(workflow, /- 'scripts\/verify-pages-public-demo\.mjs'/)
+  assert.match(workflow, /- 'scripts\/verify-pages-public-demo\.test\.mjs'/)
+})
+
+test('builds the live query from issue_date and never the obsolete issued_date alias', () => {
+  const url = decodeURIComponent(buildDataUrl(validateReceipt(receipt)).replaceAll('+', ' '))
+  assert.match(url, /issue_date IS NOT NULL/)
+  assert.match(url, /issue_date DESC/)
+  assert.doesNotMatch(url, /issued_date/)
+})
+
+test('verifies metadata, endpoint rows, and browser-readable CORS', async () => {
+  const fetchImpl = async (url) => {
+    if (String(url).includes('/api/views/')) {
+      return jsonResponse({
+        id: '3syk-w9eu',
+        columns: Object.values(receipt.fields).map((fieldName) => ({ fieldName }))
+      })
+    }
+    return jsonResponse([
+      {
+        permit_number: '2026-000001 PP',
+        contractor_company_name: 'Example Plumbing LLC',
+        issue_date: '2026-07-16T00:00:00.000',
+        permit_type_desc: 'Plumbing Permit'
+      }
+    ])
+  }
+
+  const result = await verifyPublicDemoSource(receipt, { fetchImpl })
+  assert.equal(result.status, 'pass')
+  assert.equal(result.event_date_field, 'issue_date')
+  assert.deepEqual(result.rejected_fields_absent, ['issued_date'])
+  assert.equal(result.rows_matching_contract, 1)
+})
+
+test('fails closed when the source omits a Pages-readable CORS header', async () => {
+  const fetchImpl = async () =>
+    jsonResponse(
+      { id: '3syk-w9eu', columns: [] },
+      { 'access-control-allow-origin': 'https://not-the-pages-origin.example' }
+    )
+
+  await assert.rejects(
+    verifyPublicDemoSource(receipt, { fetchImpl }),
+    /does not allow the Pages origin/
+  )
+})
+
+test('fails closed if metadata starts exposing a rejected schema alias', async () => {
+  const fetchImpl = async (url) => {
+    if (String(url).includes('/api/views/')) {
+      return jsonResponse({
+        id: '3syk-w9eu',
+        columns: [...Object.values(receipt.fields), 'issued_date'].map((fieldName) => ({
+          fieldName
+        }))
+      })
+    }
+    return jsonResponse([])
+  }
+
+  await assert.rejects(
+    verifyPublicDemoSource(receipt, { fetchImpl }),
+    /unexpectedly exposes rejected fields: issued_date/
+  )
+})

--- a/server/__tests__/services/sbaLoansChannel.test.ts
+++ b/server/__tests__/services/sbaLoansChannel.test.ts
@@ -9,6 +9,7 @@ vi.mock('@public-records/core/enrichment', () => ({
 
 import { SBALoansChannel } from '../../services/discovery-channels/SBALoansChannel'
 import { DiscoveryChannelError } from '../../services/discovery-channels/types'
+import { rateLimiterManager } from '@public-records/core/enrichment'
 
 const CKAN_RESOURCE_URL = 'https://data.sba.gov/dataset/x/foia-7a-fy2020-present-asof-250101.csv'
 
@@ -69,6 +70,7 @@ describe('SBALoansChannel (streaming)', () => {
   beforeEach(() => {
     fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
+    vi.mocked(rateLimiterManager.waitForTokens).mockClear()
   })
 
   afterEach(() => {
@@ -182,7 +184,16 @@ describe('SBALoansChannel (streaming)', () => {
         json: async () => ({
           dataset: [
             { distribution: [{ format: 'pdf', downloadURL: 'https://x/notes.pdf' }] },
-            { distribution: [{ downloadURL: CKAN_RESOURCE_URL }] }
+            {
+              distribution: [
+                {
+                  format: 'ZIP',
+                  downloadURL:
+                    'https://data.sba.gov/dataset/x/foia-7a-fy2020-present-asof-250101.zip'
+                },
+                { mediaType: 'text/csv', downloadURL: CKAN_RESOURCE_URL }
+              ]
+            }
           ]
         })
       } as unknown as Response)
@@ -191,6 +202,46 @@ describe('SBALoansChannel (streaming)', () => {
     const candidates = await new SBALoansChannel().discover({ limit: 10 })
 
     expect(candidates.map((c) => c.company_name)).toEqual(['Dcat Co'])
+    expect(rateLimiterManager.waitForTokens).toHaveBeenCalledTimes(3)
+    expect(fetchSpy.mock.calls[2]?.[0]).toBe(CKAN_RESOURCE_URL)
+  })
+
+  it('skips a same-stem non-CSV DCAT distribution that precedes the CSV', async () => {
+    const csvUrl =
+      'https://data.sba.gov/dataset/x/foia-7a-fy2020-present-asof-250102.csv?download=1'
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({})
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          dataset: [
+            {
+              distribution: [
+                {
+                  format: 'XLSX',
+                  mediaType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                  downloadURL:
+                    'https://data.sba.gov/dataset/x/foia-7a-fy2020-present-asof-250102.xlsx'
+                },
+                { downloadURL: csvUrl }
+              ]
+            }
+          ]
+        })
+      } as unknown as Response)
+      .mockResolvedValueOnce(streamingResponse([HEADER, row('CSV Co', 'NY')]))
+
+    const candidates = await new SBALoansChannel().discover({ limit: 10 })
+
+    expect(candidates.map((candidate) => candidate.company_name)).toEqual(['CSV Co'])
+    expect(fetchSpy.mock.calls[2]?.[0]).toBe(csvUrl)
   })
 
   it('fails closed with a named unavailability reason when CKAN and DCAT both lack the dataset', async () => {

--- a/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
+++ b/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
@@ -50,7 +50,10 @@ describe('SocrataBuildingPermitsChannel', () => {
       ])
     )
 
-    const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    const candidates = await new SocrataBuildingPermitsChannel().discover({
+      state: 'NY',
+      limit: 10
+    })
 
     expect(candidates.map((c) => c.company_name)).toEqual(['Acme Builders', 'Beta Contractors'])
     expect(candidates[0]).toMatchObject({
@@ -98,11 +101,31 @@ describe('SocrataBuildingPermitsChannel', () => {
     expect(url).toContain('issue_permit_date IS NOT NULL')
   })
 
+  it('uses Austin issue_date and never the obsolete issued_date alias', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      rowsResponse([
+        {
+          [TX_FIELD]: 'Lone Star Builders LLC',
+          issue_date: '2026-07-16T00:00:00.000'
+        }
+      ])
+    )
+
+    await new SocrataBuildingPermitsChannel().discover({ state: 'TX', limit: 5 })
+
+    // Austin dataset 3syk-w9eu exposes `issue_date`. Its live metadata does
+    // not contain `issued_date`; using that review-suggested alias yields a
+    // SODA no-such-column response.
+    const url = decodeURIComponent(String(fetchSpy.mock.calls[0][0]).replace(/\+/g, ' '))
+    expect(url).toContain('data.austintexas.gov/resource/3syk-w9eu.json')
+    expect(url).toContain('issue_date DESC')
+    expect(url).toContain('issue_date IS NOT NULL')
+    expect(url).not.toContain('issued_date')
+  })
+
   it('caps the total candidates at the requested limit', async () => {
     fetchSpy.mockResolvedValueOnce(
-      rowsResponse(
-        Array.from({ length: 10 }, (_, n) => ({ [NY_FIELD]: `Co ${n}` }))
-      )
+      rowsResponse(Array.from({ length: 10 }, (_, n) => ({ [NY_FIELD]: `Co ${n}` })))
     )
 
     const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 3 })

--- a/server/services/discovery-channels/SBALoansChannel.ts
+++ b/server/services/discovery-channels/SBALoansChannel.ts
@@ -92,6 +92,10 @@ export class SBALoansChannel implements DiscoveryChannel {
       ckanReason = errorMessage(err)
     }
     try {
+      // The fallback is a distinct external request and therefore consumes its
+      // own token. One token for the resolution chain is not enough when CKAN
+      // fails and DCAT is attempted in the same discovery run.
+      await rateLimiterManager.waitForTokens(RATE_BUCKET)
       return await this.resolveViaDcat()
     } catch (dcatErr) {
       throw new DiscoveryChannelError(
@@ -157,9 +161,15 @@ export class SBALoansChannel implements DiscoveryChannel {
     for (const ds of datasets as { distribution?: unknown }[]) {
       const dists = ds?.distribution
       if (!Array.isArray(dists)) continue
-      for (const dist of dists as { downloadURL?: unknown }[]) {
+      for (const dist of dists as {
+        downloadURL?: unknown
+        format?: unknown
+        mediaType?: unknown
+      }[]) {
         const url = typeof dist.downloadURL === 'string' ? dist.downloadURL : ''
-        if (url.toLowerCase().includes(RECENT_7A_RESOURCE_STEM)) return url
+        if (url.toLowerCase().includes(RECENT_7A_RESOURCE_STEM) && isCsvDistribution(dist, url)) {
+          return url
+        }
       }
     }
 
@@ -279,6 +289,29 @@ export class SBALoansChannel implements DiscoveryChannel {
 
     return out
   }
+}
+
+/** Accept a DCAT distribution only when its metadata or URL identifies CSV. */
+function isCsvDistribution(
+  dist: { format?: unknown; mediaType?: unknown },
+  downloadUrl: string
+): boolean {
+  const format = typeof dist.format === 'string' ? dist.format.trim().toLowerCase() : ''
+  const mediaType =
+    typeof dist.mediaType === 'string' ? dist.mediaType.split(';', 1)[0].trim().toLowerCase() : ''
+  let pathname = ''
+  try {
+    pathname = new URL(downloadUrl).pathname.toLowerCase()
+  } catch {
+    return false
+  }
+  return (
+    format === 'csv' ||
+    format === 'text/csv' ||
+    mediaType === 'text/csv' ||
+    mediaType === 'application/csv' ||
+    pathname.endsWith('.csv')
+  )
 }
 
 /** Resolved header: required column positions + optional enrichment positions. */

--- a/tests/e2e-pages-demo/public-data.spec.ts
+++ b/tests/e2e-pages-demo/public-data.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+
+test('built Pages bundle loads receipt-bound public records and never calls a missing /api', async ({
+  page
+}) => {
+  const requests: string[] = []
+  page.on('request', (request) => requests.push(request.url()))
+
+  await page.route('https://data.austintexas.gov/resource/3syk-w9eu.json**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'application/json;charset=utf-8',
+        'access-control-allow-origin': '*',
+        'last-modified': 'Thu, 16 Jul 2026 12:57:51 GMT'
+      },
+      body: JSON.stringify([
+        {
+          permit_number: '2026-000001 PP',
+          contractor_company_name: 'Example Plumbing LLC',
+          issue_date: '2026-07-16T00:00:00.000',
+          permit_type_desc: 'Plumbing Permit'
+        },
+        {
+          permit_number: '2026-000002 BP',
+          contractor_company_name: 'Example Builders Inc',
+          issue_date: '2026-07-15T00:00:00.000',
+          permit_type_desc: 'Building Permit'
+        }
+      ])
+    })
+  })
+
+  await page.goto('./')
+
+  await expect(
+    page.getByRole('heading', { name: 'Austin Issued Construction Permits' })
+  ).toBeVisible()
+  await expect(page.getByText('Example Plumbing LLC')).toBeVisible()
+  await expect(page.getByText('Example Builders Inc')).toBeVisible()
+  await expect(page.getByTestId('source-receipt-id')).toContainText(
+    'austin-issued-construction-permits-3syk-w9eu'
+  )
+
+  expect(
+    requests.some((url) =>
+      url.endsWith('/public-record-data-scrapper/data/austin-building-permits.receipt.json')
+    )
+  ).toBe(true)
+  expect(
+    requests.some((url) => {
+      const parsed = new URL(url)
+      return parsed.pathname === '/api' || parsed.pathname.startsWith('/api/')
+    })
+  ).toBe(false)
+  expect(
+    requests.some((url) => {
+      const parsed = new URL(url)
+      return parsed.pathname === '/_spark' || parsed.pathname.startsWith('/_spark/')
+    })
+  ).toBe(false)
+})


### PR DESCRIPTION
## Reacceptance scope

Repairs the current findings carried by merged PRs #349 and #352 without treating their green historical checks as acceptance proof.

## What changed

- replaces the broken same-origin `/api` Pages path with a receipt-bound, read-only Austin Socrata demo
- constrains the browser query to exactly four public fields and verifies live metadata/CORS
- keeps receipt mode zero-write by suppressing Spark's `/_spark/loaded` POST only in that build
- corrects the permit date contract to Austin's live `issue_date` field
- charges the SBA DCAT fallback its own rate-limit token
- rejects same-stem XLSX/ZIP distributions when resolving the SBA CSV
- expands Pages workflow triggers to every source that can change the deployed proof

## Verification

- live source: 24/24 rows; CORS `*`; exact four-field selection
- real Chrome against live Austin: GET only; zero `/api` and `/_spark` requests
- verifier: 5/5
- web unit: 4/4
- focused server: 21/21
- production Pages build and Playwright: passed
- actionlint, Prettier, focused ESLint, and `git diff --check`: passed

## Boundary

This is a draft for independent exact-head review. No deployment, task-board write, host mutation, or provider-session mutation was performed. The currently deployed Pages head remains broken until a reviewed repair is accepted and deployed.
