### PR TITLE
feat(calibration): injectable seam for the curated funder dictionary (moat)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ src-tauri/bindings/
 !/server/
 # VSCode Local History extension
 .lh/
+
+# Private scoring calibration (funder intel, source-map, credit-box tuning) — the moat.
+# Injected into the live operation; never committed to this public repo.
+server/services/calibration/*.private.json

--- a/server/__tests__/services/funderIntel.test.ts
+++ b/server/__tests__/services/funderIntel.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { mcaLenderNames, __resetFunderIntelCache } from '../../services/calibration/funderIntel'
+
+// Proves the calibration SEAM: production funder intelligence is injected from a
+// private file (SCORING_CALIBRATION_PATH), while a bare public clone falls back
+// to a small illustrative default — the public repo never carries the curated
+// dictionary. Same pattern the source-map and scoring tables will reuse.
+describe('funderIntel calibration seam', () => {
+  const originalEnv = process.env.SCORING_CALIBRATION_PATH
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'funder-cal-'))
+    __resetFunderIntelCache()
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.SCORING_CALIBRATION_PATH
+    else process.env.SCORING_CALIBRATION_PATH = originalEnv
+    __resetFunderIntelCache()
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it('injects the production dictionary from SCORING_CALIBRATION_PATH', () => {
+    const path = join(workDir, 'funders.json')
+    writeFileSync(path, JSON.stringify({ mcaLenderNames: ['ACME ADVANCE', 'BETA CAPITAL'] }))
+    process.env.SCORING_CALIBRATION_PATH = path
+    __resetFunderIntelCache()
+
+    expect(mcaLenderNames()).toEqual(['ACME ADVANCE', 'BETA CAPITAL'])
+  })
+
+  it('always returns a non-empty list (falls back to the illustrative default)', () => {
+    // Point at a path that does not exist: no injection, no crash — the shell
+    // still works so the public repo compiles/demos.
+    process.env.SCORING_CALIBRATION_PATH = join(workDir, 'does-not-exist.json')
+    __resetFunderIntelCache()
+
+    const names = mcaLenderNames()
+    expect(Array.isArray(names)).toBe(true)
+    expect(names.length).toBeGreaterThan(0)
+  })
+
+  it('honors the cache reset when the injected calibration changes', () => {
+    const path = join(workDir, 'funders.json')
+    writeFileSync(path, JSON.stringify({ mcaLenderNames: ['FIRST FUND'] }))
+    process.env.SCORING_CALIBRATION_PATH = path
+    __resetFunderIntelCache()
+    expect(mcaLenderNames()).toEqual(['FIRST FUND'])
+
+    writeFileSync(path, JSON.stringify({ mcaLenderNames: ['SECOND FUND'] }))
+    __resetFunderIntelCache()
+    expect(mcaLenderNames()).toEqual(['SECOND FUND'])
+  })
+
+  it('ignores a malformed calibration file and stays usable', () => {
+    const path = join(workDir, 'bad.json')
+    writeFileSync(path, '{ not valid json')
+    process.env.SCORING_CALIBRATION_PATH = path
+    __resetFunderIntelCache()
+
+    expect(mcaLenderNames().length).toBeGreaterThan(0)
+  })
+})

--- a/server/integrations/plaid/transactions.ts
+++ b/server/integrations/plaid/transactions.ts
@@ -9,6 +9,7 @@
  */
 
 import { plaidClient, PlaidClient } from './client'
+import { mcaLenderNames } from '../../services/calibration/funderIntel'
 
 /**
  * Plaid account types
@@ -234,32 +235,6 @@ export interface ParsedTransactionCategory {
   /** Confidence in category assignment (0-1) */
   confidence: number
 }
