### PR TITLE
fix: align API key name storage contract

### DIFF
--- a/database/migrations/025_api_key_name_width.sql
+++ b/database/migrations/025_api_key_name_width.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- Migration 025: Align API-key names with the public validation contract
+--
+-- The API accepts names up to 120 characters (server/routes/apiKeys.ts), while
+-- migration 004 created api_keys.name as VARCHAR(100). Migration 023 evolved
+-- the same table but did not widen that column, so otherwise-valid requests
+-- between 101 and 120 characters failed at the database boundary.
+--
+-- This is a new forward migration rather than an edit to 023: deployed
+-- databases may already have recorded 023 and would never replay it.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE api_keys ALTER COLUMN name TYPE VARCHAR(120);
+
+COMMENT ON COLUMN api_keys.name IS
+    'Operator-visible key name; bounded to the API contract maximum of 120 characters.';
+
+COMMIT;

--- a/database/migrations/025_down.sql
+++ b/database/migrations/025_down.sql
@@ -1,0 +1,13 @@
+-- 025_down.sql
+--
+-- Reverses migration 025. Names longer than the migration-004 limit are
+-- truncated deliberately so the rollback cannot fail midway.
+
+BEGIN;
+
+ALTER TABLE api_keys
+    ALTER COLUMN name TYPE VARCHAR(100) USING left(name, 100);
+
+COMMENT ON COLUMN api_keys.name IS NULL;
+
+COMMIT;

--- a/server/__tests__/database/migration025.test.ts
+++ b/server/__tests__/database/migration025.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+function readMigration(filename: string): string {
+  const path = fileURLToPath(new URL(`../../../database/migrations/${filename}`, import.meta.url))
+  return readFileSync(path, 'utf8')
+}
+
+describe('migration 025 API-key name width', () => {
+  it('widens the deployed column to the route contract maximum', () => {
+    const sql = readMigration('025_api_key_name_width.sql')
+
+    expect(sql).toMatch(/ALTER\s+TABLE\s+api_keys\s+ALTER\s+COLUMN\s+name\s+TYPE\s+VARCHAR\(120\)/i)
+  })
+
+  it('has an explicit bounded rollback to the prior width', () => {
+    const sql = readMigration('025_down.sql')
+
+    expect(sql).toMatch(
+      /ALTER\s+COLUMN\s+name\s+TYPE\s+VARCHAR\(100\)\s+USING\s+left\(name,\s*100\)/i
+    )
+  })
+})


### PR DESCRIPTION
## Recovery remedy

Repairs the unresolved finding from #351: the API accepts 120-character key names, while the deployed schema retained migration 004’s 100-character column.

Original discussion: https://github.com/organvm/public-record-data-scrapper/pull/351#discussion_r3597674697

This uses a new migration rather than editing already-recorded migration 023. The rollback is explicit and bounded.

## Verification

- `npx vitest run --config vitest.config.server.ts server/__tests__/database/migration025.test.ts server/__tests__/routes/apiKeys.test.ts server/__tests__/services/ApiKeyService.test.ts` — 26 passed
- `npx eslint server/__tests__/database/migration025.test.ts` — passed
- `npm run build:server` — passed

No auto-merge requested. This remains a draft until exact-head CI and distinct peer acceptance are recorded.