### PR TITLE
fix: guard the last doomed request → zero console errors on the static deploy

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,7 +9,15 @@ import './main.css'
 import './styles/theme.css'
 import './index.css'
 
-if (typeof window !== 'undefined') {
+// Guard: on a static production deploy (GitHub Pages, Cloudflare Pages, etc.)
+// the Spark runtime module fires a top-level POST to /_spark/loaded the moment
+// it is imported.  That endpoint does not exist on a static host and returns
+// 405, producing a console error.  Skip the import entirely when we are in a
+// production build AND no explicit API base URL was configured — those two facts
+// together mean there is no Spark backend, and the app already falls back to
+// local-storage state management via useSparkKV.
+const hasApiBase = Boolean(import.meta.env.VITE_API_BASE_URL)
+if (typeof window !== 'undefined' && !(import.meta.env.PROD && !hasApiBase)) {
   import('@github/spark/spark').catch((error) => {
     console.warn(
       '[main] Unable to load Spark runtime; falling back to local storage state management.',


### PR DESCRIPTION
## What was the 405 request

On every page load of the GitHub Pages static deploy, the browser POSTed to:

```
https://organvm.github.io/_spark/loaded  →  405 Method Not Allowed
```

This beacon is fired at **module top-level** inside `@github/spark/spark` (line 29 of `node_modules/@github/spark/dist/spark.js`):

```js
fetch('/_spark/loaded', { method: 'POST', ... });
```

The request fires the moment the module is evaluated — immediately after `main.tsx` calls `import('@github/spark/spark')`. GitHub Pages has no backend to serve `/_spark/*`, so it returns 405, producing the one remaining console error.

## The guard (`apps/web/src/main.tsx`)

Same two-fact predicate PR #369 used for the dataset API guard:

```ts
const hasApiBase = Boolean(import.meta.env.VITE_API_BASE_URL)
if (typeof window !== 'undefined' && !(import.meta.env.PROD && !hasApiBase)) {
  import('@github/spark/spark').catch(...)
}
```

In a static Pages build (`PROD=true`, no `VITE_API_BASE_URL`), Vite resolves the guard to `false` at build time — the dynamic import becomes dead code and the spark chunk is never fetched, so `/_spark/loaded` is never posted.

The app already uses the localStorage-backed `useSparkKV` hook for all KV state, so **UX is identical** — the Spark import was a progressive enhancement that was already falling back silently.

## Verification

- `npm run build` passes ✓  
- Built bundle confirms: guard constant compiles to `false`, wrapping the spark import so it cannot execute on the static deploy ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented production sites without a configured API URL from making an invalid Spark runtime request.
  * Eliminated `/._spark/loaded` 405 errors while preserving local-storage fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->