### PR TITLE
fix(api): tier-gate the lead export route to list-parity caps

### DIFF
--- a/server/__tests__/routes/leadExport.test.ts
+++ b/server/__tests__/routes/leadExport.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import request from 'supertest'
+import express from 'express'
 import { createTestApp, createAuthHeader } from '../helpers/testApp'
+import { authMiddleware } from '../../middleware/authMiddleware'
+import { dataTierRouter } from '../../middleware/dataTier'
+import prospectsRouter from '../../routes/prospects'
+import { errorHandler } from '../../middleware/errorHandler'
 import type { Express } from 'express'
 
 const { mockExportLeads, mockSerializeLeadExportCsv } = vi.hoisted(() => ({
@@ -115,5 +120,85 @@ describe('Lead export API', () => {
     const response = await request(app).get('/api/prospects/export/leads')
 
     expect(response.status).toBe(401)
+  })
+})
+
+// Tier gating through the REAL auth → dataTier chain (production mount order,
+// per #353): a verified `tier` claim resolves without any DB lookup, so these
+// tests exercise genuine server-side tier resolution, not a mocked accessor.
+describe('Lead export tier gating', () => {
+  let app: Express
+
+  function createTieredApp(): Express {
+    const tiered = express()
+    tiered.use(express.json())
+    tiered.use('/api/prospects', authMiddleware, dataTierRouter, prospectsRouter)
+    tiered.use(errorHandler)
+    return tiered
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createTieredApp()
+  })
+
+  it('free-tier: floors min_score to 70 and caps limit at the list parity cap', async () => {
+    mockExportLeads.mockResolvedValueOnce(leadExportBatch())
+    const freeAuth = createAuthHeader('free-user', { orgId: 'free-org', tier: 'free' })
+
+    const response = await request(app)
+      .get('/api/prospects/export/leads?min_score=0&limit=500')
+      .set('Authorization', freeAuth)
+
+    expect(response.status).toBe(200)
+    expect(mockExportLeads).toHaveBeenCalledWith(
+      expect.objectContaining({ minScore: 70, limit: 20 })
+    )
+  })
+
+  it('free-tier: respects a caller min_score already above the floor', async () => {
+    mockExportLeads.mockResolvedValueOnce(leadExportBatch())
+    const freeAuth = createAuthHeader('free-user', { orgId: 'free-org', tier: 'free' })
+
+    const response = await request(app)
+      .get('/api/prospects/export/leads?min_score=85')
+      .set('Authorization', freeAuth)
+
+    expect(response.status).toBe(200)
+    expect(mockExportLeads).toHaveBeenCalledWith(
+      expect.objectContaining({ minScore: 85, limit: 20 })
+    )
+  })
+
+  it('starter-tier: passes an explicit min_score=0 and full limit through unchanged', async () => {
+    mockExportLeads.mockResolvedValueOnce(leadExportBatch())
+    const paidAuth = createAuthHeader('pro-user', { orgId: 'pro-org', tier: 'professional' })
+
+    const response = await request(app)
+      .get('/api/prospects/export/leads?min_score=0&limit=1000')
+      .set('Authorization', paidAuth)
+
+    expect(response.status).toBe(200)
+    expect(mockExportLeads).toHaveBeenCalledWith(
+      expect.objectContaining({ minScore: 0, limit: 1000 })
+    )
+  })
+
+  it('fails closed to free-tier when the chain omits dataTierRouter', async () => {
+    mockExportLeads.mockResolvedValueOnce(leadExportBatch())
+    const bare = express()
+    bare.use(express.json())
+    bare.use('/api/prospects', authMiddleware, prospectsRouter)
+    bare.use(errorHandler)
+    const paidAuth = createAuthHeader('pro-user', { orgId: 'pro-org', tier: 'professional' })
+
+    const response = await request(bare)
+      .get('/api/prospects/export/leads?min_score=0&limit=1000')
+      .set('Authorization', paidAuth)
+
+    expect(response.status).toBe(200)
+    expect(mockExportLeads).toHaveBeenCalledWith(
+      expect.objectContaining({ minScore: 70, limit: 20 })
+    )
   })
 })

--- a/server/routes/prospects.ts
+++ b/server/routes/prospects.ts
@@ -216,6 +216,31 @@ function applyProspectTierConstraints(
   }
 }
 
+// Export caps are deliberately asymmetric with the list caps: free tier must
+// never export more rows than it can list (teaser parity), while paid tiers
+// may pull the full feed batch the export schema already allows.
+const EXPORT_TIER_LIMITS: Record<ResolvedDataTier, number> = {
+  'free-tier': PROSPECT_TIER_LIMITS['free-tier'],
+  'starter-tier': 1000
+}
+
+function applyExportTierConstraints(
+  query: LeadExportQuery,
+  dataTier: ResolvedDataTier
+): LeadExportQuery {
+  const limit = Math.min(query.limit, EXPORT_TIER_LIMITS[dataTier])
+
+  if (dataTier !== 'free-tier') {
+    return { ...query, limit }
+  }
+
+  return {
+    ...query,
+    limit,
+    min_score: Math.max(query.min_score, FREE_TIER_MIN_SCORE)
+  }
+}
+
 // GET /api/prospects - List prospects (paginated, filtered, sorted)
 router.get(
   '/',
@@ -278,7 +303,10 @@ router.get(
   '/export/leads',
   validateRequest({ query: exportQuerySchema }),
   asyncHandler(async (req, res) => {
-    const query = req.query as LeadExportQuery
+    const query = applyExportTierConstraints(
+      req.query as LeadExportQuery,
+      getResolvedDataTier(req)
+    )
     const exportService = new LeadExportService()
     const batch = await exportService.exportLeads({
       state: query.state,


### PR DESCRIPTION
## Problem

`GET /api/prospects/export/leads` — the lead-feed deliverable — had **no tier gating**, while the list endpoint caps free-tier at 20 rows with a min-score floor of 70. A free-tier caller could export up to 1000 full rows (with `min_score=0`) that the list surface would never show.

## Fix

- `EXPORT_TIER_LIMITS`: free-tier = list parity (20, derived from `PROSPECT_TIER_LIMITS`), starter-tier = the export schema's existing 1000 max.
- `applyExportTierConstraints()` parallels `applyProspectTierConstraints()`: free-tier floors `min_score` to 70 and caps limit; paid tiers pass `min_score` through unchanged (an explicit `min_score=0` keeps working for full-batch pulls).
- Wired via the already-imported `getResolvedDataTier(req)` — no middleware/mount changes.

## Verification

- `npx vitest run --config vitest.config.server.ts server/__tests__/routes/leadExport.test.ts server/__tests__/routes/prospects.test.ts server/__tests__/middleware/dataTier.test.ts` — **51 passed (3 files)**
- New tests go through the **real** `authMiddleware → dataTierRouter` chain (verified `tier` claim path — no DB), incl. a fail-closed case when `dataTierRouter` is absent from the chain.
- `npx eslint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)