### PR TITLE
heal(moat): extend the calibration seam to all 4 leak surfaces (P0 critical)

### DIFF
--- a/server/__tests__/services/QualificationService.test.ts
+++ b/server/__tests__/services/QualificationService.test.ts
@@ -1,10 +1,38 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import {
   QualificationService,
   createQualificationService
 } from '../../services/QualificationService'
+import { __resetQualificationRulesCache } from '../../services/calibration/qualificationRules'
 // DatabaseError imported for potential future use in error handling tests
 import type { UnderwritingFeatures } from '../../services/UnderwritingService'
+
+// The calibrated credit box is the MOAT and never lives in tracked source —
+// including this test. So the suite injects a SAMPLE (obviously-non-real) rule
+// set through the calibration seam (see
+// server/services/calibration/qualificationRules.ts) via SCORING_CALIBRATION_PATH
+// — exactly how an operator supplies their private calibration — and asserts the
+// service faithfully applies WHATEVER it was given (rate/amount/threshold logic)
+// plus the tier-classification logic. The real production bands are proven by the
+// same code path with the operator's own private file, not embedded here.
+//
+// The sample bands below use round, clearly-synthetic numbers that preserve tier
+// ORDERING (A best → D worst) so every scenario test still resolves to its
+// intended tier. Decline caps are Infinity in source but never read by the A..D
+// evaluation loops, so a large sentinel is fine in JSON.
+const SAMPLE_RULES = {
+  minAdbByTier: { A: 20000, B: 10000, C: 5000, D: 2000, Decline: 0 },
+  maxNsfByTier: { A: 0, B: 2, C: 5, D: 10, Decline: 999999 },
+  maxNegativeDaysByTier: { A: 0, B: 5, C: 10, D: 20, Decline: 999999 },
+  maxPositionsByTier: { A: 0, B: 1, C: 3, D: 5, Decline: 999999 },
+  minTimeInBusinessByTier: { A: 24, B: 12, C: 6, D: 3, Decline: 0 },
+  minMonthlyRevenueByTier: { A: 40000, B: 20000, C: 10000, D: 5000, Decline: 0 },
+  factorRatesByTier: { A: 1.1, B: 1.2, C: 1.3, D: 1.4, Decline: 0 },
+  maxFundingMultiple: { A: 1.4, B: 1.2, C: 1.0, D: 0.8, Decline: 0 }
+}
 
 // Mock the database module
 vi.mock('../../database/connection', () => ({
@@ -31,6 +59,8 @@ const mockExtractFeatures = vi.mocked(underwritingService.extractFeatures)
 
 describe('QualificationService', () => {
   let service: QualificationService
+  let calibrationDir: string
+  const originalCalibrationPath = process.env.SCORING_CALIBRATION_PATH
 
   const createMockFeatures = (
     overrides: Partial<UnderwritingFeatures> = {}
@@ -69,7 +99,21 @@ describe('QualificationService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Inject the SAMPLE credit box through the calibration seam so these
+    // assertions run against synthetic bands, never the real production values.
+    calibrationDir = mkdtempSync(join(tmpdir(), 'qual-cal-'))
+    const calibrationPath = join(calibrationDir, 'calibration.json')
+    writeFileSync(calibrationPath, JSON.stringify({ qualificationRules: SAMPLE_RULES }))
+    process.env.SCORING_CALIBRATION_PATH = calibrationPath
+    __resetQualificationRulesCache()
     service = new QualificationService()
+  })
+
+  afterEach(() => {
+    if (originalCalibrationPath === undefined) delete process.env.SCORING_CALIBRATION_PATH
+    else process.env.SCORING_CALIBRATION_PATH = originalCalibrationPath
+    __resetQualificationRulesCache()
+    rmSync(calibrationDir, { recursive: true, force: true })
   })
 
   describe('qualify', () => {
@@ -97,18 +141,18 @@ describe('QualificationService', () => {
 
       expect(result.qualified).toBe(true)
       expect(result.tier).toBe('A')
-      expect(result.suggestedRate).toBe(1.15)
+      expect(result.suggestedRate).toBe(SAMPLE_RULES.factorRatesByTier.A)
     })
 
     it('should qualify prospect as Tier B for good metrics', async () => {
-      // B-tier requires <= 1 warning and >= 6 passes
-      // Values that hit B-tier thresholds (just above B minimums)
+      // B-tier requires <= 1 warning and >= 6 passes. Inputs sit at/just above
+      // the B thresholds of the injected SAMPLE_RULES (not the real bands).
       const features = createMockFeatures({
-        averageDailyBalance: 20000, // B tier: >= 15000
-        nsfCount: 1, // B tier: <= 2, creates warning
-        negativeDaysPercentage: 1, // B tier: <= 3, should pass
-        estimatedPositionCount: 1, // B tier: <= 1, creates warning but within limit
-        averageMonthlyDeposits: 35000, // B tier: >= 25000
+        averageDailyBalance: 20000, // >= sample B minAdb
+        nsfCount: 1, // within sample B maxNsf, creates warning
+        negativeDaysPercentage: 1, // within sample B maxNegativeDays
+        estimatedPositionCount: 1, // at sample B maxPositions, creates warning
+        averageMonthlyDeposits: 35000, // >= sample B minMonthlyRevenue
         depositConsistencyScore: 80 // Pass
       })
 
@@ -122,14 +166,14 @@ describe('QualificationService', () => {
     })
 
     it('should qualify prospect as Tier C for moderate metrics', async () => {
-      // C-tier requires <= 3 warnings and > 1 warning (to not be B)
-      // Values that create 2-3 warnings
+      // C-tier requires <= 3 warnings and > 1 warning (to not be B). Inputs sit
+      // in the C bands of the injected SAMPLE_RULES (not the real bands).
       const features = createMockFeatures({
-        averageDailyBalance: 10000, // C tier: >= 7500, creates warning
-        nsfCount: 3, // C tier: <= 4, creates warning
-        negativeDaysPercentage: 5, // C tier: <= 7, creates warning
-        estimatedPositionCount: 2, // C tier: <= 2, creates warning
-        averageMonthlyDeposits: 18000, // C tier: >= 15000, creates warning
+        averageDailyBalance: 10000, // in sample C minAdb band, creates warning
+        nsfCount: 3, // within sample C maxNsf, creates warning
+        negativeDaysPercentage: 5, // within sample C maxNegativeDays, warning
+        estimatedPositionCount: 2, // within sample C maxPositions, warning
+        averageMonthlyDeposits: 18000, // in sample C minMonthlyRevenue band, warning
         depositConsistencyScore: 60 // Warning
       })
 
@@ -158,7 +202,7 @@ describe('QualificationService', () => {
 
       expect(result.qualified).toBe(true)
       expect(result.tier).toBe('D')
-      expect(result.suggestedRate).toBe(1.45)
+      expect(result.suggestedRate).toBe(SAMPLE_RULES.factorRatesByTier.D)
     })
 
     it('should decline prospect for poor metrics', async () => {
@@ -190,8 +234,8 @@ describe('QualificationService', () => {
 
       const result = await service.qualify('prospect-1', features, { timeInBusinessMonths: 36 })
 
-      // Tier A: up to 1.5x monthly revenue, capped at $500k
-      expect(result.maxAmount).toBe(150000) // 100000 * 1.5
+      // Tier A: up to (sample) 1.4x monthly revenue, capped at $500k.
+      expect(result.maxAmount).toBe(100000 * SAMPLE_RULES.maxFundingMultiple.A)
     })
 
     it('should include warnings for concerning metrics', async () => {
@@ -278,17 +322,17 @@ describe('QualificationService', () => {
       const requirements = service.getTierRequirements('A')
 
       expect(requirements.tier).toBe('A')
-      expect(requirements.requirements.minAdb).toBe(25000)
-      expect(requirements.requirements.maxNsf).toBe(0)
-      expect(requirements.terms.factorRate).toBe(1.15)
+      expect(requirements.requirements.minAdb).toBe(SAMPLE_RULES.minAdbByTier.A)
+      expect(requirements.requirements.maxNsf).toBe(SAMPLE_RULES.maxNsfByTier.A)
+      expect(requirements.terms.factorRate).toBe(SAMPLE_RULES.factorRatesByTier.A)
     })
 
     it('should return requirements for Tier D', () => {
       const requirements = service.getTierRequirements('D')
 
       expect(requirements.tier).toBe('D')
-      expect(requirements.requirements.minAdb).toBe(3000)
-      expect(requirements.terms.factorRate).toBe(1.45)
+      expect(requirements.requirements.minAdb).toBe(SAMPLE_RULES.minAdbByTier.D)
+      expect(requirements.terms.factorRate).toBe(SAMPLE_RULES.factorRatesByTier.D)
     })
   })
 

--- a/server/__tests__/services/ScoringService.test.ts
+++ b/server/__tests__/services/ScoringService.test.ts
@@ -316,7 +316,9 @@ describe('ScoringService', () => {
 
       const withModifier = {
         ...baseInput,
-        industryRiskModifier: 0.85 // restaurant - higher risk
+        // A sample sub-1.0 modifier (higher-risk industry); the real per-industry
+        // multipliers are calibration and never live in tracked source.
+        industryRiskModifier: 0.8
       }
 
       const baseScore = service.calculateCompositeScore(baseInput)
@@ -332,15 +334,17 @@ describe('ScoringService', () => {
         positionScore: 90
       }
 
-      const nyInput = {
+      const favorableStateInput = {
         ...baseInput,
-        stateModifier: 1.02 // NY has higher modifier
+        // A sample above-1.0 modifier (favorable state); the real per-state
+        // multipliers are calibration and never live in tracked source.
+        stateModifier: 1.05
       }
 
       const baseScore = service.calculateCompositeScore(baseInput)
-      const nyScore = service.calculateCompositeScore(nyInput)
+      const favorableScore = service.calculateCompositeScore(favorableStateInput)
 
-      expect(nyScore).toBeGreaterThan(baseScore)
+      expect(favorableScore).toBeGreaterThan(baseScore)
     })
 
     it('should add the MCA-adjacency boost additively', () => {
@@ -492,9 +496,7 @@ describe('ScoringService', () => {
     })
 
     it('should boost MCA-adjacent prospects with a recent equipment purchase', async () => {
-      const recentDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-        .toISOString()
-        .slice(0, 10)
+      const recentDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 
       const mockProspect = {
         company_name: 'Growth Mfg Co',

--- a/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
+++ b/server/__tests__/services/socrataBuildingPermitsChannel.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 // Rate limiter is a no-op in tests — never block / hit a real bucket.
 vi.mock('@public-records/core/enrichment', () => ({
@@ -9,6 +12,41 @@ vi.mock('@public-records/core/enrichment', () => ({
 
 import { SocrataBuildingPermitsChannel } from '../../services/discovery-channels/SocrataBuildingPermitsChannel'
 import { DiscoveryChannelError } from '../../services/discovery-channels/types'
+import { __resetDiscoverySourcesCache } from '../../services/calibration/discoverySources'
+
+// The curated per-state source-map is now injected through the calibration seam
+// (see server/services/calibration/discoverySources.ts). The real production
+// endpoints/fields are the MOAT and never live in tracked source — including
+// this test. So the suite injects a SAMPLE source-map via SCORING_CALIBRATION_PATH
+// (exactly how an operator supplies their private map) and asserts the channel
+// faithfully uses whatever it was given. Behavior is what's under test; the real
+// values are proven by the same code path with the operator's own private file.
+const SAMPLE_SOURCES = {
+  NY: {
+    state: 'NY',
+    url: 'https://example.data.gov/resource/nyxx-xxxx.json',
+    businessField: 'sample_ny_business',
+    orderField: 'sample_ny_date'
+  },
+  CA: {
+    state: 'CA',
+    url: 'https://example.data.gov/resource/caxx-xxxx.json',
+    businessField: 'sample_ca_business',
+    orderField: 'sample_ca_date'
+  },
+  FL: {
+    state: 'FL',
+    url: 'https://example.data.gov/resource/flxx-xxxx.json',
+    businessField: 'sample_fl_business',
+    orderField: 'sample_fl_date'
+  },
+  TX: {
+    state: 'TX',
+    url: 'https://example.data.gov/resource/txxx-xxxx.json',
+    businessField: 'sample_tx_business',
+    orderField: 'sample_tx_date'
+  }
+}
 
 /** A successful JSON Response wrapping a Socrata row array. */
 function rowsResponse(rows: Record<string, unknown>[]): Response {
@@ -20,21 +58,34 @@ function rowsResponse(rows: Record<string, unknown>[]): Response {
   } as unknown as Response
 }
 
-const NY_FIELD = 'permittee_s_business_name'
-const CA_FIELD = 'contractors_business_name'
-const FL_FIELD = 'contractor_name'
-const TX_FIELD = 'contractor_company_name'
+const NY_FIELD = SAMPLE_SOURCES.NY.businessField
+const CA_FIELD = SAMPLE_SOURCES.CA.businessField
+const FL_FIELD = SAMPLE_SOURCES.FL.businessField
+const TX_FIELD = SAMPLE_SOURCES.TX.businessField
 
 describe('SocrataBuildingPermitsChannel', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
+  let calibrationDir: string
+  const originalCalibrationPath = process.env.SCORING_CALIBRATION_PATH
 
   beforeEach(() => {
+    // Inject the sample source-map through the calibration seam.
+    calibrationDir = mkdtempSync(join(tmpdir(), 'socrata-cal-'))
+    const calibrationPath = join(calibrationDir, 'calibration.json')
+    writeFileSync(calibrationPath, JSON.stringify({ socrataBuildingPermitSources: SAMPLE_SOURCES }))
+    process.env.SCORING_CALIBRATION_PATH = calibrationPath
+    __resetDiscoverySourcesCache()
+
     fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    if (originalCalibrationPath === undefined) delete process.env.SCORING_CALIBRATION_PATH
+    else process.env.SCORING_CALIBRATION_PATH = originalCalibrationPath
+    __resetDiscoverySourcesCache()
+    rmSync(calibrationDir, { recursive: true, force: true })
   })
 
   it('always reports as configured (key-less public source)', () => {
@@ -50,7 +101,10 @@ describe('SocrataBuildingPermitsChannel', () => {
       ])
     )
 
-    const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
+    const candidates = await new SocrataBuildingPermitsChannel().discover({
+      state: 'NY',
+      limit: 10
+    })
 
     expect(candidates.map((c) => c.company_name)).toEqual(['Acme Builders', 'Beta Contractors'])
     expect(candidates[0]).toMatchObject({
@@ -93,16 +147,15 @@ describe('SocrataBuildingPermitsChannel', () => {
     ])
     // URLSearchParams encodes spaces as '+' — normalize before asserting.
     const url = decodeURIComponent(String(fetchSpy.mock.calls[0][0]).replace(/\+/g, ' '))
-    expect(url).toContain('data.cityoforlando.net/resource/ryhf-m453.json')
+    // The channel queries whatever resource the injected source-map names for FL.
+    expect(url).toContain(SAMPLE_SOURCES.FL.url)
     // SODA sorts DESC NULL FIRST — the null-guard keeps unissued applications out.
-    expect(url).toContain('issue_permit_date IS NOT NULL')
+    expect(url).toContain(`${SAMPLE_SOURCES.FL.orderField} IS NOT NULL`)
   })
 
   it('caps the total candidates at the requested limit', async () => {
     fetchSpy.mockResolvedValueOnce(
-      rowsResponse(
-        Array.from({ length: 10 }, (_, n) => ({ [NY_FIELD]: `Co ${n}` }))
-      )
+      rowsResponse(Array.from({ length: 10 }, (_, n) => ({ [NY_FIELD]: `Co ${n}` })))
     )
 
     const candidates = await new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 3 })
@@ -148,6 +201,6 @@ describe('SocrataBuildingPermitsChannel', () => {
     fetchSpy.mockResolvedValueOnce(rowsResponse([{ some_other_field: 'x' }, { another: 'y' }]))
     await expect(
       new SocrataBuildingPermitsChannel().discover({ state: 'NY', limit: 10 })
-    ).rejects.toThrow(/Socrata \(NY\) schema changed: field 'permittee_s_business_name' absent/)
+    ).rejects.toThrow(new RegExp(`Socrata \\(NY\\) schema changed: field '${NY_FIELD}' absent`))
   })
 })

--- a/server/services/QualificationService.ts
+++ b/server/services/QualificationService.ts
@@ -21,6 +21,7 @@ import {
   UnderwritingService,
   underwritingService
 } from './UnderwritingService'
+import { qualificationRules } from './calibration/qualificationRules'
 
 /**
  * Qualification tiers
@@ -98,65 +99,18 @@ export interface QualificationRules {
 }
 
 /**
- * Default qualification rules
+ * Default qualification rules.
+ *
+ * The calibrated credit-box band VALUES are calibration, not source: they are
+ * injected from the private scoring calibration file (see
+ * ./calibration/qualificationRules — the reusable seam from
+ * ./calibration/funderIntel). A bare public clone gets illustrative bands that
+ * keep the engine functional; the operator's real values load identically to
+ * before once a private.json (or SCORING_CALIBRATION_PATH) is present. The
+ * QualificationRules TYPE stays public (see the interface above).
  */
-const DEFAULT_RULES: QualificationRules = {
-  minAdbByTier: {
-    A: 25000,
-    B: 15000,
-    C: 7500,
-    D: 3000,
-    Decline: 0
-  },
-  maxNsfByTier: {
-    A: 0,
-    B: 2,
-    C: 4,
-    D: 8,
-    Decline: Infinity
-  },
-  maxNegativeDaysByTier: {
-    A: 0,
-    B: 3,
-    C: 7,
-    D: 15,
-    Decline: Infinity
-  },
-  maxPositionsByTier: {
-    A: 0,
-    B: 1,
-    C: 2,
-    D: 4,
-    Decline: Infinity
-  },
-  minTimeInBusinessByTier: {
-    A: 24, // 2 years
-    B: 12, // 1 year
-    C: 6, // 6 months
-    D: 3, // 3 months
-    Decline: 0
-  },
-  minMonthlyRevenueByTier: {
-    A: 50000,
-    B: 25000,
-    C: 15000,
-    D: 10000,
-    Decline: 0
-  },
-  factorRatesByTier: {
-    A: 1.15,
-    B: 1.25,
-    C: 1.35,
-    D: 1.45,
-    Decline: 0
-  },
-  maxFundingMultiple: {
-    A: 1.5, // Up to 1.5x monthly revenue
-    B: 1.25,
-    C: 1.0,
-    D: 0.75,
-    Decline: 0
-  }
+function defaultRules(): QualificationRules {
+  return qualificationRules()
 }
 
 /**
@@ -197,7 +151,7 @@ export class QualificationService {
   private underwriting: UnderwritingService
 
   constructor(rules?: Partial<QualificationRules>, underwriting?: UnderwritingService) {
-    this.rules = { ...DEFAULT_RULES, ...rules }
+    this.rules = { ...defaultRules(), ...rules }
     this.underwriting = underwriting || underwritingService
   }
 

--- a/server/services/ScoringService.ts
+++ b/server/services/ScoringService.ts
@@ -20,6 +20,7 @@
 import { database } from '../database/connection'
 import { EquipmentLifecycleDetector } from './EquipmentLifecycleDetector'
 import { mlScoringStrategy, type MlScoreOutput } from './MLScoringStrategy'
+import { industryRiskModifiers, stateModifiers } from './calibration/scoringModifiers'
 
 export interface IntentScoreInput {
   daysSinceLastFiling: number
@@ -122,30 +123,13 @@ const DEFAULT_CONFIG: ScoringConfig = {
   compositePositionWeight: 0.25
 }
 
-// Industry risk modifiers (lower = higher risk)
-const INDUSTRY_RISK_MODIFIERS: Record<string, number> = {
-  restaurant: 0.85,
-  retail: 0.9,
-  construction: 0.8,
-  healthcare: 0.95,
-  manufacturing: 0.88,
-  services: 0.92,
-  technology: 0.95
-}
-
-// State modifiers (regulatory environment, market size)
-const STATE_MODIFIERS: Record<string, number> = {
-  CA: 1.0,
-  TX: 0.98,
-  FL: 0.95,
-  NY: 1.02,
-  IL: 0.97,
-  PA: 0.96,
-  OH: 0.94,
-  GA: 0.96,
-  NC: 0.95,
-  MI: 0.93
-}
+// Industry-risk and state modifier tables (lower industry value = higher risk).
+// The POPULATED tables are calibration, not source: they are injected from the
+// private scoring calibration file (see ./calibration/scoringModifiers — the
+// reusable seam from ./calibration/funderIntel). A bare public clone gets a
+// small illustrative set; unknown industries/states fall back to a neutral 1.0
+// in calculateCompositeScore. The composite formula weights (DEFAULT_CONFIG
+// above) remain public research and are NOT calibration.
 
 export class ScoringService {
   private config: ScoringConfig
@@ -546,8 +530,8 @@ export class ScoringService {
     // Get modifiers
     const industry = options.industry || prospect.industry
     const state = options.state || prospect.state
-    const industryModifier = INDUSTRY_RISK_MODIFIERS[industry] || 1
-    const stateModifier = STATE_MODIFIERS[state] || 1
+    const industryModifier = industryRiskModifiers()[industry] || 1
+    const stateModifier = stateModifiers()[state] || 1
 
     // Detect equipment-lifecycle signals from the filings already fetched.
     // A recent equipment purchase financed outside the MCA channel marks an

--- a/server/services/calibration/discoverySources.private.json.example
+++ b/server/services/calibration/discoverySources.private.json.example
@@ -1,0 +1,18 @@
+{
+  "_note": "Template for the PRIVATE discovery source-map calibration. Copy to discoverySources.private.json (gitignored) and populate with the real curated endpoints, or point SCORING_CALIBRATION_PATH at one shared JSON that carries this and every other calibration key. Without it, the platform uses the illustrative sample entries in discoverySources.ts — the shape works, the curated source-map does not ship in this public repo. The keys below (socrataBuildingPermitSources, sbaCkanPackageId) may also live alongside qualificationRules / industryRiskModifiers / stateModifiers in ONE shared file read via SCORING_CALIBRATION_PATH.",
+  "socrataBuildingPermitSources": {
+    "XX": {
+      "state": "XX",
+      "url": "https://example.data.gov/resource/xxxx-xxxx.json",
+      "businessField": "business_name",
+      "orderField": "issued_date"
+    },
+    "YY": {
+      "state": "YY",
+      "url": "https://sample.data.gov/resource/yyyy-yyyy.json",
+      "businessField": "contractor_name",
+      "orderField": "issue_date"
+    }
+  },
+  "sbaCkanPackageId": "00000000-0000-0000-0000-000000000000"
+}

--- a/server/services/calibration/discoverySources.ts
+++ b/server/services/calibration/discoverySources.ts
@@ -1,0 +1,167 @@
+/**
+ * Discovery source-map calibration — the public SHELL of a private dictionary.
+ *
+ * Knowing WHICH curated open-data endpoints (and their per-city field mappings)
+ * yield high-signal financing leads — and which specific FOIA package holds the
+ * recent SBA 7(a) loan-level records — is hard-won market intelligence, not
+ * commodity code. This module exposes the shape and a small ILLUSTRATIVE default
+ * so the public repository compiles, tests, and demos; the production source-map
+ * is INJECTED from a private calibration file that is never committed to this
+ * public repo.
+ *
+ * This is the discovery source-map half of the reusable calibration seam
+ * introduced in ./funderIntel.ts (the scoring/credit-box tables reuse it too).
+ *
+ * Resolution order (first hit wins):
+ *   1. process.env.SCORING_CALIBRATION_PATH — an explicit JSON path (tests/ops)
+ *   2. <this dir>/discoverySources.private.json — the operator's private file (gitignored)
+ *   3. the illustrative public default (below)
+ *
+ * A single private JSON may carry every calibration key; this module reads the
+ * `socrataBuildingPermitSources` and `sbaCkanPackageId` top-level keys.
+ *
+ * Private/injected JSON shape:
+ *   {
+ *     "socrataBuildingPermitSources": {
+ *       "NY": { "state": "NY", "url": "https://.../resource/xxxx-xxxx.json",
+ *               "businessField": "...", "orderField": "..." }, ...
+ *     },
+ *     "sbaCkanPackageId": "<curated FOIA package uuid>"
+ *   }
+ *
+ * @module server/services/calibration/discoverySources
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+/** One Socrata city dataset: geography, resource URL, and row field mapping. */
+export interface SocrataSource {
+  /** State this dataset implicitly covers (datasets are city-scoped). */
+  state: string
+  /** Base resource URL (.json). */
+  url: string
+  /** Field holding the business name in each row. */
+  businessField: string
+  /** Field used for newest-first ordering. */
+  orderField: string
+}
+
+interface DiscoverySourceCalibration {
+  socrataBuildingPermitSources: Record<string, SocrataSource>
+  sbaCkanPackageId: string
+}
+
+// Illustrative ONLY — NOT the production source-map. Deliberately generic
+// sample entries so a bare public clone has no curated market intelligence to
+// lift. The shape works; the real endpoints do not ship in this public repo.
+const ILLUSTRATIVE_SOCRATA_SOURCES: Record<string, SocrataSource> = {
+  XX: {
+    state: 'XX',
+    url: 'https://example.data.gov/resource/xxxx-xxxx.json',
+    businessField: 'business_name',
+    orderField: 'issued_date'
+  },
+  YY: {
+    state: 'YY',
+    url: 'https://sample.data.gov/resource/yyyy-yyyy.json',
+    businessField: 'contractor_name',
+    orderField: 'issue_date'
+  }
+}
+
+// Illustrative ONLY — a clearly-fake placeholder id, NOT the real curated FOIA
+// package. The self-healing resolver in SBALoansChannel tolerates a package id
+// that resolves to nothing (it falls through to the DCAT catalog).
+const ILLUSTRATIVE_SBA_CKAN_PACKAGE_ID = '00000000-0000-0000-0000-000000000000'
+
+let cache: DiscoverySourceCalibration | null = null
+
+function isSocrataSource(v: unknown): v is SocrataSource {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.state === 'string' &&
+    typeof o.url === 'string' &&
+    typeof o.businessField === 'string' &&
+    typeof o.orderField === 'string'
+  )
+}
+
+function coerceSocrataSources(raw: unknown): Record<string, SocrataSource> | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const out: Record<string, SocrataSource> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!isSocrataSource(value)) return null
+    out[key] = {
+      state: value.state,
+      url: value.url,
+      businessField: value.businessField,
+      orderField: value.orderField
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+function loadCalibration(): DiscoverySourceCalibration {
+  if (cache) return cache
+  const candidates = [
+    process.env.SCORING_CALIBRATION_PATH,
+    join(__dirname, 'discoverySources.private.json')
+  ].filter((p): p is string => Boolean(p))
+
+  let socrataBuildingPermitSources: Record<string, SocrataSource> | null = null
+  let sbaCkanPackageId: string | null = null
+
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue
+      const data = JSON.parse(readFileSync(path, 'utf8')) as {
+        socrataBuildingPermitSources?: unknown
+        sbaCkanPackageId?: unknown
+      }
+      if (socrataBuildingPermitSources === null) {
+        socrataBuildingPermitSources = coerceSocrataSources(data.socrataBuildingPermitSources)
+      }
+      if (sbaCkanPackageId === null) {
+        sbaCkanPackageId =
+          typeof data.sbaCkanPackageId === 'string' && data.sbaCkanPackageId.length > 0
+            ? data.sbaCkanPackageId
+            : null
+      }
+      if (socrataBuildingPermitSources !== null && sbaCkanPackageId !== null) break
+    } catch {
+      // Malformed/unreadable candidate — fall through to the next / illustrative.
+    }
+  }
+
+  cache = {
+    socrataBuildingPermitSources: socrataBuildingPermitSources ?? {
+      ...ILLUSTRATIVE_SOCRATA_SOURCES
+    },
+    sbaCkanPackageId: sbaCkanPackageId ?? ILLUSTRATIVE_SBA_CKAN_PACKAGE_ID
+  }
+  return cache
+}
+
+/**
+ * The curated per-state Socrata building-permit source-map. Production values
+ * are injected from a private calibration file; a bare public clone gets only
+ * the illustrative sample entries.
+ */
+export function socrataBuildingPermitSources(): Record<string, SocrataSource> {
+  return loadCalibration().socrataBuildingPermitSources
+}
+
+/**
+ * The curated SBA 7(a)/504 FOIA CKAN package id. Production value is injected
+ * from a private calibration file; a bare public clone gets only a fake
+ * placeholder id (the resolver heals past it via the DCAT catalog).
+ */
+export function sbaCkanPackageId(): string {
+  return loadCalibration().sbaCkanPackageId
+}
+
+/** Test/ops seam: drop the cache so a new SCORING_CALIBRATION_PATH takes effect. */
+export function __resetDiscoverySourcesCache(): void {
+  cache = null
+}

--- a/server/services/calibration/qualificationRules.private.json.example
+++ b/server/services/calibration/qualificationRules.private.json.example
@@ -1,0 +1,13 @@
+{
+  "_note": "Template for the PRIVATE qualification credit-box calibration. Copy to qualificationRules.private.json (gitignored) and populate with the real calibrated bands, or point SCORING_CALIBRATION_PATH at one shared JSON that carries this and every other calibration key. Without it, the platform uses the illustrative bands in qualificationRules.ts — the engine works, the real credit box does not ship in this public repo. Each per-tier sub-table must carry a number for every tier (A, B, C, D, Decline); use a large sentinel where the source uses Infinity (JSON has no Infinity literal, e.g. 999999). Any omitted sub-table falls back to the illustrative default for that table.",
+  "qualificationRules": {
+    "minAdbByTier": { "A": 20000, "B": 10000, "C": 5000, "D": 2000, "Decline": 0 },
+    "maxNsfByTier": { "A": 0, "B": 2, "C": 5, "D": 10, "Decline": 999999 },
+    "maxNegativeDaysByTier": { "A": 0, "B": 5, "C": 10, "D": 20, "Decline": 999999 },
+    "maxPositionsByTier": { "A": 0, "B": 1, "C": 3, "D": 5, "Decline": 999999 },
+    "minTimeInBusinessByTier": { "A": 24, "B": 12, "C": 6, "D": 3, "Decline": 0 },
+    "minMonthlyRevenueByTier": { "A": 40000, "B": 20000, "C": 10000, "D": 5000, "Decline": 0 },
+    "factorRatesByTier": { "A": 1.2, "B": 1.3, "C": 1.4, "D": 1.5, "Decline": 0 },
+    "maxFundingMultiple": { "A": 1.4, "B": 1.1, "C": 0.8, "D": 0.5, "Decline": 0 }
+  }
+}

--- a/server/services/calibration/qualificationRules.ts
+++ b/server/services/calibration/qualificationRules.ts
@@ -1,0 +1,137 @@
+/**
+ * Qualification credit-box calibration — the public SHELL of a private dictionary.
+ *
+ * The calibrated credit-box bands (the ADB / NSF / negative-day / position /
+ * time-in-business / revenue thresholds, factor rates, and funding multiples per
+ * tier) are hard-won underwriting intelligence, not commodity code. This module
+ * exposes the SHAPE (see QualificationRules in ../QualificationService) and a
+ * small ILLUSTRATIVE default so the public repository compiles, tests, and demos;
+ * the production credit box is INJECTED from a private calibration file that is
+ * never committed to this public repo.
+ *
+ * This is the scoring/credit-box half of the reusable calibration seam
+ * introduced in ./funderIntel.ts.
+ *
+ * Resolution order (first hit wins):
+ *   1. process.env.SCORING_CALIBRATION_PATH — an explicit JSON path (tests/ops)
+ *   2. <this dir>/qualificationRules.private.json — the operator's private file (gitignored)
+ *   3. the illustrative public default (below)
+ *
+ * A single private JSON may carry every calibration key; this module reads the
+ * `qualificationRules` top-level key. Any missing sub-table falls back to the
+ * illustrative default for that table, so a partial override stays valid.
+ *
+ * Private/injected JSON shape:
+ *   { "qualificationRules": { "minAdbByTier": { "A": ..., ... }, ... } }
+ *
+ * @module server/services/calibration/qualificationRules
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import type { QualificationRules, QualificationTier } from '../QualificationService'
+
+// Illustrative ONLY — NOT the production credit box. Rounded, generic
+// placeholder bands that keep the app functional (a bare public clone still
+// qualifies/declines and computes terms) but are deliberately not the real
+// calibration.
+const ILLUSTRATIVE_RULES: QualificationRules = {
+  minAdbByTier: { A: 20000, B: 10000, C: 5000, D: 2000, Decline: 0 },
+  maxNsfByTier: { A: 0, B: 2, C: 5, D: 10, Decline: Infinity },
+  maxNegativeDaysByTier: { A: 0, B: 5, C: 10, D: 20, Decline: Infinity },
+  maxPositionsByTier: { A: 0, B: 1, C: 3, D: 5, Decline: Infinity },
+  minTimeInBusinessByTier: { A: 24, B: 12, C: 6, D: 3, Decline: 0 },
+  minMonthlyRevenueByTier: { A: 40000, B: 20000, C: 10000, D: 5000, Decline: 0 },
+  factorRatesByTier: { A: 1.2, B: 1.3, C: 1.4, D: 1.5, Decline: 0 },
+  maxFundingMultiple: { A: 1.4, B: 1.1, C: 0.8, D: 0.5, Decline: 0 }
+}
+
+let cache: QualificationRules | null = null
+
+const TIERS: QualificationTier[] = ['A', 'B', 'C', 'D', 'Decline']
+
+/**
+ * Accept a per-tier numeric table only if it carries a finite (or ±Infinity)
+ * number for EVERY tier. A partial/garbled table is rejected so the caller
+ * falls back to the illustrative default for that sub-table.
+ */
+function coerceTierNumbers(raw: unknown): Record<QualificationTier, number> | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const src = raw as Record<string, unknown>
+  const out = {} as Record<QualificationTier, number>
+  for (const tier of TIERS) {
+    const v = src[tier]
+    if (typeof v !== 'number' || Number.isNaN(v)) return null
+    out[tier] = v
+  }
+  return out
+}
+
+function loadCalibration(): QualificationRules {
+  if (cache) return cache
+  const candidates = [
+    process.env.SCORING_CALIBRATION_PATH,
+    join(__dirname, 'qualificationRules.private.json')
+  ].filter((p): p is string => Boolean(p))
+
+  // Start from the illustrative default and overlay any well-formed sub-table
+  // found in the first candidate that carries a `qualificationRules` object.
+  const merged: QualificationRules = {
+    minAdbByTier: { ...ILLUSTRATIVE_RULES.minAdbByTier },
+    maxNsfByTier: { ...ILLUSTRATIVE_RULES.maxNsfByTier },
+    maxNegativeDaysByTier: { ...ILLUSTRATIVE_RULES.maxNegativeDaysByTier },
+    maxPositionsByTier: { ...ILLUSTRATIVE_RULES.maxPositionsByTier },
+    minTimeInBusinessByTier: { ...ILLUSTRATIVE_RULES.minTimeInBusinessByTier },
+    minMonthlyRevenueByTier: { ...ILLUSTRATIVE_RULES.minMonthlyRevenueByTier },
+    factorRatesByTier: { ...ILLUSTRATIVE_RULES.factorRatesByTier },
+    maxFundingMultiple: { ...ILLUSTRATIVE_RULES.maxFundingMultiple }
+  }
+
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue
+      const data = JSON.parse(readFileSync(path, 'utf8')) as { qualificationRules?: unknown }
+      const rules = data.qualificationRules
+      if (typeof rules !== 'object' || rules === null) continue
+      const r = rules as Record<string, unknown>
+      const keys: (keyof QualificationRules)[] = [
+        'minAdbByTier',
+        'maxNsfByTier',
+        'maxNegativeDaysByTier',
+        'maxPositionsByTier',
+        'minTimeInBusinessByTier',
+        'minMonthlyRevenueByTier',
+        'factorRatesByTier',
+        'maxFundingMultiple'
+      ]
+      let applied = false
+      for (const key of keys) {
+        const table = coerceTierNumbers(r[key])
+        if (table) {
+          merged[key] = table
+          applied = true
+        }
+      }
+      // First candidate carrying a usable override wins; stop scanning.
+      if (applied) break
+    } catch {
+      // Malformed/unreadable candidate — fall through to the next / illustrative.
+    }
+  }
+
+  cache = merged
+  return cache
+}
+
+/**
+ * The calibrated qualification credit-box rules. Production values are injected
+ * from a private calibration file; a bare public clone gets only the
+ * illustrative bands.
+ */
+export function qualificationRules(): QualificationRules {
+  return loadCalibration()
+}
+
+/** Test/ops seam: drop the cache so a new SCORING_CALIBRATION_PATH takes effect. */
+export function __resetQualificationRulesCache(): void {
+  cache = null
+}

--- a/server/services/calibration/scoringModifiers.private.json.example
+++ b/server/services/calibration/scoringModifiers.private.json.example
@@ -1,0 +1,13 @@
+{
+  "_note": "Template for the PRIVATE scoring-modifier calibration. Copy to scoringModifiers.private.json (gitignored) and populate with the real industry-risk and state modifier tables, or point SCORING_CALIBRATION_PATH at one shared JSON that carries this and every other calibration key. Without it, the platform uses the illustrative sets in scoringModifiers.ts (unknown industries/states fall back to a neutral 1.0) — the scorer works, the real multipliers do not ship in this public repo. NOTE: the composite formula weights (DEFAULT_CONFIG in ScoringService, intentRecencyWeight etc.) are public research and are NOT part of this calibration.",
+  "industryRiskModifiers": {
+    "sample-industry-a": 0.9,
+    "sample-industry-b": 1.0,
+    "sample-industry-c": 0.9
+  },
+  "stateModifiers": {
+    "XX": 1.0,
+    "YY": 0.9,
+    "ZZ": 1.0
+  }
+}

--- a/server/services/calibration/scoringModifiers.ts
+++ b/server/services/calibration/scoringModifiers.ts
@@ -1,0 +1,127 @@
+/**
+ * Scoring-modifier calibration — the public SHELL of a private dictionary.
+ *
+ * The populated industry-risk and state modifier tables (how much each industry
+ * or state scales a composite prospect score) are hard-won market intelligence,
+ * not commodity code. This module exposes the SHAPE (Record<string, number>) and
+ * a small ILLUSTRATIVE default so the public repository compiles, tests, and
+ * demos; the production modifier tables are INJECTED from a private calibration
+ * file that is never committed to this public repo.
+ *
+ * This is the scoring-table half of the reusable calibration seam introduced in
+ * ./funderIntel.ts. NOTE: the composite formula weights (DEFAULT_CONFIG in
+ * ../ScoringService — intentRecencyWeight etc.) are documented public research
+ * and stay in the source; only these populated modifier tables are private.
+ *
+ * Resolution order (first hit wins):
+ *   1. process.env.SCORING_CALIBRATION_PATH — an explicit JSON path (tests/ops)
+ *   2. <this dir>/scoringModifiers.private.json — the operator's private file (gitignored)
+ *   3. the illustrative public default (below)
+ *
+ * A single private JSON may carry every calibration key; this module reads the
+ * `industryRiskModifiers` and `stateModifiers` top-level keys.
+ *
+ * Private/injected JSON shape:
+ *   {
+ *     "industryRiskModifiers": { "<industry>": <multiplier>, ... },
+ *     "stateModifiers": { "<state>": <multiplier>, ... }
+ *   }
+ *
+ * @module server/services/calibration/scoringModifiers
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+// Illustrative ONLY — NOT the production modifier tables. Obviously-sample
+// entries (not real industry/state keys, and no real multiplier) so a bare
+// public clone still scores prospects — every real industry/state falls back to
+// a neutral 1.0 in the caller — while carrying none of the real calibration.
+const ILLUSTRATIVE_INDUSTRY_MODIFIERS: Record<string, number> = {
+  'sample-industry-a': 0.9,
+  'sample-industry-b': 1.0
+}
+
+const ILLUSTRATIVE_STATE_MODIFIERS: Record<string, number> = {
+  XX: 1.0,
+  YY: 0.9
+}
+
+interface ScoringModifierCalibration {
+  industryRiskModifiers: Record<string, number>
+  stateModifiers: Record<string, number>
+}
+
+let cache: ScoringModifierCalibration | null = null
+
+/**
+ * Accept a plain object whose every value is a finite number; reject anything
+ * else so the caller falls back to the illustrative default for that table.
+ */
+function coerceNumberMap(raw: unknown): Record<string, number> | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const out: Record<string, number> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null
+    out[key] = value
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+function loadCalibration(): ScoringModifierCalibration {
+  if (cache) return cache
+  const candidates = [
+    process.env.SCORING_CALIBRATION_PATH,
+    join(__dirname, 'scoringModifiers.private.json')
+  ].filter((p): p is string => Boolean(p))
+
+  let industryRiskModifiers: Record<string, number> | null = null
+  let stateModifiers: Record<string, number> | null = null
+
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue
+      const data = JSON.parse(readFileSync(path, 'utf8')) as {
+        industryRiskModifiers?: unknown
+        stateModifiers?: unknown
+      }
+      if (industryRiskModifiers === null) {
+        industryRiskModifiers = coerceNumberMap(data.industryRiskModifiers)
+      }
+      if (stateModifiers === null) {
+        stateModifiers = coerceNumberMap(data.stateModifiers)
+      }
+      if (industryRiskModifiers !== null && stateModifiers !== null) break
+    } catch {
+      // Malformed/unreadable candidate — fall through to the next / illustrative.
+    }
+  }
+
+  cache = {
+    industryRiskModifiers: industryRiskModifiers ?? { ...ILLUSTRATIVE_INDUSTRY_MODIFIERS },
+    stateModifiers: stateModifiers ?? { ...ILLUSTRATIVE_STATE_MODIFIERS }
+  }
+  return cache
+}
+
+/**
+ * The industry-risk modifier table (lower = higher risk). Production values are
+ * injected from a private calibration file; a bare public clone gets only the
+ * illustrative set.
+ */
+export function industryRiskModifiers(): Record<string, number> {
+  return loadCalibration().industryRiskModifiers
+}
+
+/**
+ * The state modifier table (regulatory environment, market size). Production
+ * values are injected from a private calibration file; a bare public clone gets
+ * only the illustrative set.
+ */
+export function stateModifiers(): Record<string, number> {
+  return loadCalibration().stateModifiers
+}
+
+/** Test/ops seam: drop the cache so a new SCORING_CALIBRATION_PATH takes effect. */
+export function __resetScoringModifiersCache(): void {
+  cache = null
+}

--- a/server/services/discovery-channels/SBALoansChannel.ts
+++ b/server/services/discovery-channels/SBALoansChannel.ts
@@ -5,8 +5,11 @@
  * financing event and a strong 'contract' (capital-secured) growth signal.
  *
  * ── Dataset (public FOIA release, NO API KEY) ───────────────────────────────
- *   SBA "7(a) & 504 FOIA" — loan-level borrower records
- *     legacy CKAN id: 0ff8e8e9-b967-4f4e-987c-6ac78c575087  (data.sba.gov)
+ *   SBA "7(a) & 504 FOIA" — loan-level borrower records (data.sba.gov). The
+ *     curated legacy CKAN package id is calibration, not source: it is injected
+ *     from the private discovery source-map (see
+ *     ../calibration/discoverySources) so this public repo carries only a fake
+ *     placeholder. A bare public clone still resolves via the DCAT rung below.
  *   We fetch the recent 7(a) CSV resource (FY2020-present). The "as-of" date
  *   is embedded in the filename, so the concrete file URL must be resolved at
  *   runtime. Resolution is a self-healing chain (#347):
@@ -41,10 +44,14 @@ import {
   DiscoveryChannelError
 } from './types'
 import { clampLimit, normalizeState, errorMessage, fetchWithTimeout, fetchJson } from './utils'
+import { sbaCkanPackageId } from '../calibration/discoverySources'
 
 const CHANNEL = 'sba-7a-loans'
-const CKAN_PACKAGE_ID = '0ff8e8e9-b967-4f4e-987c-6ac78c575087'
-const CKAN_PACKAGE_SHOW = `https://data.sba.gov/api/3/action/package_show?id=${CKAN_PACKAGE_ID}`
+// The curated CKAN package id is calibration (see ../calibration/discoverySources)
+// — injected privately, illustrative placeholder in the public repo. The
+// package_show URL is therefore built at runtime from the resolved id.
+const CKAN_PACKAGE_SHOW = (): string =>
+  `https://data.sba.gov/api/3/action/package_show?id=${sbaCkanPackageId()}`
 // Project Open Data (DCAT) catalog the post-2026 Drupal portal serves.
 const DCAT_CATALOG_URL = 'https://data.sba.gov/data.json'
 // Filename stem of the recent 7(a) CSV resource (date suffix rotates).
@@ -107,7 +114,7 @@ export class SBALoansChannel implements DiscoveryChannel {
   private async resolveViaCkan(): Promise<string> {
     const body = await fetchJson(
       CHANNEL,
-      CKAN_PACKAGE_SHOW,
+      CKAN_PACKAGE_SHOW(),
       { headers: { Accept: 'application/json' } },
       'SBA CKAN',
       REQUEST_TIMEOUT_MS

--- a/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
+++ b/server/services/discovery-channels/SocrataBuildingPermitsChannel.ts
@@ -6,28 +6,16 @@
  * expansion activity and near-term capital needs.
  *
  * ── Endpoints (public Socrata SODA, NO API KEY) ─────────────────────────────
- *  NY → NYC DOB Permit Issuance
- *       https://data.cityofnewyork.us/resource/ipu4-2q9a.json
- *       Business field:  permittee_s_business_name
- *       State:           implicit NY (NYC dataset)
- *       Date field:      issuance_date  (MM/DD/YYYY string)
- *  CA → City of Los Angeles "LA BUILD PERMITS"
- *       https://data.lacity.org/resource/xnhu-aczu.json
- *       Business field:  contractors_business_name
- *       State:           implicit CA (LA dataset)
- *       Date field:      issue_date  (ISO 8601)
- *  FL → City of Orlando "Permit Applications" (updated daily; verified live
- *       2026-07-16 — Miami-Dade's Socrata is gone, 302 → ArcGIS legacy)
- *       https://data.cityoforlando.net/resource/ryhf-m453.json
- *       Business field:  contractor_name
- *       State:           implicit FL (Orlando dataset)
- *       Date field:      issue_permit_date  (ISO 8601; null until issuance —
- *                        see the $where null-guard below)
- *  TX → City of Austin "Issued Construction Permits"
- *       https://data.austintexas.gov/resource/3syk-w9eu.json
- *       Business field:  contractor_company_name
- *       State:           implicit TX (Austin dataset)
- *       Date field:      issue_date  (ISO 8601)
+ *  The curated per-state source-map — which city Socrata dataset covers each
+ *  state, its resource URL, and the per-dataset business-name / order field
+ *  mapping — is market intelligence, NOT source. It is injected from the
+ *  private discovery source-map (see ../calibration/discoverySources); this
+ *  public repo carries only obviously-sample entries. Each registered source is
+ *  a city-scoped dataset providing:
+ *    - state:         the state the dataset implicitly covers
+ *    - url:           the SODA resource (.json) endpoint
+ *    - businessField: the row field holding the business / contractor name
+ *    - orderField:    the date field used for newest-first ordering
  *
  *  All accept SODA query params ($limit, $order, $where). We request newest
  *  first and cap rows; SODA sorts DESC with NULL FIRST, so the $where also
@@ -50,48 +38,18 @@ import {
   DiscoveryChannelError
 } from './types'
 import { clampLimit, fetchJson } from './utils'
+import { socrataBuildingPermitSources, type SocrataSource } from '../calibration/discoverySources'
 
 const CHANNEL = 'socrata-building-permits'
 const REQUEST_TIMEOUT_MS = 12000
 const RATE_BUCKET = 'socrata'
 
-interface SocrataSource {
-  /** State this dataset implicitly covers (datasets are city-scoped). */
-  state: string
-  /** Base resource URL (.json). */
-  url: string
-  /** Field holding the business name in each row. */
-  businessField: string
-  /** Field used for newest-first ordering. */
-  orderField: string
-}
-
-// Per-state dataset registry. Adding a state = adding a documented entry here.
-const SOURCES: Record<string, SocrataSource> = {
-  NY: {
-    state: 'NY',
-    url: 'https://data.cityofnewyork.us/resource/ipu4-2q9a.json',
-    businessField: 'permittee_s_business_name',
-    orderField: 'issuance_date'
-  },
-  CA: {
-    state: 'CA',
-    url: 'https://data.lacity.org/resource/xnhu-aczu.json',
-    businessField: 'contractors_business_name',
-    orderField: 'issue_date'
-  },
-  FL: {
-    state: 'FL',
-    url: 'https://data.cityoforlando.net/resource/ryhf-m453.json',
-    businessField: 'contractor_name',
-    orderField: 'issue_permit_date'
-  },
-  TX: {
-    state: 'TX',
-    url: 'https://data.austintexas.gov/resource/3syk-w9eu.json',
-    businessField: 'contractor_company_name',
-    orderField: 'issue_date'
-  }
+// Per-state dataset registry. The curated map is calibration (see
+// ../calibration/discoverySources): production endpoints are injected from the
+// private source-map, a bare public clone gets illustrative sample entries.
+// Adding a state = adding a documented entry to that private source-map.
+function sources(): Record<string, SocrataSource> {
+  return socrataBuildingPermitSources()
 }
 
 export class SocrataBuildingPermitsChannel implements DiscoveryChannel {
@@ -124,18 +82,19 @@ export class SocrataBuildingPermitsChannel implements DiscoveryChannel {
    * geography).
    */
   private resolveSources(state?: string): SocrataSource[] {
+    const registry = sources()
     if (state) {
       const code = state.trim().toUpperCase()
-      const source = SOURCES[code]
+      const source = registry[code]
       if (!source) {
         throw new DiscoveryChannelError(
           CHANNEL,
-          `no building-permit dataset registered for state '${code}' (have: ${Object.keys(SOURCES).join(', ')})`
+          `no building-permit dataset registered for state '${code}' (have: ${Object.keys(registry).join(', ')})`
         )
       }
       return [source]
     }
-    return Object.values(SOURCES)
+    return Object.values(registry)
   }
 
   private async fetchSource(


### PR DESCRIPTION
**P0 critical moat leak** (DECORVM moat-audit). Private, hard-won calibration lived in tracked PUBLIC source across 4 files: the SBA CKAN source id (`SBALoansChannel`), the Socrata source-map (`SocrataBuildingPermitsChannel`), the credit-box bands (`QualificationService` DEFAULT_RULES), and the risk-modifier tables (`ScoringService`).

**Fix — finish the repo's own pattern.** Extends the established calibration seam (`server/services/calibration/funderIntel.ts`: `env SCORING_CALIBRATION_PATH → <name>.private.json → illustrative default`) to all four surfaces. Public **types/shapes stay**; only the calibrated **values** move behind the seam. New modules `discoverySources` / `qualificationRules` / `scoringModifiers` (+ `.private.json.example` templates with fake placeholders). Two tests that hardcoded the real values now inject **sample** values through the seam and assert faithful application — so no real calibration lives in **any** tracked `.ts`, tests included. Illustrative defaults de-leaked too.

**Verified.** Full server suite **1494 passed / 0 failed**; `tsc --noEmit` adds zero errors; eslint clean; `git grep` confirms zero real values in tracked source; runtime with a private.json present is byte-identical.

**Follow-up (pre-existing, out of scope — filed separately):** `samples/scored-mca-leads-sample.json` and `StackAnalysisService.ts` also embed real modifier values; not introduced here, tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)