-
-/**
- * Known MCA lender names for payment detection
- */
-const KNOWN_MCA_LENDERS = [
-  'KAPITUS',
-  'CAN CAPITAL',
-  'BLUEVINE',
-  'ONDECK',
-  'KABBAGE',
-  'SQUARE CAPITAL',
-  'PAYPAL WORKING CAPITAL',
-  'FUNDBOX',
-  'CREDIBLY',
-  'NATIONAL FUNDING',
-  'RAPID FINANCE',
-  'FORWARD FINANCING',
-  'LIBERTAS FUNDING',
-  'ALLIED FUNDING',
-  'GREENBOX CAPITAL',
-  'PEARL CAPITAL',
-  'RELIANT FUNDING',
-  'MERCHANT CASH',
-  'BUSINESS FUNDING',
-  'FUNDING CIRCLE'
-]
 
 /**
  * NSF/Overdraft fee indicators
@@ -619,7 +594,7 @@ export class PlaidTransactionsManager {
     // Check for lender payments (MCA, loans, etc.)
     const isLenderPayment =
       !isNsfFee &&
-      (KNOWN_MCA_LENDERS.some((lender) => name.includes(lender) || merchantName.includes(lender)) ||
+      (mcaLenderNames().some((lender) => name.includes(lender) || merchantName.includes(lender)) ||
         category.includes('Loan') ||
         category.includes('Loan Payments') ||
         primaryCategory === 'LOAN_PAYMENTS')

--- a/server/services/UnderwritingService.ts
+++ b/server/services/UnderwritingService.ts
@@ -20,6 +20,7 @@ import {
   plaidTransactionsManager,
   PlaidTransactionsManager
 } from '../integrations/plaid'
+import { mcaLenderNames } from './calibration/funderIntel'
 
 /**
  * Daily balance record for ADB calculation
@@ -606,29 +607,9 @@ export class UnderwritingService {
   private extractLenderName(tx: PlaidTransaction): string {
     const name = (tx.merchantName || tx.name || '').toUpperCase()
 
-    // Try to match known lenders
-    const knownLenders = [
-      'KAPITUS',
-      'CAN CAPITAL',
-      'BLUEVINE',
-      'ONDECK',
-      'KABBAGE',
-      'SQUARE CAPITAL',
-      'PAYPAL WORKING CAPITAL',
-      'FUNDBOX',
-      'CREDIBLY',
-      'NATIONAL FUNDING',
-      'RAPID FINANCE',
-      'FORWARD FINANCING',
-      'LIBERTAS FUNDING',
-      'ALLIED FUNDING',
-      'GREENBOX CAPITAL',
-      'PEARL CAPITAL',
-      'RELIANT FUNDING',
-      'FUNDING CIRCLE'
-    ]
-
-    for (const lender of knownLenders) {
+    // Match against the curated funder dictionary (injected from private
+    // calibration; a bare public clone sees only the illustrative default).
+    for (const lender of mcaLenderNames()) {
       if (name.includes(lender)) {
         return lender
       }

--- a/server/services/calibration/funderIntel.private.example.json
+++ b/server/services/calibration/funderIntel.private.example.json
@@ -1,0 +1,8 @@
+{
+  "_note": "Template for the PRIVATE funder-intelligence calibration. Copy to funderIntel.private.json (gitignored) and populate with the production funder dictionary, or point SCORING_CALIBRATION_PATH at your own JSON. Without it, the platform uses the illustrative default in funderIntel.ts — the shape works, the market intelligence does not ship in this public repo.",
+  "mcaLenderNames": [
+    "EXAMPLE FUNDING CO",
+    "SAMPLE CAPITAL PARTNERS",
+    "DEMO ADVANCE GROUP"
+  ]
+}

--- a/server/services/calibration/funderIntel.ts
+++ b/server/services/calibration/funderIntel.ts
@@ -1,0 +1,71 @@
+/**
+ * Funder-intelligence calibration — the public SHELL of a private dictionary.
+ *
+ * Knowing WHICH merchant-cash-advance funders operate and how to recognize
+ * them on a bank statement is hard-won market intelligence, not commodity
+ * code. This module exposes the shape and a small ILLUSTRATIVE default so the
+ * public repository compiles, tests, and demos; the production funder
+ * dictionary is INJECTED from a private calibration file that is never
+ * committed to this public repo.
+ *
+ * This is the reusable calibration seam. The discovery source-map and the
+ * scoring/credit-box tables follow the same pattern: public interface +
+ * illustrative default here, real values injected privately.
+ *
+ * Resolution order (first hit wins):
+ *   1. process.env.SCORING_CALIBRATION_PATH — an explicit JSON path (tests/ops)
+ *   2. <this dir>/funderIntel.private.json    — the operator's private file (gitignored)
+ *   3. the illustrative public default (below)
+ *
+ * Private/injected JSON shape: { "mcaLenderNames": ["...", ...] }
+ *
+ * @module server/services/calibration/funderIntel
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+// Illustrative ONLY — NOT the production funder dictionary. Deliberately
+// generic so a bare public clone has no curated market intelligence to lift.
+const ILLUSTRATIVE_MCA_LENDERS: readonly string[] = ['SAMPLE CAPITAL', 'EXAMPLE FUNDING']
+
+interface FunderCalibration {
+  mcaLenderNames: string[]
+}
+
+let cache: FunderCalibration | null = null
+
+function loadCalibration(): FunderCalibration {
+  if (cache) return cache
+  const candidates = [
+    process.env.SCORING_CALIBRATION_PATH,
+    join(__dirname, 'funderIntel.private.json')
+  ].filter((p): p is string => Boolean(p))
+
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue
+      const data = JSON.parse(readFileSync(path, 'utf8')) as { mcaLenderNames?: unknown }
+      if (Array.isArray(data.mcaLenderNames) && data.mcaLenderNames.length > 0) {
+        cache = { mcaLenderNames: data.mcaLenderNames.map(String) }
+        return cache
+      }
+    } catch {
+      // Malformed/unreadable candidate — fall through to the next / illustrative.
+    }
+  }
+  cache = { mcaLenderNames: [...ILLUSTRATIVE_MCA_LENDERS] }
+  return cache
+}
+
+/**
+ * The recognized MCA/funder name list. Production values are injected from a
+ * private calibration file; a bare public clone gets only the illustrative set.
+ */
+export function mcaLenderNames(): string[] {
+  return loadCalibration().mcaLenderNames
+}
+
+/** Test/ops seam: drop the cache so a new SCORING_CALIBRATION_PATH takes effect. */
+export function __resetFunderIntelCache(): void {
+  cache = null
+}


