### PR TITLE
fix(web): graceful demo fallback — replace red error banner with working demo state

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -182,6 +182,7 @@ function App() {
           <LoadingAndErrorState
             isLoading={data.isLoading}
             loadError={data.loadError}
+            isDemoFallback={data.isDemoFallback}
             onRetry={() => void data.fetchData()}
           />
 

--- a/apps/web/src/components/layout/LoadingAndErrorState.tsx
+++ b/apps/web/src/components/layout/LoadingAndErrorState.tsx
@@ -3,13 +3,37 @@ import { Button } from '@public-records/ui/button'
 interface LoadingAndErrorStateProps {
   isLoading: boolean
   loadError: string | null
+  /** When true, the live API was unreachable but demo data is being rendered. */
+  isDemoFallback?: boolean
   onRetry: () => void
 }
 
-export function LoadingAndErrorState({ isLoading, loadError, onRetry }: LoadingAndErrorStateProps) {
+export function LoadingAndErrorState({
+  isLoading,
+  loadError,
+  isDemoFallback = false,
+  onRetry
+}: LoadingAndErrorStateProps) {
   return (
     <>
-      {loadError && (
+      {isDemoFallback && (
+        <div className="glass-effect border border-blue-400/30 rounded-lg p-3 text-blue-100/90 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
+          <p>
+            <span className="font-medium">Demo data</span> — connect a live data source to see real
+            prospects.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            className="shrink-0 border-blue-400/40 text-blue-100 hover:bg-blue-500/20"
+          >
+            Connect live data
+          </Button>
+        </div>
+      )}
+
+      {loadError && !isDemoFallback && (
         <div className="glass-effect border border-red-500/40 rounded-lg p-4 text-red-100 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
           <div>
             <p className="font-semibold">Failed to load live data</p>

--- a/apps/web/src/hooks/useDataFetching.ts
+++ b/apps/web/src/hooks/useDataFetching.ts
@@ -24,6 +24,8 @@ export interface UseDataFetchingResult {
   userActions: UserAction[]
   isLoading: boolean
   loadError: string | null
+  /** True when the live API was unreachable and demo data is being shown instead. */
+  isDemoFallback: boolean
   lastDataRefresh: string
   setProspects: (updater: Prospect[] | ((prev: Prospect[]) => Prospect[])) => void
   setCompetitors: (
@@ -51,6 +53,7 @@ export function useDataFetching({
 
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [isDemoFallback, setIsDemoFallback] = useState(false)
 
   const fetchData = useCallback(
     async ({ signal, silent }: { signal?: AbortSignal; silent?: boolean } = {}) => {
@@ -58,6 +61,7 @@ export function useDataFetching({
         setIsLoading(true)
       }
       setLoadError(null)
+      setIsDemoFallback(false)
 
       try {
         if (useMockData) {
@@ -100,9 +104,28 @@ export function useDataFetching({
           return false
         }
 
-        const message = error instanceof Error ? error.message : 'Failed to load data'
-        setLoadError(message)
-        console.error('Failed to load datasets', error)
+        // Live API unreachable — load demo data so the product looks functional
+        // to first-time visitors instead of showing a scary red error banner.
+        console.error('Failed to load datasets — falling back to demo data', error)
+        try {
+          const [demoProspects, demoCompetitors, demoPortfolio] = [
+            generateProspects(12, { dataTier }),
+            generateCompetitorData({ dataTier }),
+            generatePortfolioCompanies(8, { dataTier })
+          ]
+          if (!signal?.aborted) {
+            setProspects(demoProspects)
+            setCompetitors(demoCompetitors)
+            setPortfolio(demoPortfolio)
+            setLastDataRefresh(new Date().toISOString())
+            setIsDemoFallback(true)
+          }
+        } catch (fallbackError) {
+          // If even demo generation fails, surface the original error.
+          console.error('Demo fallback also failed', fallbackError)
+          const message = error instanceof Error ? error.message : 'Failed to load data'
+          setLoadError(message)
+        }
         return false
       } finally {
         if (!silent && !signal?.aborted) {
@@ -134,6 +157,7 @@ export function useDataFetching({
     userActions: userActions || [],
     isLoading,
     loadError,
+    isDemoFallback,
     lastDataRefresh: lastDataRefresh || new Date().toISOString(),
     setProspects: setProspects as UseDataFetchingResult['setProspects'],
     setCompetitors: setCompetitors as UseDataFetchingResult['setCompetitors'],


### PR DESCRIPTION
## Summary

- **Root cause**: Netlify deploys only the Vite frontend; the Node `server/` backend is not hosted there, so every API fetch fails on load, producing a prominent red "Failed to load live data / Request failed" banner with zero prospects rendered.
- **Fix**: On any fetch failure, `useDataFetching` now calls the existing `generateProspects(12)` / `generateCompetitorData` / `generatePortfolioCompanies(8)` generators (already bundled in the app) and loads that as demo data. A new `isDemoFallback` flag propagates to `LoadingAndErrorState`, which renders a subtle blue-tinted info notice ("Demo data — connect a live data source to see real prospects") instead of the red error. The "Retry / Connect live data" button re-attempts the live fetch and, if it succeeds, clears `isDemoFallback` and loads real data. Live path is completely unchanged.
- **Constraint respected**: only `apps/web/src/` touched — no server/, no moat calibration, no README.

## Files changed

- `apps/web/src/hooks/useDataFetching.ts` — catch block loads demo data + sets `isDemoFallback` instead of setting `loadError`
- `apps/web/src/components/layout/LoadingAndErrorState.tsx` — adds `isDemoFallback` prop; renders blue info banner when true, hides red error when fallback is active
- `apps/web/src/App.tsx` — passes `data.isDemoFallback` to `LoadingAndErrorState`

## Test plan

- [x] `cd apps/web && npm run build` — passes (exit 0, 7556 modules transformed)
- [ ] Deploy to Netlify and confirm: first-time visitor sees 12 demo prospect cards + blue "Demo data" banner instead of red error
- [ ] With `VITE_API_BASE_URL` pointing to a live backend, confirm real prospects load normally and the blue banner does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)