### PR TITLE
feat(underwriting): bank-statement pattern analyzer walking skeleton

### DIFF
--- a/samples/bank-statement-sample.json
+++ b/samples/bank-statement-sample.json
@@ -1,0 +1,944 @@
+{
+  "_note": "SYNTHETIC sample statement (labeled, zero PII) — a ready-to-POST body for /api/underwriting/analyze-statement. Two stacked MCA positions (daily FORWARD FINANCING, weekly KAPITUS), 4 NSF events, mixed regular/lumpy deposits over ~90 days. Sign convention: positive=debit, negative=deposit.",
+  "transactions": [
+    {
+      "date": "2026-04-20",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 17500
+    },
+    {
+      "date": "2026-04-20",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 16300
+    },
+    {
+      "date": "2026-04-21",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 15800
+    },
+    {
+      "date": "2026-04-21",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -11200,
+      "running_balance": 27000
+    },
+    {
+      "date": "2026-04-22",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 26500
+    },
+    {
+      "date": "2026-04-22",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 9200,
+      "running_balance": 17300
+    },
+    {
+      "date": "2026-04-23",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 16800
+    },
+    {
+      "date": "2026-04-23",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8400,
+      "running_balance": 25200
+    },
+    {
+      "date": "2026-04-24",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 24700
+    },
+    {
+      "date": "2026-04-24",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 12300,
+      "running_balance": 12400
+    },
+    {
+      "date": "2026-04-24",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 5200,
+      "running_balance": 7200
+    },
+    {
+      "date": "2026-04-27",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 6700
+    },
+    {
+      "date": "2026-04-27",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 5500
+    },
+    {
+      "date": "2026-04-27",
+      "description": "FPL ELECTRIC UTILITY",
+      "amount": 465.2,
+      "running_balance": 5034.8
+    },
+    {
+      "date": "2026-04-28",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 4534.8
+    },
+    {
+      "date": "2026-04-28",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -14750,
+      "running_balance": 19284.8
+    },
+    {
+      "date": "2026-04-29",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 18784.8
+    },
+    {
+      "date": "2026-04-29",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8400,
+      "running_balance": 10384.8
+    },
+    {
+      "date": "2026-04-29",
+      "description": "NSF FEE INSUFFICIENT FUNDS",
+      "amount": 35,
+      "running_balance": 10349.8
+    },
+    {
+      "date": "2026-04-30",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 9849.8
+    },
+    {
+      "date": "2026-04-30",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -9300,
+      "running_balance": 19149.8
+    },
+    {
+      "date": "2026-05-01",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 18649.8
+    },
+    {
+      "date": "2026-05-01",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -12800,
+      "running_balance": 31449.8
+    },
+    {
+      "date": "2026-05-01",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 11100,
+      "running_balance": 20349.8
+    },
+    {
+      "date": "2026-05-01",
+      "description": "COMMERCIAL RENT LLC",
+      "amount": 5800,
+      "running_balance": 14549.8
+    },
+    {
+      "date": "2026-05-04",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 14049.8
+    },
+    {
+      "date": "2026-05-04",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 12849.8
+    },
+    {
+      "date": "2026-05-05",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 12349.8
+    },
+    {
+      "date": "2026-05-05",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -10150,
+      "running_balance": 22499.8
+    },
+    {
+      "date": "2026-05-05",
+      "description": "OFFICE DEPOT SUPPLIES",
+      "amount": 210.4,
+      "running_balance": 22289.4
+    },
+    {
+      "date": "2026-05-06",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 21789.4
+    },
+    {
+      "date": "2026-05-06",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 10300,
+      "running_balance": 11489.4
+    },
+    {
+      "date": "2026-05-07",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 10989.4
+    },
+    {
+      "date": "2026-05-07",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -13400,
+      "running_balance": 24389.4
+    },
+    {
+      "date": "2026-05-08",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 23889.4
+    },
+    {
+      "date": "2026-05-08",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 13200,
+      "running_balance": 10689.4
+    },
+    {
+      "date": "2026-05-08",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 6850,
+      "running_balance": 3839.4
+    },
+    {
+      "date": "2026-05-11",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 3339.4
+    },
+    {
+      "date": "2026-05-11",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 2139.4
+    },
+    {
+      "date": "2026-05-12",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 1639.4
+    },
+    {
+      "date": "2026-05-12",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8900,
+      "running_balance": 10539.4
+    },
+    {
+      "date": "2026-05-13",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 10039.4
+    },
+    {
+      "date": "2026-05-13",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8800,
+      "running_balance": 1239.4
+    },
+    {
+      "date": "2026-05-14",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 739.4
+    },
+    {
+      "date": "2026-05-14",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -11200,
+      "running_balance": 11939.4
+    },
+    {
+      "date": "2026-05-15",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 11439.4
+    },
+    {
+      "date": "2026-05-15",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8400,
+      "running_balance": 19839.4
+    },
+    {
+      "date": "2026-05-15",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 9200,
+      "running_balance": 10639.4
+    },
+    {
+      "date": "2026-05-15",
+      "description": "INSURANCE REIMBURSEMENT",
+      "amount": -22000,
+      "running_balance": 32639.4
+    },
+    {
+      "date": "2026-05-18",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 32139.4
+    },
+    {
+      "date": "2026-05-18",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 30939.4
+    },
+    {
+      "date": "2026-05-19",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 30439.4
+    },
+    {
+      "date": "2026-05-19",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -14750,
+      "running_balance": 45189.4
+    },
+    {
+      "date": "2026-05-20",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 44689.4
+    },
+    {
+      "date": "2026-05-20",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 12300,
+      "running_balance": 32389.4
+    },
+    {
+      "date": "2026-05-21",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 31889.4
+    },
+    {
+      "date": "2026-05-21",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -9300,
+      "running_balance": 41189.4
+    },
+    {
+      "date": "2026-05-21",
+      "description": "NSF FEE INSUFFICIENT FUNDS",
+      "amount": 35,
+      "running_balance": 41154.4
+    },
+    {
+      "date": "2026-05-22",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 40654.4
+    },
+    {
+      "date": "2026-05-22",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8400,
+      "running_balance": 32254.4
+    },
+    {
+      "date": "2026-05-22",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 7400,
+      "running_balance": 24854.4
+    },
+    {
+      "date": "2026-05-25",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 24354.4
+    },
+    {
+      "date": "2026-05-25",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 23154.4
+    },
+    {
+      "date": "2026-05-26",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 22654.4
+    },
+    {
+      "date": "2026-05-26",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -12800,
+      "running_balance": 35454.4
+    },
+    {
+      "date": "2026-05-26",
+      "description": "OFFICE DEPOT SUPPLIES",
+      "amount": 385.75,
+      "running_balance": 35068.65
+    },
+    {
+      "date": "2026-05-27",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 34568.65
+    },
+    {
+      "date": "2026-05-27",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 11100,
+      "running_balance": 23468.65
+    },
+    {
+      "date": "2026-05-27",
+      "description": "FPL ELECTRIC UTILITY",
+      "amount": 465.2,
+      "running_balance": 23003.45
+    },
+    {
+      "date": "2026-05-28",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 22503.45
+    },
+    {
+      "date": "2026-05-28",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -10150,
+      "running_balance": 32653.45
+    },
+    {
+      "date": "2026-05-29",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 32153.45
+    },
+    {
+      "date": "2026-05-29",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -13400,
+      "running_balance": 45553.45
+    },
+    {
+      "date": "2026-05-29",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 10300,
+      "running_balance": 35253.45
+    },
+    {
+      "date": "2026-06-01",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 34753.45
+    },
+    {
+      "date": "2026-06-01",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 33553.45
+    },
+    {
+      "date": "2026-06-01",
+      "description": "COMMERCIAL RENT LLC",
+      "amount": 5800,
+      "running_balance": 27753.45
+    },
+    {
+      "date": "2026-06-02",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 27253.45
+    },
+    {
+      "date": "2026-06-02",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8900,
+      "running_balance": 36153.45
+    },
+    {
+      "date": "2026-06-03",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 35653.45
+    },
+    {
+      "date": "2026-06-03",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 13200,
+      "running_balance": 22453.45
+    },
+    {
+      "date": "2026-06-04",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 21953.45
+    },
+    {
+      "date": "2026-06-04",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -11200,
+      "running_balance": 33153.45
+    },
+    {
+      "date": "2026-06-05",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 32653.45
+    },
+    {
+      "date": "2026-06-05",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8800,
+      "running_balance": 23853.45
+    },
+    {
+      "date": "2026-06-05",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 5900,
+      "running_balance": 17953.45
+    },
+    {
+      "date": "2026-06-08",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 17453.45
+    },
+    {
+      "date": "2026-06-08",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 16253.45
+    },
+    {
+      "date": "2026-06-09",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 15753.45
+    },
+    {
+      "date": "2026-06-09",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8400,
+      "running_balance": 24153.45
+    },
+    {
+      "date": "2026-06-10",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 23653.45
+    },
+    {
+      "date": "2026-06-10",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 9200,
+      "running_balance": 14453.45
+    },
+    {
+      "date": "2026-06-11",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 13953.45
+    },
+    {
+      "date": "2026-06-11",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -14750,
+      "running_balance": 28703.45
+    },
+    {
+      "date": "2026-06-12",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 28203.45
+    },
+    {
+      "date": "2026-06-12",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -9300,
+      "running_balance": 37503.45
+    },
+    {
+      "date": "2026-06-12",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 12300,
+      "running_balance": 25203.45
+    },
+    {
+      "date": "2026-06-12",
+      "description": "INSURANCE REIMBURSEMENT",
+      "amount": -22000,
+      "running_balance": 47203.45
+    },
+    {
+      "date": "2026-06-15",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 46703.45
+    },
+    {
+      "date": "2026-06-15",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 45503.45
+    },
+    {
+      "date": "2026-06-16",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 45003.45
+    },
+    {
+      "date": "2026-06-16",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -12800,
+      "running_balance": 57803.45
+    },
+    {
+      "date": "2026-06-16",
+      "description": "OFFICE DEPOT SUPPLIES",
+      "amount": 149.99,
+      "running_balance": 57653.46
+    },
+    {
+      "date": "2026-06-17",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 57153.46
+    },
+    {
+      "date": "2026-06-17",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8400,
+      "running_balance": 48753.46
+    },
+    {
+      "date": "2026-06-17",
+      "description": "NSF FEE INSUFFICIENT FUNDS",
+      "amount": 35,
+      "running_balance": 48718.46
+    },
+    {
+      "date": "2026-06-18",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 48218.46
+    },
+    {
+      "date": "2026-06-18",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -10150,
+      "running_balance": 58368.46
+    },
+    {
+      "date": "2026-06-19",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 57868.46
+    },
+    {
+      "date": "2026-06-19",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 11100,
+      "running_balance": 46768.46
+    },
+    {
+      "date": "2026-06-19",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 6300,
+      "running_balance": 40468.46
+    },
+    {
+      "date": "2026-06-22",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 39968.46
+    },
+    {
+      "date": "2026-06-22",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 38768.46
+    },
+    {
+      "date": "2026-06-23",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 38268.46
+    },
+    {
+      "date": "2026-06-23",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -13400,
+      "running_balance": 51668.46
+    },
+    {
+      "date": "2026-06-24",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 51168.46
+    },
+    {
+      "date": "2026-06-24",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 10300,
+      "running_balance": 40868.46
+    },
+    {
+      "date": "2026-06-25",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 40368.46
+    },
+    {
+      "date": "2026-06-25",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8900,
+      "running_balance": 49268.46
+    },
+    {
+      "date": "2026-06-26",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 48768.46
+    },
+    {
+      "date": "2026-06-26",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -11200,
+      "running_balance": 59968.46
+    },
+    {
+      "date": "2026-06-26",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 13200,
+      "running_balance": 46768.46
+    },
+    {
+      "date": "2026-06-26",
+      "description": "FPL ELECTRIC UTILITY",
+      "amount": 465.2,
+      "running_balance": 46303.26
+    },
+    {
+      "date": "2026-06-29",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 45803.26
+    },
+    {
+      "date": "2026-06-29",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 44603.26
+    },
+    {
+      "date": "2026-06-30",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 44103.26
+    },
+    {
+      "date": "2026-06-30",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8400,
+      "running_balance": 52503.26
+    },
+    {
+      "date": "2026-07-01",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 52003.26
+    },
+    {
+      "date": "2026-07-01",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8800,
+      "running_balance": 43203.26
+    },
+    {
+      "date": "2026-07-01",
+      "description": "COMMERCIAL RENT LLC",
+      "amount": 5800,
+      "running_balance": 37403.26
+    },
+    {
+      "date": "2026-07-02",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 36903.26
+    },
+    {
+      "date": "2026-07-02",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -14750,
+      "running_balance": 51653.26
+    },
+    {
+      "date": "2026-07-03",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 51153.26
+    },
+    {
+      "date": "2026-07-03",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 9200,
+      "running_balance": 41953.26
+    },
+    {
+      "date": "2026-07-03",
+      "description": "GUSTO PAYROLL RUN",
+      "amount": 5200,
+      "running_balance": 36753.26
+    },
+    {
+      "date": "2026-07-06",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 36253.26
+    },
+    {
+      "date": "2026-07-06",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 35053.26
+    },
+    {
+      "date": "2026-07-07",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 34553.26
+    },
+    {
+      "date": "2026-07-07",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -9300,
+      "running_balance": 43853.26
+    },
+    {
+      "date": "2026-07-07",
+      "description": "OFFICE DEPOT SUPPLIES",
+      "amount": 512.3,
+      "running_balance": 43340.96
+    },
+    {
+      "date": "2026-07-08",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 42840.96
+    },
+    {
+      "date": "2026-07-08",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 12300,
+      "running_balance": 30540.96
+    },
+    {
+      "date": "2026-07-08",
+      "description": "NSF FEE INSUFFICIENT FUNDS",
+      "amount": 35,
+      "running_balance": 30505.96
+    },
+    {
+      "date": "2026-07-09",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 30005.96
+    },
+    {
+      "date": "2026-07-09",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -12800,
+      "running_balance": 42805.96
+    },
+    {
+      "date": "2026-07-10",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 42305.96
+    },
+    {
+      "date": "2026-07-10",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -10150,
+      "running_balance": 52455.96
+    },
+    {
+      "date": "2026-07-10",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 8400,
+      "running_balance": 44055.96
+    },
+    {
+      "date": "2026-07-13",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 43555.96
+    },
+    {
+      "date": "2026-07-13",
+      "description": "KAPITUS FUNDING PMT",
+      "amount": 1200,
+      "running_balance": 42355.96
+    },
+    {
+      "date": "2026-07-14",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 41855.96
+    },
+    {
+      "date": "2026-07-14",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -13400,
+      "running_balance": 55255.96
+    },
+    {
+      "date": "2026-07-15",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 54755.96
+    },
+    {
+      "date": "2026-07-15",
+      "description": "SYSCO FOOD SUPPLIER PAYMENT",
+      "amount": 11100,
+      "running_balance": 43655.96
+    },
+    {
+      "date": "2026-07-16",
+      "description": "FORWARD FINANCING ACH DEBIT",
+      "amount": 500,
+      "running_balance": 43155.96
+    },
+    {
+      "date": "2026-07-16",
+      "description": "CUSTOMER PAYMENT ACH",
+      "amount": -8900,
+      "running_balance": 52055.96
+    }
+  ],
+  "time_in_business_months": 30,
+  "industry": "restaurant",
+  "state": "FL"
+}