### PR DESCRIPTION
## Why

The MCA funder/lender dictionary — the curated market intelligence of *which* funders to recognize on a bank statement — was a hardcoded array, duplicated in `UnderwritingService` and `integrations/plaid/transactions.ts`, readable by anyone who clones this public repo. This is the first slice of separating the **calibration** (private) from the **shell** (public), so the repo stays an impressive, working lure while the tuned values that make it *good* are injected privately.

## What

- **`server/services/calibration/funderIntel.ts`** — a reusable calibration seam: exposes the shape + a small **illustrative** default, and injects the production dictionary from `SCORING_CALIBRATION_PATH` or a gitignored `funderIntel.private.json` (template committed as `.private.example.json`).
- Both consumers (`UnderwritingService.extractLenderName`, `transactions.parseTransactionCategory`) now read `mcaLenderNames()`. The duplicated hardcoded arrays are gone from tracked source.
- `.gitignore` excludes `server/services/calibration/*.private.json` — the real dictionary never lands in this public repo (it's recoverable from pre-merge history for the operator's private file; history isn't scrubbed — the moat is the *live* injected calibration, not the snapshot).
- `funderIntel.test.ts` proves the seam: injection via env, illustrative fallback, cache reset, malformed-file tolerance.

**This is the reusable pattern** the discovery source-map and the scoring/credit-box tables follow next.

## Safety / scope

- **Demo unaffected:** the bank-statement analyzer detects positions by cadence, not the dictionary.
- **Tests:** 775/775 across `services` + `integrations` on the illustrative default (the CI / no-private-file scenario); the lender-name assertions pass via the existing raw-name fallback.
- **Avoids `SBALoansChannel.ts`** (edited by in-flight draft #354) — no conflict.
- Companion `moat-audit.py` (organvm/limen#1183) tracks the boundary: this resolves the `curated-mca-funder-dictionary` leak; the source-map and scoring-calibration patterns remain as staged follow-ons.

## NOT auto-merged

Held for review — this is the crown-jewel revenue repo and there is active peer reacceptance work in flight (#354–#356). Green CI here is the gate; the merge is a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)