### PR TITLE
docs(samples): redact exact scoring weights + cutoffs from public sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -65,14 +65,16 @@ fields and adds nested objects:
 
 ## Scoring
 
-The sample follows the platform scoring service weights:
+Each `priority_score` is a 0–100 composite of three proprietary sub-scores — **intent**,
+**health**, and **position** — combined under a proprietary weighting and adjusted by
+industry and state risk modifiers, then bucketed into an A–F grade and an outreach
+recommendation.
 
-`priority_score = round((intent_score * 0.40 + health_score * 0.35 + position_score * 0.25) * industry_modifier * state_modifier)`
+- **Intent** captures UCC filing recency, filing volume, active/lapsed/terminated pattern, and recent trend.
+- **Health** captures synthetic review/sentiment/violation proxies.
+- **Position** captures active UCC count, known MCA positions, and estimated payment burden.
 
-Intent captures UCC filing recency, filing volume, active/lapsed/terminated pattern, and recent trend.
-Health captures synthetic review/sentiment/violation proxies. Position captures active UCC count,
-known MCA positions, and estimated payment burden.
-
-Grades use these thresholds: A = 80-100, B = 65-79, C = 50-64, D = 35-49, F = 0-34.
-Recommendations use these thresholds: high priority at 75+ with confidence at 60+, moderate at 55+,
-low at 40+, and pass below 40.
+The exact sub-score weights, modifier tables, and grade/recommendation cutoffs are part of the
+platform's calibrated scoring engine and are not published. The sample values above are produced
+by that engine so the output *shape* is faithful; the calibration behind them is what the product
+delivers.

--- a/samples/scored-mca-leads-sample.json
+++ b/samples/scored-mca-leads-sample.json
@@ -10,20 +10,9 @@
   },
   "scoring_model": {
     "score_range": "0-100",
-    "composite_formula": "round((intent_score * 0.40 + health_score * 0.35 + position_score * 0.25) * industry_modifier * state_modifier)",
-    "grade_thresholds": {
-      "A": "80-100",
-      "B": "65-79",
-      "C": "50-64",
-      "D": "35-49",
-      "F": "0-34"
-    },
-    "recommendation_thresholds": {
-      "high_priority": "priority_score >= 75 and confidence >= 60",
-      "moderate_priority": "priority_score >= 55",
-      "low_priority": "priority_score >= 40",
-      "pass": "priority_score < 40"
-    },
+    "composite": "Proprietary weighted blend of the intent, health, and position sub-scores, adjusted by industry and state risk modifiers. Exact weights, modifier tables, and grade/recommendation cutoffs are part of the platform's calibrated scoring engine and are not published; these sample values are produced by that engine so the output shape is faithful.",
+    "grades": "A-F buckets over the 0-100 composite (A strongest).",
+    "recommendations": "Outreach priority tiers (high / moderate / low / pass) derived from the composite score and confidence.",
     "factors": {
       "intent_score": "UCC recency, volume, active/lapsed/terminated pattern, and recent filing trend.",
       "health_score": "Synthetic business health indicators such as review volume, sentiment trend, and violations.",


### PR DESCRIPTION
## Problem

`samples/README.md` and `samples/scored-mca-leads-sample.json` published the **real** scoring calibration in plain text: the composite formula with the exact intent/health/position weights, the A–F grade cutoffs, and the recommendation thresholds. That is the tuned scoring engine's proprietary IP sitting in a public file — readable by anyone who clones the repo.

## Fix

Redact both to a faithful description of the model's **shape** — three proprietary sub-scores (intent / health / position), industry + state risk modifiers, an A–F composite grade, and priority tiers — without any of the numbers. The synthetic sample rows are untouched; they stay a clean, sellable demo artifact whose output shape is genuinely produced by the calibrated engine.

No code references the redacted JSON keys (verified). Docs/samples-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)