### PR TITLE
fix: expose resolved tier on public routes

### DIFF
--- a/server/__tests__/routes/publicDataTier.test.ts
+++ b/server/__tests__/routes/publicDataTier.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+
+vi.mock('@/queue/queues', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/queue/queues')>()
+  return {
+    ...actual,
+    getIngestionCoverageTelemetry: vi.fn(() => [])
+  }
+})
+
+import { Server } from '@/index'
+
+describe('public route data-tier contract', () => {
+  let app: ReturnType<Server['getApp']>
+
+  beforeEach(() => {
+    app = new Server().getApp()
+  })
+
+  it.each([
+    ['root', '/', 200],
+    ['status', '/status', 200],
+    ['health', '/api/health', 200],
+    ['OpenAPI document', '/api/docs/openapi.json', 200],
+    ['metrics rejection', '/api/metrics', 401],
+    ['billing status', '/api/billing/status', 200]
+  ])('advertises the resolved free tier on %s', async (_label, path, expectedStatus) => {
+    const response = await request(app).get(path)
+
+    expect(response.status).toBe(expectedStatus)
+    expect(response.headers['x-data-tier-resolved']).toBe('free-tier')
+  })
+
+  it('advertises the resolved free tier before a webhook rejection', async () => {
+    const response = await request(app)
+      .post('/api/webhooks/sendgrid/events')
+      .set('content-type', 'application/json')
+      .send('[]')
+
+    expect(response.status).not.toBe(404)
+    expect(response.headers['x-data-tier-resolved']).toBe('free-tier')
+  })
+})

--- a/server/index.ts
+++ b/server/index.ts
@@ -137,10 +137,17 @@ export class Server {
   }
 
   private setupRoutes(): void {
+    // Public routes have no authenticated entitlement context, so resolve them
+    // explicitly as free-tier and expose that decision on every response. Keep
+    // these mounts path-scoped: mounting dataTierRouter globally would run
+    // before auth and incorrectly freeze protected requests at free-tier.
+    this.app.use('/api/docs', dataTierRouter)
+
     // Swagger UI documentation
     this.setupSwaggerDocs()
 
     // Public status page (no auth, bookmarkable)
+    this.app.use('/status', dataTierRouter)
     this.app.use(statusRouter)
 
     // Public routes (no authentication required). dataTierRouter resolves
@@ -149,15 +156,15 @@ export class Server {
     this.app.use('/api/health', dataTierRouter, healthRouter)
 
     // Webhook routes (signature verification, no JWT auth)
-    this.app.use('/api/webhooks', webhooksRouter)
+    this.app.use('/api/webhooks', dataTierRouter, webhooksRouter)
 
     // Metrics (self-protecting: valid JWT OR METRICS_TOKEN; 401 when neither —
     // must NOT sit behind the global authMiddleware or the token scrape path breaks)
-    this.app.use('/api/metrics', metricsRouter)
+    this.app.use('/api/metrics', dataTierRouter, metricsRouter)
 
     // Billing routes (Stripe). The webhook is authenticated via Stripe signature
     // verification on the raw body (mounted above), not JWT.
-    this.app.use('/api/billing', billingRouter)
+    this.app.use('/api/billing', dataTierRouter, billingRouter)
 
     // Protected API routes (authentication required).
     // orgContextMiddleware runs AFTER authMiddleware (so req.user.orgId is
@@ -194,7 +201,7 @@ export class Server {
     this.app.use('/api/scrape', apiKeyOrJwtAuth, dataTierRouter, scrapeRouter)
 
     // Root endpoint
-    this.app.get('/', (req, res) => {
+    this.app.get('/', dataTierRouter, (req, res) => {
       res.json({
         name: 'UCC-MCA Intelligence API',
         version: '1.0.0',


### PR DESCRIPTION
## Recovery remedy

Repairs the unresolved finding from #353: removing the unsafe global pre-auth tier middleware left public routes without the `x-data-tier-resolved` contract.

Original discussion: https://github.com/organvm/public-record-data-scrapper/pull/353#discussion_r3597786554

The fix mounts tier resolution only on public route prefixes and the root handler. Protected routes retain their existing auth-first ordering, and raw webhook/billing body parsing remains ahead of route middleware.

## Verification

- `npx vitest run --config vitest.config.server.ts server/__tests__/routes/publicDataTier.test.ts server/__tests__/middleware/dataTier.test.ts server/__tests__/routes/status.test.ts server/__tests__/routes/health.test.ts server/__tests__/routes/metrics.test.ts server/__tests__/routes/billing.checkout.test.ts server/__tests__/routes/billing.webhook.test.ts` — 88 passed
- `npx eslint server/index.ts server/__tests__/routes/publicDataTier.test.ts` — passed
- `npm run build:server` — passed

No auto-merge requested. This remains a draft until exact-head CI and distinct peer acceptance are recorded.