--- a/server/__tests__/routes/underwriting.test.ts
+++ b/server/__tests__/routes/underwriting.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import express, { type Express } from 'express'
+
+// Mock the database: QualificationService's prospect lookup misses (empty
+// result) and the tier claim path never reaches the DB — so the REAL analyzer
+// and REAL qualifier run end-to-end here with no infrastructure.
+vi.mock('../../database/connection', () => ({
+  database: {
+    query: vi.fn().mockResolvedValue([])
+  }
+}))
+
+import { createAuthHeader } from '../helpers/testApp'
+import { authMiddleware } from '../../middleware/authMiddleware'
+import { dataTierRouter } from '../../middleware/dataTier'
+import { errorHandler } from '../../middleware/errorHandler'
+import underwritingRouter from '../../routes/underwriting'
+
+function createUnderwritingApp(): Express {
+  const app = express()
+  app.use(express.json())
+  // Production mount order minus orgContext (which needs a live DB pool).
+  app.use('/api/underwriting', authMiddleware, dataTierRouter, underwritingRouter)
+  app.use(errorHandler)
+  return app
+}
+
+/** A minimal statement: daily lender debit + weekly lender debit + deposits. */
+function sampleBody() {
+  const transactions: Array<{
+    date: string
+    description: string
+    amount: number
+    running_balance?: number
+  }> = []
+  const cursor = new Date('2026-06-01T00:00:00Z')
+  let balance = 15000
+  for (let i = 0; i < 28; i++) {
+    const day = cursor.toISOString().slice(0, 10)
+    const weekday = cursor.getUTCDay()
+    if (weekday >= 1 && weekday <= 5) {
+      balance -= 400
+      transactions.push({
+        date: day,
+        description: 'LENDER A ACH DEBIT',
+        amount: 400,
+        running_balance: balance
+      })
+    }
+    if (weekday === 1) {
+      balance -= 900
+      transactions.push({
+        date: day,
+        description: 'LENDER B FUNDING PMT',
+        amount: 900,
+        running_balance: balance
+      })
+    }
+    if (weekday === 2 || weekday === 4) {
+      balance += 6000
+      transactions.push({
+        date: day,
+        description: 'CUSTOMER PAYMENT ACH',
+        amount: -6000,
+        running_balance: balance
+      })
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return { transactions, time_in_business_months: 30, industry: 'restaurant', state: 'fl' }
+}
+
+describe('POST /api/underwriting/analyze-statement', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = createUnderwritingApp()
+  })
+
+  it('requires authentication', async () => {
+    const response = await request(app)
+      .post('/api/underwriting/analyze-statement')
+      .send(sampleBody())
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns a 402 upsell for free-tier callers', async () => {
+    const freeAuth = createAuthHeader('free-user', { orgId: 'free-org', tier: 'free' })
+
+    const response = await request(app)
+      .post('/api/underwriting/analyze-statement')
+      .set('Authorization', freeAuth)
+      .send(sampleBody())
+
+    expect(response.status).toBe(402)
+    expect(response.body.error.code).toBe('TIER_UPGRADE_REQUIRED')
+    expect(response.body.error.details.requiredTier).toBe('starter')
+  })
+
+  it('analyzes a statement end-to-end for a paid tier', async () => {
+    const paidAuth = createAuthHeader('pro-user', { orgId: 'pro-org', tier: 'professional' })
+
+    const response = await request(app)
+      .post('/api/underwriting/analyze-statement')
+      .set('Authorization', paidAuth)
+      .send(sampleBody())
+
+    expect(response.status).toBe(200)
+    expect(response.headers['x-data-tier-resolved']).toBe('starter-tier')
+
+    const { features, qualification, stackingDetected, capacityEstimate } = response.body.data
+    expect(features.estimatedPositionCount).toBe(2)
+    expect(stackingDetected).toBe(true)
+    expect(features.balanceAnchored).toBe(true)
+    expect(features.nsfCount).toBe(0)
+    expect(typeof capacityEstimate).toBe('number')
+    // The real QualificationService ran: a graded verdict with reasons.
+    expect(qualification.tier).toBeDefined()
+    expect(Array.isArray(qualification.reasons)).toBe(true)
+    expect(qualification.reasons.length).toBeGreaterThan(0)
+  })
+
+  it('rejects a body without transactions', async () => {
+    const paidAuth = createAuthHeader('pro-user', { orgId: 'pro-org', tier: 'professional' })
+
+    const response = await request(app)
+      .post('/api/underwriting/analyze-statement')
+      .set('Authorization', paidAuth)
+      .send({ industry: 'restaurant' })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects transactions with a malformed date', async () => {
+    const paidAuth = createAuthHeader('pro-user', { orgId: 'pro-org', tier: 'professional' })
+
+    const response = await request(app)
+      .post('/api/underwriting/analyze-statement')
+      .set('Authorization', paidAuth)
+      .send({
+        transactions: [{ date: '06/01/2026', description: 'DEPOSIT', amount: -100 }]
+      })
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/server/__tests__/services/BankStatementAnalyzer.test.ts
+++ b/server/__tests__/services/BankStatementAnalyzer.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import {
+  BankStatementAnalyzer,
+  type CsvTransaction
+} from '../../services/BankStatementAnalyzer'
+
+const analyzer = new BankStatementAnalyzer()
+
+/** Build a run of weekday debits with a fixed amount and description. */
+function weekdayDebits(
+  description: string,
+  amount: number,
+  startIso: string,
+  count: number
+): CsvTransaction[] {
+  const rows: CsvTransaction[] = []
+  const cursor = new Date(`${startIso}T00:00:00Z`)
+  while (rows.length < count) {
+    const day = cursor.getUTCDay()
+    if (day >= 1 && day <= 5) {
+      rows.push({ date: cursor.toISOString().slice(0, 10), description, amount })
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return rows
+}
+
+/** Weekly (every-7-days) debits. */
+function weeklyDebits(
+  description: string,
+  amount: number,
+  startIso: string,
+  count: number
+): CsvTransaction[] {
+  const rows: CsvTransaction[] = []
+  const cursor = new Date(`${startIso}T00:00:00Z`)
+  for (let i = 0; i < count; i++) {
+    rows.push({ date: cursor.toISOString().slice(0, 10), description, amount })
+    cursor.setUTCDate(cursor.getUTCDate() + 7)
+  }
+  return rows
+}
+
+describe('BankStatementAnalyzer', () => {
+  it('throws on an empty transaction list', () => {
+    expect(() => analyzer.analyze([])).toThrow(/at least one transaction/)
+  })
+
+  it('computes ADB from an anchored running-balance series', () => {
+    // Three consecutive days, balances 100 / 200 / 300 → ADB 200.
+    const result = analyzer.analyze([
+      { date: '2026-06-01', description: 'DEPOSIT A', amount: -100, running_balance: 100 },
+      { date: '2026-06-02', description: 'DEPOSIT B', amount: -100, running_balance: 200 },
+      { date: '2026-06-03', description: 'DEPOSIT C', amount: -100, running_balance: 300 }
+    ])
+
+    expect(result.balanceAnchored).toBe(true)
+    expect(result.averageDailyBalance).toBe(200)
+    expect(result.minimumDailyBalance).toBe(100)
+    expect(result.maximumDailyBalance).toBe(300)
+    expect(result.currentBalance).toBe(300)
+    expect(result.totalDaysAnalyzed).toBe(3)
+  })
+
+  it('counts anchored negative days; reports zero when unanchored', () => {
+    const anchored = analyzer.analyze([
+      { date: '2026-06-01', description: 'VENDOR', amount: 50, running_balance: -25 },
+      { date: '2026-06-02', description: 'DEPOSIT', amount: -100, running_balance: 75 }
+    ])
+    expect(anchored.negativeDays).toBe(1)
+    expect(anchored.negativeDaysPercentage).toBe(50)
+
+    const unanchored = analyzer.analyze([
+      { date: '2026-06-01', description: 'VENDOR', amount: 50 },
+      { date: '2026-06-02', description: 'DEPOSIT', amount: -100 }
+    ])
+    expect(unanchored.balanceAnchored).toBe(false)
+    expect(unanchored.negativeDays).toBe(0)
+    expect(unanchored.negativeDaysPercentage).toBe(0)
+  })
+
+  it('detects NSF events by description keyword', () => {
+    const result = analyzer.analyze([
+      { date: '2026-06-01', description: 'NSF FEE INSUFFICIENT FUNDS', amount: 35 },
+      { date: '2026-06-05', description: 'OVERDRAFT ITEM FEE', amount: 35 },
+      { date: '2026-06-09', description: 'CUSTOMER PAYMENT', amount: -500 }
+    ])
+    expect(result.nsfCount).toBe(2)
+    expect(result.nsfFeeTotal).toBe(70)
+  })
+
+  it('detects a daily fixed debit as one position', () => {
+    const result = analyzer.analyze(weekdayDebits('LENDER A ACH DEBIT', 450, '2026-06-01', 15))
+    expect(result.estimatedPositionCount).toBe(1)
+    expect(result.stackingDetected).toBe(false)
+    expect(result.lenderPayments[0].frequency).toBe('daily')
+    expect(result.lenderPayments[0].lenderName).toBe('LENDER A ACH DEBIT')
+    expect(result.estimatedPaymentObligations).toBe(450)
+  })
+
+  it('detects a concurrent weekly fixed debit as a second position and flags stacking', () => {
+    const rows = [
+      ...weekdayDebits('LENDER A ACH DEBIT', 450, '2026-06-01', 15),
+      ...weeklyDebits('LENDER B FUNDING PMT', 1000, '2026-06-01', 4)
+    ]
+    const result = analyzer.analyze(rows)
+    expect(result.estimatedPositionCount).toBe(2)
+    expect(result.stackingDetected).toBe(true)
+    // Daily 450 + weekly 1000/5 business days = 650/day.
+    expect(result.estimatedPaymentObligations).toBe(650)
+  })
+
+  it('ignores variable-amount recurring debits (payroll is not a position)', () => {
+    const amounts = [5200, 6850, 7400, 5900]
+    const rows = weeklyDebits('GUSTO PAYROLL RUN', 0, '2026-06-01', 4).map((row, i) => ({
+      ...row,
+      amount: amounts[i]
+    }))
+    const result = analyzer.analyze(rows)
+    expect(result.estimatedPositionCount).toBe(0)
+    expect(result.stackingDetected).toBe(false)
+  })
+
+  it('computes capacity as (ADB * 0.5) - daily obligations', () => {
+    const rows = weekdayDebits('LENDER A ACH DEBIT', 450, '2026-06-01', 15).map((row) => ({
+      ...row,
+      running_balance: 10000
+    }))
+    const result = analyzer.analyze(rows)
+    expect(result.averageDailyBalance).toBe(10000)
+    expect(result.capacityEstimate).toBe(10000 * 0.5 - 450)
+  })
+
+  it('reports a stable revenue trend for flat monthly deposits', () => {
+    const rows: CsvTransaction[] = []
+    for (const month of ['04', '05', '06']) {
+      for (const day of ['05', '15', '25']) {
+        rows.push({ date: `2026-${month}-${day}`, description: 'CUSTOMER PAYMENT', amount: -10000 })
+      }
+    }
+    const result = analyzer.analyze(rows)
+    expect(result.revenueTrend.direction).toBe('stable')
+    expect(result.revenueTrend.averageMonthlyRevenue).toBe(30000)
+    expect(result.revenueTrend.monthlyData).toHaveLength(3)
+    expect(result.depositConsistencyScore).toBeGreaterThan(80)
+  })
+
+  it('analyzes the shipped sample statement into the demo narrative', () => {
+    // The committed sample is the demo artifact — bind it to the analyzer so
+    // a drift in either shows up here, not in the room.
+    const sample = JSON.parse(
+      readFileSync(join(__dirname, '../../../samples/bank-statement-sample.json'), 'utf8')
+    ) as { transactions: CsvTransaction[] }
+
+    const result = analyzer.analyze(sample.transactions)
+
+    expect(result.balanceAnchored).toBe(true)
+    expect(result.estimatedPositionCount).toBe(2)
+    expect(result.stackingDetected).toBe(true)
+    const lenders = result.lenderPayments.map((p) => p.lenderName).sort()
+    expect(lenders).toEqual(['FORWARD FINANCING ACH DEBIT', 'KAPITUS FUNDING PMT'])
+    expect(result.lenderPayments.find((p) => p.lenderName.includes('FORWARD'))?.frequency).toBe(
+      'daily'
+    )
+    expect(result.lenderPayments.find((p) => p.lenderName.includes('KAPITUS'))?.frequency).toBe(
+      'weekly'
+    )
+    expect(result.nsfCount).toBe(4)
+    expect(result.averageDailyBalance).toBeGreaterThan(0)
+    expect(result.revenueTrend.monthlyData.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import discoveryRouter from './routes/discovery'
 import metricsRouter from './routes/metrics'
 import agenticRouter from './routes/agentic'
 import scrapeRouter from './routes/scrape'
+import underwritingRouter from './routes/underwriting'
 
 // Import queue infrastructure
 import {
@@ -180,6 +181,7 @@ export class Server {
     this.app.use('/api/compliance', authMiddleware, orgContextMiddleware, dataTierRouter, complianceRouter)
     this.app.use('/api/discovery', authMiddleware, orgContextMiddleware, dataTierRouter, discoveryRouter)
     this.app.use('/api/agentic', authMiddleware, orgContextMiddleware, dataTierRouter, agenticRouter)
+    this.app.use('/api/underwriting', authMiddleware, orgContextMiddleware, dataTierRouter, underwritingRouter)
     // API key management (JWT + admin only - API keys must not be able to mint more keys)
     this.app.use(
       '/api/keys',

--- a/server/routes/underwriting.ts
+++ b/server/routes/underwriting.ts
@@ -1,0 +1,97 @@
+/**
+ * Underwriting routes.
+ *
+ *   POST /api/underwriting/analyze-statement
+ *     Analyze a normalized bank-statement transaction list into the full
+ *     underwriting feature set (BankStatementAnalyzer) and run the existing
+ *     QualificationService over it. Paid-tier surface: free-tier callers get
+ *     a 402 upsell, same contract as the prospect-cap gate.
+ *
+ * Mounted behind authMiddleware + orgContextMiddleware + dataTierRouter
+ * (server/index.ts), so `getResolvedDataTier` reads the server-side resolved
+ * entitlement — never a client-supplied header.
+ *
+ * @module server/routes/underwriting
+ */
+
+import { Router } from 'express'
+import { z } from 'zod'
+import { validateRequest } from '../middleware/validateRequest'
+import { asyncHandler } from '../middleware/errorHandler'
+import { getResolvedDataTier } from '../middleware/dataTier'
+import { BankStatementAnalyzer } from '../services/BankStatementAnalyzer'
+import { QualificationService } from '../services/QualificationService'
+
+const router = Router()
+
+const transactionSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+  description: z.string().min(1).max(200),
+  // Plaid sign convention: positive = debit/withdrawal, negative = deposit.
+  amount: z.number().finite(),
+  running_balance: z.number().finite().optional()
+})
+
+const analyzeStatementSchema = z.object({
+  transactions: z.array(transactionSchema).min(1).max(10000),
+  time_in_business_months: z.number().int().positive().max(600).optional(),
+  industry: z.string().max(100).optional(),
+  state: z
+    .string()
+    .regex(/^[A-Za-z]{2}$/)
+    .transform((v) => v.toUpperCase())
+    .optional()
+})
+
+type AnalyzeStatementBody = z.infer<typeof analyzeStatementSchema>
+
+// POST /api/underwriting/analyze-statement - statement rows in, features +
+// qualification verdict out. Nothing is persisted.
+router.post(
+  '/analyze-statement',
+  validateRequest({ body: analyzeStatementSchema }),
+  asyncHandler(async (req, res) => {
+    if (getResolvedDataTier(req) === 'free-tier') {
+      return res.status(402).json({
+        success: false,
+        error: {
+          message:
+            'Bank-statement analysis is a paid feature. Upgrade to Starter or Pro to run underwriting on statement data.',
+          code: 'TIER_UPGRADE_REQUIRED',
+          statusCode: 402,
+          details: {
+            currentTier: 'free',
+            requiredTier: 'starter',
+            cta: { action: 'upgrade_plan', label: 'Upgrade to Starter', href: '/pricing' }
+          }
+        }
+      })
+    }
+
+    const body = req.body as AnalyzeStatementBody
+
+    const analyzer = new BankStatementAnalyzer()
+    const analysis = analyzer.analyze(body.transactions)
+
+    // Standalone analysis: the synthetic id never matches a prospect row, so
+    // QualificationService falls back to the options provided here.
+    const qualificationService = new QualificationService()
+    const qualification = await qualificationService.qualify('statement-analysis', analysis, {
+      timeInBusinessMonths: body.time_in_business_months,
+      industry: body.industry,
+      state: body.state
+    })
+
+    res.json({
+      success: true,
+      data: {
+        features: analysis,
+        qualification,
+        capacityEstimate: analysis.capacityEstimate,
+        stackingDetected: analysis.stackingDetected
+      }
+    })
+  })
+)
+
+export default router

--- a/server/services/BankStatementAnalyzer.ts
+++ b/server/services/BankStatementAnalyzer.ts
@@ -1,0 +1,414 @@
+/**
+ * Bank-statement pattern analyzer (walking skeleton).
+ *
+ * Computes the same `UnderwritingFeatures` shape the Plaid-backed
+ * `UnderwritingService` extracts — but from a normalized statement-transaction
+ * list (e.g. parsed from a CSV a broker received from a merchant), so
+ * underwriting can start before any bank connection exists. The feature output
+ * plugs straight into the existing `QualificationService`.
+ *
+ * Sign convention matches Plaid (and `UnderwritingService.analyzeTransactions`):
+ * POSITIVE amount = debit/withdrawal, NEGATIVE amount = credit/deposit.
+ *
+ * Thresholds, frequency classification, obligation divisors, trend and
+ * consistency math intentionally mirror `UnderwritingService` so a statement
+ * analysis and a Plaid analysis of the same account agree.
+ *
+ * Skeleton limits (named, honest): input is pre-parsed rows only (no PDF/OCR,
+ * no OFX); recurring-debit detection is description-pattern based, so the
+ * detected `lenderName` is the normalized statement description, not a
+ * verified lender identity — treat positions as leads for human review.
+ *
+ * @module server/services/BankStatementAnalyzer
+ */
+
+import type {
+  UnderwritingFeatures,
+  DetectedLenderPayment,
+  RevenueTrend,
+  MonthlyRevenue
+} from './UnderwritingService'
+
+/** One normalized statement transaction row. */
+export interface CsvTransaction {
+  /** ISO date, YYYY-MM-DD */
+  date: string
+  /** Statement description line */
+  description: string
+  /** Plaid sign convention: positive = debit, negative = deposit */
+  amount: number
+  /** Statement running balance AFTER this transaction, when the export has it */
+  running_balance?: number
+}
+
+/** Analyzer output: the full underwriting feature set + skeleton extras. */
+export interface BankStatementAnalysis extends UnderwritingFeatures {
+  /** True when two or more concurrent daily/weekly fixed-debit positions are detected */
+  stackingDetected: boolean
+  /** Simple headroom estimate: (ADB * 0.5) - estimated daily obligations */
+  capacityEstimate: number
+}
+
+// Mirrors NSF_INDICATORS in server/integrations/plaid/transactions.ts (not
+// exported there); keep the two lists in sync.
+const NSF_DESCRIPTION_KEYWORDS = [
+  'NSF',
+  'OVERDRAFT',
+  'OD FEE',
+  'INSUFFICIENT FUNDS',
+  'RETURNED ITEM',
+  'RETURNED CHECK',
+  'UNCOLLECTED FUNDS'
+]
+
+// A description group must recur at least this often before it can count as a
+// fixed-debit position (fewer repeats cannot establish a daily/weekly cadence).
+const MIN_POSITION_OCCURRENCES = 4
+// Amount coefficient-of-variation ceiling for a "fixed" debit: MCA remittances
+// are near-constant; payroll/supplier runs vary. Matches the "very consistent
+// amounts" band of UnderwritingService.calculateLenderConfidence.
+const FIXED_AMOUNT_CV_MAX = 0.1
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+export class BankStatementAnalyzer {
+  /**
+   * Analyze a normalized statement-transaction list into the underwriting
+   * feature set. Throws on an empty list — no data is not a zero-risk signal.
+   */
+  analyze(transactions: CsvTransaction[]): BankStatementAnalysis {
+    if (transactions.length === 0) {
+      throw new Error('Bank-statement analysis requires at least one transaction')
+    }
+
+    const rows = [...transactions].sort((a, b) => a.date.localeCompare(b.date))
+    const startDate = rows[0].date
+    const endDate = rows[rows.length - 1].date
+    const totalDaysAnalyzed = Math.max(1, daysBetween(startDate, endDate) + 1)
+
+    const balanceAnchored = rows.some((r) => typeof r.running_balance === 'number')
+    const dailyBalances = this.buildDailyBalanceSeries(rows, balanceAnchored)
+
+    const averageDailyBalance = round2(mean(dailyBalances))
+    const minimumDailyBalance = round2(Math.min(...dailyBalances))
+    const maximumDailyBalance = round2(Math.max(...dailyBalances))
+    const currentBalance = round2(dailyBalances[dailyBalances.length - 1])
+
+    // Negative-day metrics are only meaningful when the series is anchored to
+    // a real statement balance (same guard as UnderwritingService).
+    const negativeDays = balanceAnchored ? dailyBalances.filter((b) => b < 0).length : 0
+    const negativeDaysPercentage = balanceAnchored
+      ? round2((negativeDays / dailyBalances.length) * 100)
+      : 0
+
+    const { nsfCount, nsfFeeTotal } = this.detectNsfEvents(rows)
+    const lenderPayments = this.detectRecurringFixedDebits(rows)
+    const { positionCount, totalObligations } = this.estimateObligations(lenderPayments)
+
+    const deposits = rows.filter((r) => r.amount < 0)
+    const totalDeposits = round2(deposits.reduce((sum, r) => sum + Math.abs(r.amount), 0))
+    const monthsSpanned = Math.max(1, totalDaysAnalyzed / 30)
+    const averageMonthlyDeposits = round2(totalDeposits / monthsSpanned)
+    const lastDepositDate = deposits.length > 0 ? deposits[deposits.length - 1].date : null
+    const daysSinceLastDeposit = lastDepositDate
+      ? daysBetween(lastDepositDate, endDate)
+      : totalDaysAnalyzed
+
+    const revenueTrend = this.computeRevenueTrend(deposits)
+    const depositConsistencyScore = this.computeDepositConsistency(deposits)
+
+    const estimatedPaymentObligations = round2(totalObligations)
+    const capacityEstimate = round2(averageDailyBalance * 0.5 - estimatedPaymentObligations)
+
+    return {
+      averageDailyBalance,
+      minimumDailyBalance,
+      maximumDailyBalance,
+      currentBalance,
+      nsfCount,
+      nsfFeeTotal: round2(nsfFeeTotal),
+      negativeDays,
+      negativeDaysPercentage,
+      balanceAnchored,
+      lenderPayments,
+      estimatedPositionCount: positionCount,
+      estimatedPaymentObligations,
+      revenueTrend,
+      averageMonthlyDeposits,
+      totalDeposits,
+      depositConsistencyScore,
+      daysSinceLastDeposit,
+      analysisStartDate: startDate,
+      analysisEndDate: endDate,
+      totalDaysAnalyzed,
+      totalTransactionsAnalyzed: rows.length,
+      primaryAccountId: 'statement-csv',
+      primaryAccountType: 'checking',
+      stackingDetected: positionCount >= 2,
+      capacityEstimate
+    }
+  }
+
+  /**
+   * One balance value per calendar day across the analysis span, carrying the
+   * last known balance forward over quiet days. Anchored mode trusts the
+   * statement's running balance; unanchored mode accumulates flows from an
+   * assumed zero opening balance (relative movement only).
+   */
+  private buildDailyBalanceSeries(rows: CsvTransaction[], anchored: boolean): number[] {
+    const endOfDayBalance = new Map<string, number>()
+
+    if (anchored) {
+      for (const row of rows) {
+        if (typeof row.running_balance === 'number') {
+          endOfDayBalance.set(row.date, row.running_balance)
+        }
+      }
+    } else {
+      let running = 0
+      for (const row of rows) {
+        running -= row.amount // positive amount = debit = balance goes down
+        endOfDayBalance.set(row.date, running)
+      }
+    }
+
+    const series: number[] = []
+    const start = new Date(`${rows[0].date}T00:00:00Z`)
+    const end = new Date(`${rows[rows.length - 1].date}T00:00:00Z`)
+    // Seed with the earliest known balance so leading quiet days (anchored
+    // mode only) carry a real value instead of zero.
+    let last = endOfDayBalance.get(rows[0].date) ?? 0
+    for (let t = start.getTime(); t <= end.getTime(); t += MS_PER_DAY) {
+      const day = new Date(t).toISOString().slice(0, 10)
+      const known = endOfDayBalance.get(day)
+      if (known !== undefined) last = known
+      series.push(last)
+    }
+    return series
+  }
+
+  private detectNsfEvents(rows: CsvTransaction[]): { nsfCount: number; nsfFeeTotal: number } {
+    let nsfCount = 0
+    let nsfFeeTotal = 0
+    for (const row of rows) {
+      const description = row.description.toUpperCase()
+      if (NSF_DESCRIPTION_KEYWORDS.some((keyword) => description.includes(keyword))) {
+        nsfCount++
+        nsfFeeTotal += Math.abs(row.amount)
+      }
+    }
+    return { nsfCount, nsfFeeTotal }
+  }
+
+  /**
+   * Find recurring fixed debits: description groups that repeat at a daily or
+   * weekly cadence with near-constant amounts — the signature of an active
+   * MCA/loan remittance. Bi-weekly/monthly/irregular groups (rent, utilities)
+   * are not counted as positions.
+   */
+  private detectRecurringFixedDebits(rows: CsvTransaction[]): DetectedLenderPayment[] {
+    const groups = new Map<string, CsvTransaction[]>()
+    for (const row of rows) {
+      if (row.amount <= 0) continue // debits only
+      const description = row.description.toUpperCase()
+      if (NSF_DESCRIPTION_KEYWORDS.some((keyword) => description.includes(keyword))) continue
+      const key = description.replace(/\s+/g, ' ').trim()
+      const existing = groups.get(key) ?? []
+      existing.push(row)
+      groups.set(key, existing)
+    }
+
+    const detected: DetectedLenderPayment[] = []
+    for (const [name, payments] of groups) {
+      if (payments.length < MIN_POSITION_OCCURRENCES) continue
+
+      const amounts = payments.map((p) => p.amount)
+      const avgAmount = mean(amounts)
+      if (avgAmount <= 0 || coefficientOfVariation(amounts) > FIXED_AMOUNT_CV_MAX) continue
+
+      const frequency = classifyFrequency(payments.map((p) => p.date))
+      if (frequency !== 'daily' && frequency !== 'weekly') continue
+
+      const latest = payments[payments.length - 1]
+      detected.push({
+        transactionId: `statement:${name}:${latest.date}`,
+        date: latest.date,
+        amount: round2(avgAmount),
+        lenderName: name,
+        frequency,
+        confidence: this.confidenceFor(payments)
+      })
+    }
+    return detected
+  }
+
+  // Same shape as UnderwritingService.calculateLenderConfidence: base 0.5,
+  // bumped by repeat count and amount consistency.
+  private confidenceFor(payments: CsvTransaction[]): number {
+    let score = 0.5
+    if (payments.length >= 20) score += 0.2
+    else if (payments.length >= 10) score += 0.15
+    else if (payments.length >= 5) score += 0.1
+
+    const cv = coefficientOfVariation(payments.map((p) => p.amount))
+    if (cv < 0.1) score += 0.2
+    else if (cv < 0.25) score += 0.1
+
+    return Math.min(1, round2(score))
+  }
+
+  // Daily-equivalent obligations, same divisors as
+  // UnderwritingService.estimatePositions (5 / 10 / 22 business days).
+  private estimateObligations(lenderPayments: DetectedLenderPayment[]): {
+    positionCount: number
+    totalObligations: number
+  } {
+    const positionCount = new Set(lenderPayments.map((p) => p.lenderName)).size
+    let totalObligations = 0
+    for (const payment of lenderPayments) {
+      switch (payment.frequency) {
+        case 'daily':
+          totalObligations += payment.amount
+          break
+        case 'weekly':
+          totalObligations += payment.amount / 5
+          break
+        case 'bi-weekly':
+          totalObligations += payment.amount / 10
+          break
+        default:
+          totalObligations += payment.amount / 22
+      }
+    }
+    return { positionCount, totalObligations }
+  }
+
+  private computeRevenueTrend(deposits: CsvTransaction[]): RevenueTrend {
+    const byMonth = new Map<string, MonthlyRevenue>()
+    for (const deposit of deposits) {
+      const month = deposit.date.substring(0, 7)
+      const entry = byMonth.get(month) ?? {
+        month,
+        totalDeposits: 0,
+        depositCount: 0,
+        averageDeposit: 0,
+        maxDeposit: 0,
+        minDeposit: Infinity
+      }
+      const amount = Math.abs(deposit.amount)
+      entry.totalDeposits += amount
+      entry.depositCount++
+      if (amount > entry.maxDeposit) entry.maxDeposit = amount
+      if (amount < entry.minDeposit) entry.minDeposit = amount
+      byMonth.set(month, entry)
+    }
+
+    const monthlyData = [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month))
+    for (const entry of monthlyData) {
+      entry.averageDeposit = entry.depositCount > 0 ? entry.totalDeposits / entry.depositCount : 0
+      if (entry.minDeposit === Infinity) entry.minDeposit = 0
+    }
+
+    const revenues = monthlyData.map((m) => m.totalDeposits)
+    const averageMonthlyRevenue = revenues.length > 0 ? mean(revenues) : 0
+    const sorted = [...revenues].sort((a, b) => a - b)
+    const medianMonthlyRevenue = sorted.length > 0 ? sorted[Math.floor(sorted.length / 2)] : 0
+
+    const stdDev = Math.sqrt(
+      revenues.length > 1
+        ? revenues.reduce((sum, r) => sum + Math.pow(r - averageMonthlyRevenue, 2), 0) /
+            revenues.length
+        : 0
+    )
+    const seasonalityScore =
+      averageMonthlyRevenue > 0 ? Math.min(100, (stdDev / averageMonthlyRevenue) * 100) : 0
+
+    return {
+      ...this.trendDirection(revenues),
+      averageMonthlyRevenue: round2(averageMonthlyRevenue),
+      medianMonthlyRevenue: round2(medianMonthlyRevenue),
+      seasonalityScore: round2(seasonalityScore),
+      monthlyData
+    }
+  }
+
+  // Same classification bands as UnderwritingService.calculateTrendDirection:
+  // CV > 0.5 volatile, |first→last smoothed change| beyond ±10% directional.
+  private trendDirection(values: number[]): {
+    direction: RevenueTrend['direction']
+    percentageChange: number
+  } {
+    if (values.length < 2) {
+      return { direction: 'stable', percentageChange: 0 }
+    }
+
+    const firstAvg = (values[0] + values[1] + (values[2] ?? values[1])) / 3
+    const lastIdx = values.length - 1
+    const lastAvg =
+      (values[lastIdx] + values[lastIdx - 1] + (values[lastIdx - 2] ?? values[lastIdx - 1])) / 3
+    const percentageChange = firstAvg > 0 ? ((lastAvg - firstAvg) / firstAvg) * 100 : 0
+
+    const cv = coefficientOfVariation(values)
+    let direction: RevenueTrend['direction']
+    if (cv > 0.5) direction = 'volatile'
+    else if (percentageChange > 10) direction = 'increasing'
+    else if (percentageChange < -10) direction = 'decreasing'
+    else direction = 'stable'
+
+    return { direction, percentageChange: round2(percentageChange) }
+  }
+
+  // Interval + amount CV scoring, 60/40 weighted — mirrors
+  // UnderwritingService.calculateDepositConsistency.
+  private computeDepositConsistency(deposits: CsvTransaction[]): number {
+    if (deposits.length < 2) return 0
+
+    const intervals: number[] = []
+    for (let i = 1; i < deposits.length; i++) {
+      intervals.push(daysBetween(deposits[i - 1].date, deposits[i].date))
+    }
+    const intervalCv = intervals.length > 0 ? coefficientOfVariation(intervals) : 1
+    const amountCv = coefficientOfVariation(deposits.map((d) => Math.abs(d.amount)))
+
+    const intervalScore = Math.max(0, Math.min(100, 100 - intervalCv * 50))
+    const amountScore = Math.max(0, Math.min(100, 100 - amountCv * 50))
+    return Math.round(intervalScore * 0.6 + amountScore * 0.4)
+  }
+}
+
+function classifyFrequency(sortedDates: string[]): DetectedLenderPayment['frequency'] {
+  if (sortedDates.length < 2) return 'irregular'
+  const intervals: number[] = []
+  for (let i = 1; i < sortedDates.length; i++) {
+    intervals.push(daysBetween(sortedDates[i - 1], sortedDates[i]))
+  }
+  const avg = mean(intervals)
+  if (avg <= 2) return 'daily'
+  if (avg <= 8) return 'weekly'
+  if (avg <= 16) return 'bi-weekly'
+  if (avg <= 35) return 'monthly'
+  return 'irregular'
+}
+
+function daysBetween(fromDate: string, toDate: string): number {
+  return Math.round(
+    (new Date(`${toDate}T00:00:00Z`).getTime() - new Date(`${fromDate}T00:00:00Z`).getTime()) /
+      MS_PER_DAY
+  )
+}
+
+function mean(values: number[]): number {
+  return values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 0
+}
+
+function coefficientOfVariation(values: number[]): number {
+  if (values.length === 0) return 1
+  const avg = mean(values)
+  if (avg === 0) return 1
+  const variance = values.reduce((sum, v) => sum + Math.pow(v - avg, 2), 0) / values.length
+  return Math.sqrt(variance) / Math.abs(avg)
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}


### PR DESCRIPTION
## What

The P1 roadmap item from the evolution plan (bank-statement pattern analyzer), shipped as a walking skeleton that reuses the existing underwriting stack instead of duplicating it:

- **`server/services/BankStatementAnalyzer.ts`** — pure service: normalized statement rows (`date, description, amount, running_balance?`, Plaid sign convention) → the full `UnderwritingFeatures` shape `QualificationService` already consumes. ADB + negative-day metrics honor `balanceAnchored` semantics; NSF keyword detection mirrors the Plaid transaction manager; recurring **fixed-debit position detection** (daily/weekly cadence, amount CV ≤ 0.1) yields `estimatedPositionCount`, a `stackingDetected` flag, and daily-equivalent `estimatedPaymentObligations` with the same divisors as `UnderwritingService.estimatePositions`; plus a simple `capacityEstimate = ADB*0.5 − obligations`.
- **`POST /api/underwriting/analyze-statement`** — protected mount (`authMiddleware → orgContextMiddleware → dataTierRouter`); free-tier gets the standard 402 `TIER_UPGRADE_REQUIRED` upsell; paid tiers get `{features, qualification, capacityEstimate, stackingDetected}` from the **existing** `QualificationService`. Nothing is persisted.
- **`samples/bank-statement-sample.json`** — clearly-synthetic 90-day statement as a ready-to-POST request body (daily FORWARD FINANCING + weekly KAPITUS remittances = 2 stacked positions, 4 NSF events, mixed regular/lumpy deposits, running balance). A regression test binds the committed sample to the analyzer output.

Named skeleton limits (module doc): pre-parsed rows only — no PDF/OCR/OFX; lender identity is the normalized description, positions are leads for human review.

## Verification

- `npx vitest run --config vitest.config.server.ts server/__tests__/services/BankStatementAnalyzer.test.ts server/__tests__/routes/underwriting.test.ts` — **15 passed (2 files)**; the route test runs the REAL `authMiddleware → dataTierRouter` chain and the REAL analyzer + qualifier (only the DB mocked).
- `npx eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)